### PR TITLE
feat(git): a configured git program for the write surface

### DIFF
--- a/crates/khive-pack-git/src/local_git.rs
+++ b/crates/khive-pack-git/src/local_git.rs
@@ -48,8 +48,8 @@ const HARDENING: &[&str] = &[
 /// modified that its own `git status` calls clean. Reading a repository must not run its code.
 const FILTER_NEUTRALIZED: &[&str] = &["clean", "smudge", "process"];
 
-fn filter_overrides(repo: &Path) -> Vec<String> {
-    let mut command = base_command();
+fn filter_overrides(program: &Path, repo: &Path) -> Vec<String> {
+    let mut command = base_command(program);
     command
         .arg("-C")
         .arg(repo)
@@ -169,8 +169,8 @@ pub(crate) struct DiffResult {
 ///
 /// Split out so the config READ that enumerates filter drivers runs under the same hardening as
 /// the operation it is hardening, without recursing into the enumeration it exists to feed.
-fn base_command() -> Command {
-    let mut command = Command::new("git");
+fn base_command(program: &Path) -> Command {
+    let mut command = Command::new(program);
     // Inherited GIT_DIR, index/object paths, config injection, and identities
     // must not redirect an operation away from the caller's authorized repo.
     command.env_clear();
@@ -193,8 +193,13 @@ fn base_command() -> Command {
     command
 }
 
-fn git_command(repo: &Path, argv: &[&str], identity: Option<(&str, &str)>) -> Command {
-    let mut command = base_command();
+fn git_command(
+    program: &Path,
+    repo: &Path,
+    argv: &[&str],
+    identity: Option<(&str, &str)>,
+) -> Command {
+    let mut command = base_command(program);
     if let Some((name, email)) = identity {
         command
             .env("GIT_AUTHOR_NAME", name)
@@ -204,7 +209,7 @@ fn git_command(repo: &Path, argv: &[&str], identity: Option<(&str, &str)>) -> Co
     }
     // Every invocation, not only the ones known today to convert content: a verb added later that
     // reads or writes the worktree inherits this rather than having to remember it.
-    for setting in filter_overrides(repo) {
+    for setting in filter_overrides(program, repo) {
         command.arg("-c").arg(setting);
     }
     command.arg("-C").arg(repo).args(argv);
@@ -265,16 +270,19 @@ fn cas_refused(argv: &[&str], stderr: &[u8]) -> bool {
 }
 
 fn run_git(
+    program: &Path,
     repo: &Path,
     argv: &[&str],
     input: Option<&[u8]>,
     identity: Option<(&str, &str)>,
     ref_effect: bool,
 ) -> Result<Vec<u8>> {
-    run_git_output(repo, argv, input, identity, ref_effect, None).map(|output| output.stdout)
+    run_git_output(program, repo, argv, input, identity, ref_effect, None)
+        .map(|output| output.stdout)
 }
 
 fn run_git_output(
+    program: &Path,
     repo: &Path,
     argv: &[&str],
     input: Option<&[u8]>,
@@ -283,7 +291,7 @@ fn run_git_output(
     allowed_exit: Option<i32>,
 ) -> Result<GitOutput> {
     let operation = argv.first().copied().unwrap_or("operation");
-    let mut command = git_command(repo, argv, identity);
+    let mut command = git_command(program, repo, argv, identity);
     command
         .stdin(if input.is_some() {
             Stdio::piped()
@@ -369,12 +377,18 @@ where
         .map_err(|_| LocalGitError::after_start(operation, ref_effect))?
 }
 
-async fn run_async(repo: &Path, argv: &[&str], input: Option<Vec<u8>>) -> Result<Vec<u8>> {
+async fn run_async(
+    program: &Path,
+    repo: &Path,
+    argv: &[&str],
+    input: Option<Vec<u8>>,
+) -> Result<Vec<u8>> {
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     let argv: Vec<String> = argv.iter().map(|value| (*value).to_string()).collect();
     tokio::task::spawn_blocking(move || {
         let args: Vec<&str> = argv.iter().map(String::as_str).collect();
-        run_git(&repo, &args, input.as_deref(), None, false)
+        run_git(&program, &repo, &args, input.as_deref(), None, false)
     })
     .await
     .map_err(|_| LocalGitError::new("git_failed", "git object worker did not complete"))?
@@ -415,9 +429,10 @@ fn branch_ref(branch: &str) -> Result<String> {
     Ok(format!("refs/heads/{branch}"))
 }
 
-fn resolve_commit_sync(repo: &Path, reference: &str) -> Result<String> {
+fn resolve_commit_sync(program: &Path, repo: &Path, reference: &str) -> Result<String> {
     let reference = checked_ref(reference)?;
     oid_output(&run_git(
+        program,
         repo,
         &["rev-parse", "--verify", "--end-of-options", &reference],
         None,
@@ -426,8 +441,9 @@ fn resolve_commit_sync(repo: &Path, reference: &str) -> Result<String> {
     )?)
 }
 
-fn require_direct_ref(repo: &Path, reference: &str) -> Result<()> {
+fn require_direct_ref(program: &Path, repo: &Path, reference: &str) -> Result<()> {
     let output = run_git_output(
+        program,
         repo,
         &["symbolic-ref", "--quiet", "--no-recurse", reference],
         None,
@@ -444,19 +460,20 @@ fn require_direct_ref(repo: &Path, reference: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) async fn resolve_commit(repo: &Path, reference: &str) -> Result<String> {
+pub(crate) async fn resolve_commit(program: &Path, repo: &Path, reference: &str) -> Result<String> {
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     let reference = reference.to_string();
     blocking("rev-parse", false, move || {
-        resolve_commit_sync(&repo, &reference)
+        resolve_commit_sync(&program, &repo, &reference)
     })
     .await
 }
 
-fn branch_head_sync(repo: &Path, branch: &str) -> Result<String> {
+fn branch_head_sync(program: &Path, repo: &Path, branch: &str) -> Result<String> {
     let reference = branch_ref(branch)?;
-    require_direct_ref(repo, &reference)?;
-    resolve_commit_sync(repo, &reference).map_err(|error| {
+    require_direct_ref(program, repo, &reference)?;
+    resolve_commit_sync(program, repo, &reference).map_err(|error| {
         if error.code() == "git_failed" {
             LocalGitError::new(
                 "expected_head_mismatch",
@@ -468,10 +485,14 @@ fn branch_head_sync(repo: &Path, branch: &str) -> Result<String> {
     })
 }
 
-pub(crate) async fn branch_head(repo: &Path, branch: &str) -> Result<String> {
+pub(crate) async fn branch_head(program: &Path, repo: &Path, branch: &str) -> Result<String> {
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     let branch = branch.to_string();
-    blocking("rev-parse", false, move || branch_head_sync(&repo, &branch)).await
+    blocking("rev-parse", false, move || {
+        branch_head_sync(&program, &repo, &branch)
+    })
+    .await
 }
 
 #[derive(Debug)]
@@ -530,22 +551,24 @@ fn parse_listing(bytes: &[u8]) -> Result<Vec<ListedBlob>> {
 }
 
 pub(crate) async fn checkout(rt: &KhiveRuntime, repo: &Path, reference: &str) -> Result<Checkout> {
+    let program = rt.config().git_write.git_program();
     let reference = checked_ref(reference)?;
     let commit = oid_output(
         &run_async(
+            program,
             repo,
             &["rev-parse", "--verify", "--end-of-options", &reference],
             None,
         )
         .await?,
     )?;
-    let listing = run_async(repo, &["ls-tree", "-r", "-z", &commit], None).await?;
+    let listing = run_async(program, repo, &["ls-tree", "-r", "-z", &commit], None).await?;
     // Validate every mode and path before producing any manifest entries.
     let listed = parse_listing(&listing)?;
     let store = tree::blob_store(rt)?;
     let mut entries = Vec::with_capacity(listed.len());
     for entry in listed {
-        let bytes = run_async(repo, &["cat-file", "blob", &entry.oid], None).await?;
+        let bytes = run_async(program, repo, &["cat-file", "blob", &entry.oid], None).await?;
         let content_ref = store.put(bytes).await?;
         entries.push(TreeEntry {
             path: entry.path,
@@ -592,6 +615,7 @@ pub(crate) async fn write_manifest_tree(
     repo: &Path,
     manifest_ref: &str,
 ) -> Result<String> {
+    let program = rt.config().git_write.git_program();
     let entries = tree::load(rt, manifest_ref).await?;
     tree::verify_blobs(rt, &entries).await?;
     let store = tree::blob_store(rt)?;
@@ -605,6 +629,7 @@ pub(crate) async fn write_manifest_tree(
             .await?;
         let oid = oid_output(
             &run_async(
+                program,
                 repo,
                 &["hash-object", "-w", "--no-filters", "--stdin"],
                 Some(bytes),
@@ -644,8 +669,15 @@ pub(crate) async fn write_manifest_tree(
         let entries = directories
             .remove(&path)
             .expect("directory came from the same map");
-        let oid =
-            oid_output(&run_async(repo, &["mktree", "-z"], Some(mktree_input(&entries))).await?)?;
+        let oid = oid_output(
+            &run_async(
+                program,
+                repo,
+                &["mktree", "-z"],
+                Some(mktree_input(&entries)),
+            )
+            .await?,
+        )?;
         if path.is_empty() {
             return Ok(oid);
         }
@@ -667,6 +699,7 @@ pub(crate) async fn write_manifest_tree(
 }
 
 fn create_commit_sync(
+    program: &Path,
     repo: &Path,
     git_tree: &str,
     parent: &str,
@@ -691,6 +724,7 @@ fn create_commit_sync(
         }
     }
     oid_output(&run_git(
+        program,
         repo,
         &["commit-tree", git_tree, "-p", parent, "-m", message],
         None,
@@ -700,6 +734,7 @@ fn create_commit_sync(
 }
 
 pub(crate) async fn create_commit(
+    program: &Path,
     repo: &Path,
     git_tree: &str,
     parent: &str,
@@ -707,6 +742,7 @@ pub(crate) async fn create_commit(
     author_name: &str,
     author_email: &str,
 ) -> Result<String> {
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     let git_tree = git_tree.to_string();
     let parent = parent.to_string();
@@ -715,6 +751,7 @@ pub(crate) async fn create_commit(
     let author_email = author_email.to_string();
     blocking("commit-tree", false, move || {
         create_commit_sync(
+            &program,
             &repo,
             &git_tree,
             &parent,
@@ -740,6 +777,7 @@ fn receipt_marker(receipt_id: &str) -> Result<String> {
 }
 
 fn update_branch_sync(
+    program: &Path,
     repo: &Path,
     branch: &str,
     new: &str,
@@ -756,9 +794,10 @@ fn update_branch_sync(
     validate_oid(expected, "expected_head")?;
     let reference = branch_ref(branch)?;
     let marker = receipt_marker(receipt_id)?;
-    require_direct_ref(repo, &reference)?;
+    require_direct_ref(program, repo, &reference)?;
     // A symref installed after inspection must never redirect the ref-store write.
     run_git(
+        program,
         repo,
         &[
             "update-ref",
@@ -778,30 +817,33 @@ fn update_branch_sync(
 }
 
 pub(crate) async fn update_branch(
+    program: &Path,
     repo: &Path,
     branch: &str,
     new: &str,
     expected: &str,
     receipt_id: &str,
 ) -> Result<()> {
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     let branch = branch.to_string();
     let new = new.to_string();
     let expected = expected.to_string();
     let receipt_id = receipt_id.to_string();
     blocking("update-ref", true, move || {
-        update_branch_sync(&repo, &branch, &new, &expected, &receipt_id)
+        update_branch_sync(&program, &repo, &branch, &new, &expected, &receipt_id)
     })
     .await
 }
 
 pub(crate) async fn create_branch_ref(
+    program: &Path,
     repo: &Path,
     branch: &str,
     new: &str,
     receipt_id: &str,
 ) -> Result<()> {
-    update_branch(repo, branch, new, ZERO_OID, receipt_id).await
+    update_branch(program, repo, branch, new, ZERO_OID, receipt_id).await
 }
 
 fn parse_operation_recorded(bytes: &[u8], new_sha: &str, marker: &str) -> Result<bool> {
@@ -837,6 +879,7 @@ fn parse_operation_recorded(bytes: &[u8], new_sha: &str, marker: &str) -> Result
 /// SHA equal to or an ancestor of the named ref's current head. This is not a
 /// claim of crash-atomicity for the ref backend.
 pub(crate) async fn operation_recorded(
+    program: &Path,
     repo: &Path,
     branch: &str,
     new_sha: &str,
@@ -845,11 +888,13 @@ pub(crate) async fn operation_recorded(
     validate_oid(new_sha, "new head")?;
     let reference = branch_ref(branch)?;
     let marker = receipt_marker(receipt_id)?;
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     let new_sha = new_sha.to_string();
     blocking("reflog", false, move || {
-        require_direct_ref(&repo, &reference)?;
+        require_direct_ref(&program, &repo, &reference)?;
         let exists = run_git_output(
+            &program,
             &repo,
             &["reflog", "exists", &reference],
             None,
@@ -861,6 +906,7 @@ pub(crate) async fn operation_recorded(
             return Ok(false);
         }
         let bytes = run_git(
+            &program,
             &repo,
             &[
                 "reflog",
@@ -884,13 +930,14 @@ pub(crate) async fn operation_recorded(
         if !parse_operation_recorded(&bytes, &new_sha, &marker)? {
             return Ok(false);
         }
-        require_direct_ref(&repo, &reference)?;
+        require_direct_ref(&program, &repo, &reference)?;
         // Resolve the head once, then make the ancestry query against immutable IDs.
-        let head = resolve_commit_sync(&repo, &reference)?;
+        let head = resolve_commit_sync(&program, &repo, &reference)?;
         if head.eq_ignore_ascii_case(&new_sha) {
             return Ok(true);
         }
         let ancestry = run_git_output(
+            &program,
             &repo,
             &["merge-base", "--is-ancestor", &new_sha, &head],
             None,
@@ -947,6 +994,7 @@ pub(crate) async fn diff(
     base: &str,
     head: &str,
 ) -> Result<DiffResult> {
+    let program = rt.config().git_write.git_program();
     let scratch;
     let (working_repo, left, right) = match input_kind {
         "commits" => {
@@ -954,6 +1002,7 @@ pub(crate) async fn diff(
             let head_ref = checked_ref(head)?;
             let left = oid_output(
                 &run_async(
+                    program,
                     repo,
                     &["rev-parse", "--verify", "--end-of-options", &base_ref],
                     None,
@@ -962,6 +1011,7 @@ pub(crate) async fn diff(
             )?;
             let right = oid_output(
                 &run_async(
+                    program,
                     repo,
                     &["rev-parse", "--verify", "--end-of-options", &head_ref],
                     None,
@@ -978,6 +1028,7 @@ pub(crate) async fn diff(
                     LocalGitError::new("scratch_error", "could not create scratch repository")
                 })?;
             run_async(
+                program,
                 scratch.path(),
                 &["init", "--bare", "--template=", "--object-format=sha1"],
                 None,
@@ -995,6 +1046,7 @@ pub(crate) async fn diff(
         }
     };
     let bytes = run_async(
+        program,
         working_repo,
         &[
             "diff-tree",
@@ -1010,6 +1062,7 @@ pub(crate) async fn diff(
     )
     .await?;
     let numstat = run_async(
+        program,
         working_repo,
         &[
             "diff-tree",
@@ -1034,12 +1087,19 @@ pub(crate) async fn diff(
     })
 }
 
-pub(crate) async fn is_ancestor(repo: &Path, base: &str, head: &str) -> Result<bool> {
+pub(crate) async fn is_ancestor(
+    program: &Path,
+    repo: &Path,
+    base: &str,
+    head: &str,
+) -> Result<bool> {
     validate_oid(base, "base")?;
     validate_oid(head, "head")?;
+    let program = program.to_path_buf();
     let (repo, base, head) = (repo.to_path_buf(), base.to_string(), head.to_string());
     blocking("merge-base", false, move || {
         Ok(run_git_output(
+            &program,
             &repo,
             &["merge-base", "--is-ancestor", &base, &head],
             None,
@@ -1053,10 +1113,12 @@ pub(crate) async fn is_ancestor(repo: &Path, base: &str, head: &str) -> Result<b
     .await
 }
 
-pub(crate) async fn object_directory(repo: &Path) -> Result<std::path::PathBuf> {
+pub(crate) async fn object_directory(program: &Path, repo: &Path) -> Result<std::path::PathBuf> {
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     blocking("rev-parse", false, move || {
         let bytes = run_git(
+            &program,
             &repo,
             &["rev-parse", "--git-path", "objects"],
             None,
@@ -1074,6 +1136,7 @@ pub(crate) async fn object_directory(repo: &Path) -> Result<std::path::PathBuf> 
 }
 
 pub(crate) async fn record_push_marker(
+    program: &Path,
     repo: &Path,
     branch: &str,
     sha: &str,
@@ -1082,13 +1145,15 @@ pub(crate) async fn record_push_marker(
     validate_oid(sha, "pushed head")?;
     let reference = branch_ref(branch)?;
     let marker = receipt_marker(receipt_id)?;
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     let sha = sha.to_string();
     blocking("reflog", false, move || {
-        require_direct_ref(&repo, &reference)?;
+        require_direct_ref(&program, &repo, &reference)?;
         // update-ref suppresses reflog writes for an unchanged SHA. An explicit
         // reflog write records acknowledgement without changing any source ref.
         run_git(
+            &program,
             &repo,
             &["reflog", "write", &reference, &sha, &sha, &marker],
             None,
@@ -1100,13 +1165,22 @@ pub(crate) async fn record_push_marker(
     .await
 }
 
-pub(crate) async fn push_marker_support(repo: &Path) -> Result<(String, bool)> {
+pub(crate) async fn push_marker_support(program: &Path, repo: &Path) -> Result<(String, bool)> {
+    let program = program.to_path_buf();
     let repo = repo.to_path_buf();
     blocking("reflog", false, move || {
-        let version = run_git(&repo, &["--version"], None, None, false)?;
+        let version = run_git(&program, &repo, &["--version"], None, None, false)?;
         let version = String::from_utf8(version)
             .map_err(|_| LocalGitError::new("git_output", "invalid Git version"))?;
-        let help = run_git_output(&repo, &["reflog", "-h"], None, None, false, Some(129))?;
+        let help = run_git_output(
+            &program,
+            &repo,
+            &["reflog", "-h"],
+            None,
+            None,
+            false,
+            Some(129),
+        )?;
         Ok((
             version.trim().to_owned(),
             String::from_utf8_lossy(&help.stdout).contains("git reflog write "),
@@ -1146,7 +1220,12 @@ pub(crate) struct StatusResult {
 /// already in the hardened environment, so this refreshes nothing and takes no index lock: the
 /// working tree and the index are byte-identical before and after. `total` counts every entry git
 /// reported, so `total == 0` is a whole-repository claim even when `entries` was capped by `limit`.
-pub(crate) async fn status(repo: &Path, untracked: &str, limit: usize) -> Result<StatusResult> {
+pub(crate) async fn status(
+    program: &Path,
+    repo: &Path,
+    untracked: &str,
+    limit: usize,
+) -> Result<StatusResult> {
     let untracked_arg = match untracked {
         "no" | "normal" | "all" => format!("--untracked-files={untracked}"),
         _ => {
@@ -1157,6 +1236,7 @@ pub(crate) async fn status(repo: &Path, untracked: &str, limit: usize) -> Result
         }
     };
     let bytes = run_async(
+        program,
         repo,
         &[
             "status",
@@ -1289,7 +1369,7 @@ fn parse_status(bytes: &[u8], limit: usize) -> Result<StatusResult> {
 /// performed, because git would rewrite configuration in place and the caller would read success.
 /// `--template=` is passed so the new repository inherits no sample hooks, which keeps ADR-182
 /// Amendment 2 item 4 true of a repository this pack created.
-pub(crate) async fn init(repo: &Path, branch: &str) -> Result<String> {
+pub(crate) async fn init(program: &Path, repo: &Path, branch: &str) -> Result<String> {
     validate_ref_name("branch", branch)
         .map_err(|error| LocalGitError::new("invalid_params", error.to_string()))?;
     if !repo.is_dir() {
@@ -1310,7 +1390,13 @@ pub(crate) async fn init(repo: &Path, branch: &str) -> Result<String> {
     // receipt that is wrong, and this call must not delete a `.git` it may not have created (the
     // check above is a moment earlier, and `git init` is idempotent over an existing repository),
     // so the outcome is reported as unestablished with the path that has to be looked at.
-    let created = run_async(repo, &["init", "-q", "--template=", "-b", branch], None).await;
+    let created = run_async(
+        program,
+        repo,
+        &["init", "-q", "--template=", "-b", branch],
+        None,
+    )
+    .await;
     let partial = |error: LocalGitError| {
         if !repo.join(".git").exists() {
             return error;
@@ -1329,11 +1415,11 @@ pub(crate) async fn init(repo: &Path, branch: &str) -> Result<String> {
         }
     };
     created.map_err(partial)?;
-    resolve_head_branch(repo).await.map_err(partial)
+    resolve_head_branch(program, repo).await.map_err(partial)
 }
 
-async fn resolve_head_branch(repo: &Path) -> Result<String> {
-    let bytes = run_async(repo, &["symbolic-ref", "--short", "HEAD"], None).await?;
+async fn resolve_head_branch(program: &Path, repo: &Path) -> Result<String> {
+    let bytes = run_async(program, repo, &["symbolic-ref", "--short", "HEAD"], None).await?;
     Ok(String::from_utf8_lossy(&bytes).trim().to_string())
 }
 
@@ -1353,6 +1439,7 @@ pub(crate) struct LogEntry {
 /// main-command option and so precedes the subcommand; it stops a caller-supplied path from being
 /// read as a glob or a magic pathspec.
 pub(crate) async fn log(
+    program: &Path,
     repo: &Path,
     reference: &str,
     limit: usize,
@@ -1379,7 +1466,7 @@ pub(crate) async fn log(
         argv.push("--");
         argv.push(path);
     }
-    let bytes = run_async(repo, &argv, None).await?;
+    let bytes = run_async(program, repo, &argv, None).await?;
     let text = std::str::from_utf8(&bytes)
         .map_err(|_| LocalGitError::new("git_failed", "git log emitted a non-UTF-8 record"))?;
     let mut entries = Vec::new();
@@ -1416,9 +1503,14 @@ mod tests {
         let dir = tempfile::tempdir().expect("fixture directory");
         let repo = dir.path().join("repo");
         std::fs::create_dir(&repo).expect("repo directory");
-        run_async(&repo, &["init", "-q", "--template="], None)
-            .await
-            .expect("initialize fixture");
+        run_async(
+            Path::new("git"),
+            &repo,
+            &["init", "-q", "--template="],
+            None,
+        )
+        .await
+        .expect("initialize fixture");
         std::fs::write(repo.join("file.txt"), b"file contents\n").expect("file");
         std::fs::create_dir(repo.join("dir")).expect("directory");
         std::fs::write(repo.join("dir/nested.txt"), b"nested contents\n").expect("nested file");
@@ -1429,11 +1521,11 @@ mod tests {
         ] {
             symlink(OsStr::from_bytes(target), repo.join(path)).expect("symlink");
         }
-        run_async(&repo, &["add", "--all"], None)
+        run_async(Path::new("git"), &repo, &["add", "--all"], None)
             .await
             .expect("index fixture");
         let original = oid_output(
-            &run_async(&repo, &["write-tree"], None)
+            &run_async(Path::new("git"), &repo, &["write-tree"], None)
                 .await
                 .expect("original tree"),
         )
@@ -1449,7 +1541,7 @@ mod tests {
         rt.install_blob_store(std::sync::Arc::new(blobs))
             .expect("install blob store");
         let store = tree::blob_store(&rt).expect("blob store");
-        let listing = run_async(&repo, &["ls-files", "-s", "-z"], None)
+        let listing = run_async(Path::new("git"), &repo, &["ls-files", "-s", "-z"], None)
             .await
             .expect("index listing");
         let mut entries = Vec::new();
@@ -1473,9 +1565,14 @@ mod tests {
                 mode => panic!("unexpected index mode {mode}"),
             };
             let path = std::str::from_utf8(&record[tab + 1..]).unwrap();
-            let bytes = run_async(&repo, &["cat-file", "blob", fields[1]], None)
-                .await
-                .expect("index blob");
+            let bytes = run_async(
+                Path::new("git"),
+                &repo,
+                &["cat-file", "blob", fields[1]],
+                None,
+            )
+            .await
+            .expect("index blob");
             if mode == 120000 {
                 assert_eq!(
                     bytes,
@@ -1497,6 +1594,7 @@ mod tests {
             .expect("write manifest tree");
         assert_eq!(roundtrip, original);
         let diff = run_async(
+            Path::new("git"),
             &repo,
             &[
                 "diff-tree",

--- a/crates/khive-pack-git/src/local_handlers.rs
+++ b/crates/khive-pack-git/src/local_handlers.rs
@@ -424,7 +424,12 @@ impl GitPack {
         match verb {
             "git.init" => {
                 let branch = optional(params, "branch")?.unwrap_or("main");
-                let head = local_git::init(repo, branch).await?;
+                let head = local_git::init(
+                    self.runtime().config().git_write.git_program(),
+                    repo,
+                    branch,
+                )
+                .await?;
                 let result = json!({"repo":repo.display().to_string(), "branch":head,
                     "receipt_id":receipt.id});
                 receipt.result = result.clone();
@@ -452,7 +457,12 @@ impl GitPack {
             "git.branch" => {
                 let name = required(params, "name")?;
                 let from = optional(params, "from")?;
-                let sha = local_git::resolve_commit(repo, from.unwrap_or("HEAD")).await?;
+                let sha = local_git::resolve_commit(
+                    self.runtime().config().git_write.git_program(),
+                    repo,
+                    from.unwrap_or("HEAD"),
+                )
+                .await?;
                 if optional(params, "expected")?
                     .is_some_and(|expected| !sha.eq_ignore_ascii_case(expected))
                 {
@@ -462,13 +472,27 @@ impl GitPack {
                     "sha":sha, "ref":format!("refs/heads/{name}"), "receipt_id":receipt.id});
                 receipt.result = result.clone();
                 receipts::persist(self.runtime(), receipt).await?;
-                local_git::create_branch_ref(repo, name, &sha, &receipt.id).await?;
+                local_git::create_branch_ref(
+                    self.runtime().config().git_write.git_program(),
+                    repo,
+                    name,
+                    &sha,
+                    &receipt.id,
+                )
+                .await?;
                 Ok(result)
             }
             "git.commit" => {
                 let branch = required(params, "branch")?;
                 let expected = required(params, "expected_head")?.to_ascii_lowercase();
-                if local_git::branch_head(repo, branch).await? != expected {
+                if local_git::branch_head(
+                    self.runtime().config().git_write.git_program(),
+                    repo,
+                    branch,
+                )
+                .await?
+                    != expected
+                {
                     return Err(Failure::refused("expected_head_mismatch"));
                 }
                 let config = &self.runtime().config().git_write;
@@ -484,6 +508,7 @@ impl GitPack {
                 let tree = required(params, "tree")?;
                 let git_tree = local_git::write_manifest_tree(self.runtime(), repo, tree).await?;
                 let sha = local_git::create_commit(
+                    self.runtime().config().git_write.git_program(),
                     repo,
                     &git_tree,
                     &expected,
@@ -497,7 +522,15 @@ impl GitPack {
                 receipt.result = result.clone();
                 // The candidate SHA is durable before update-ref can have an effect.
                 receipts::persist(self.runtime(), receipt).await?;
-                local_git::update_branch(repo, branch, &sha, &expected, &receipt.id).await?;
+                local_git::update_branch(
+                    self.runtime().config().git_write.git_program(),
+                    repo,
+                    branch,
+                    &sha,
+                    &expected,
+                    &receipt.id,
+                )
+                .await?;
                 Ok(result)
             }
             "git.reconcile" => {
@@ -527,9 +560,15 @@ impl GitPack {
                     if let (Some(branch), Some(sha)) = (branch, sha) {
                         // Settlement requires both the operation marker and current reachability.
                         // Missing/pruned evidence or a rewound ref leaves the prior row unknown.
-                        if local_git::operation_recorded(repo, branch, sha, &prior.id)
-                            .await
-                            .unwrap_or(false)
+                        if local_git::operation_recorded(
+                            self.runtime().config().git_write.git_program(),
+                            repo,
+                            branch,
+                            sha,
+                            &prior.id,
+                        )
+                        .await
+                        .unwrap_or(false)
                         {
                             prior.disposition = Disposition::Committed;
                             prior.finished_at = Some(chrono::Utc::now().timestamp_micros());
@@ -724,9 +763,14 @@ impl GitPack {
                 .ok_or_else(invalid)? as usize,
         };
         let (canonical, index) = self.read_gate(token, registry, "git.status", repo).await?;
-        let result = local_git::status(&canonical, untracked, limit)
-            .await
-            .map_err(read_refusal)?;
+        let result = local_git::status(
+            self.runtime().config().git_write.git_program(),
+            &canonical,
+            untracked,
+            limit,
+        )
+        .await
+        .map_err(read_refusal)?;
         let entries = serde_json::to_value(&result.entries)
             .map_err(|_| RuntimeError::Internal("status entries did not serialize".into()))?;
         let branch = serde_json::to_value(&result.branch)
@@ -763,9 +807,15 @@ impl GitPack {
                 .ok_or_else(invalid)? as usize,
         };
         let (canonical, index) = self.read_gate(token, registry, "git.log", repo).await?;
-        let commits = local_git::log(&canonical, reference, limit, path)
-            .await
-            .map_err(read_refusal)?;
+        let commits = local_git::log(
+            self.runtime().config().git_write.git_program(),
+            &canonical,
+            reference,
+            limit,
+            path,
+        )
+        .await
+        .map_err(read_refusal)?;
         let truncated = commits.len() == limit;
         let commits = serde_json::to_value(&commits)
             .map_err(|_| RuntimeError::Internal("log entries did not serialize".into()))?;

--- a/crates/khive-pack-git/src/local_remote_tests.rs
+++ b/crates/khive-pack-git/src/local_remote_tests.rs
@@ -60,7 +60,16 @@ struct Fixture {
 
 impl Fixture {
     async fn new(remote: impl FnOnce(&Path) -> String, slug: &str) -> Self {
+        Self::with_program(remote, slug, || None).await
+    }
+
+    async fn with_program(
+        remote: impl FnOnce(&Path) -> String,
+        slug: &str,
+        program: impl FnOnce() -> Option<PathBuf>,
+    ) -> Self {
         let env_guard = crate::cache::ENV_MUTEX.lock().await;
+        let program = program();
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path().join("repo");
         let platform_repo = dir.path().join("platform");
@@ -112,6 +121,7 @@ impl Fixture {
         let rt = KhiveRuntime::new(RuntimeConfig {
             db_path: None,
             git_write: GitWriteSectionConfig {
+                program,
                 allowed: [&repo, &platform_repo, &unmapped_repo]
                     .into_iter()
                     .map(|repo| GitWriteEntryConfig {
@@ -281,12 +291,192 @@ async fn local_file_push_moves_native_ref_without_credentials() {
     assert_eq!(receipt.actor, f.actor);
     assert_eq!(receipt.gate["decision"], "allow");
     assert_eq!(receipt.policy["decision"], "allow");
+    assert!(crate::local_git::operation_recorded(
+        Path::new("git"),
+        &f.repo,
+        "work",
+        &f.head,
+        &receipt.id
+    )
+    .await
+    .unwrap());
+    f.no_credential_read();
+}
+
+#[tokio::test]
+async fn git_program_quoted_path_controls_native_push_and_receiver() {
+    let dir = tempfile::tempdir().unwrap();
+    let program = dir.path().join("selected git's executable");
+    let marker = dir.path().join("selected-program-calls");
+    let f = Fixture::with_program(file_url, "", || {
+        let native = Command::new("/usr/bin/which").arg("git").output().unwrap();
+        assert!(native.status.success());
+        let native = String::from_utf8(native.stdout).unwrap();
+        let quote = |value: &str| format!("'{}'", value.replace('\'', "'\\''"));
+        std::fs::write(
+            &program,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> {}\nexec {} \"$@\"\n",
+                quote(marker.to_str().unwrap()),
+                quote(native.trim())
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o700)).unwrap();
+        Some(program.clone())
+    })
+    .await;
+    let hook_marker = dir.path().join("destination-hook");
+    let hook = f.bare.join("hooks/update");
+    std::fs::create_dir_all(hook.parent().unwrap()).unwrap();
+    std::fs::write(
+        &hook,
+        format!("#!/bin/sh\ntouch '{}'\n", hook_marker.display()),
+    )
+    .unwrap();
+    std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o700)).unwrap();
+    f.call(&f.actor, "git.push", f.push()).await.unwrap();
+    assert_eq!(f.remote_head(), f.head);
+    assert!(!hook_marker.exists());
+    let receipt = f.last(&f.actor).await;
     assert!(
-        crate::local_git::operation_recorded(&f.repo, "work", &f.head, &receipt.id)
+        crate::local_git::operation_recorded(&program, &f.repo, "work", &f.head, &receipt.id)
             .await
             .unwrap()
     );
+    let calls = std::fs::read_to_string(marker).unwrap();
+    for command in [
+        "config -z",
+        "--version",
+        "reflog -h",
+        "init",
+        "ls-remote",
+        " push --porcelain ",
+        "reflog write",
+        "receive-pack",
+    ] {
+        assert!(
+            calls.contains(command),
+            "selected program missed {command}: {calls}"
+        );
+    }
+    assert!(
+        calls
+            .lines()
+            .any(|line| line.starts_with("-c core.hooksPath=/dev/null receive-pack ")),
+        "{calls}"
+    );
     f.no_credential_read();
+}
+
+// The parent changes only a child's environment, never the shared test process.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "requires real Apple and Homebrew Git installations"]
+fn git_program_real_two_git_path_orders() {
+    let old = Path::new("/usr/bin/git");
+    let capable = Path::new("/opt/homebrew/bin/git");
+    for (program, supported) in [(old, false), (capable, true)] {
+        let help = Command::new(program)
+            .args(["reflog", "-h"])
+            .output()
+            .unwrap();
+        let help = format!(
+            "{}{}",
+            String::from_utf8_lossy(&help.stdout),
+            String::from_utf8_lossy(&help.stderr)
+        );
+        assert_eq!(
+            help.contains("reflog write"),
+            supported,
+            "{}: {help}",
+            program.display()
+        );
+    }
+    for (path, first, supported) in [
+        ("/usr/bin:/opt/homebrew/bin:/bin", old, false),
+        ("/opt/homebrew/bin:/usr/bin:/bin", capable, true),
+    ] {
+        for configured in [false, true] {
+            let child = Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "local_remote_tests::git_program_path_order_child",
+                    "--ignored",
+                    "--nocapture",
+                ])
+                .env("PATH", path)
+                .env(
+                    "KHIVE_TEST_GIT_PROGRAM",
+                    if configured {
+                        capable.as_os_str()
+                    } else {
+                        std::ffi::OsStr::new("")
+                    },
+                )
+                .env("KHIVE_TEST_GIT_FIRST", first)
+                .env(
+                    "KHIVE_TEST_GIT_SUPPORTED",
+                    if configured || supported {
+                        "true"
+                    } else {
+                        "false"
+                    },
+                )
+                .output()
+                .unwrap();
+            let output = format!(
+                "{}{}",
+                String::from_utf8_lossy(&child.stdout),
+                String::from_utf8_lossy(&child.stderr)
+            );
+            assert!(
+                child.status.success() && output.contains("git-program-child-verified"),
+                "{path}, configured={configured}: {output}"
+            );
+            println!("{output}");
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+#[ignore = "child of git_program_real_two_git_path_orders"]
+async fn git_program_path_order_child() {
+    let configured = std::env::var_os("KHIVE_TEST_GIT_PROGRAM").expect("parent supplies program");
+    let program = (!configured.is_empty()).then(|| PathBuf::from(configured));
+    let first = std::env::var_os("KHIVE_TEST_GIT_FIRST").expect("parent supplies first Git");
+    let supported = std::env::var("KHIVE_TEST_GIT_SUPPORTED").unwrap() == "true";
+    let selected = program.clone().unwrap_or_else(|| first.into());
+    let expected = Command::new(&selected).arg("--version").output().unwrap();
+    assert!(expected.status.success());
+    let expected = String::from_utf8(expected.stdout)
+        .unwrap()
+        .trim()
+        .to_owned();
+    let f = Fixture::with_program(file_url, "", || program).await;
+    let actual =
+        crate::local_git::push_marker_support(f.rt.config().git_write.git_program(), &f.repo)
+            .await
+            .unwrap();
+    assert_eq!(actual, (expected.clone(), supported));
+    if supported {
+        f.call(&f.actor, "git.push", f.push()).await.unwrap();
+        assert_eq!(f.remote_head(), f.head);
+        assert_eq!(f.last(&f.actor).await.disposition, Disposition::Committed);
+    } else {
+        f.refusal("git.push", f.push(), "unsupported_toolchain")
+            .await;
+        assert_eq!(
+            f.last(&f.actor).await.result["toolchain"]["git_version"],
+            expected
+        );
+    }
+    f.no_credential_read();
+    println!(
+        "git-program-child-verified selected={} version={expected} supported={supported}",
+        selected.display()
+    );
 }
 
 #[tokio::test]
@@ -518,7 +708,7 @@ async fn local_push_reconcile_requires_marker_and_exact_remote_without_credentia
     receipt.disposition = Disposition::Unknown;
     receipt.finished_at = None;
     receipts::insert(&f.rt, &receipt).await.unwrap();
-    crate::local_git::record_push_marker(&f.repo, "work", &f.head, &receipt.id)
+    crate::local_git::record_push_marker(Path::new("git"), &f.repo, "work", &f.head, &receipt.id)
         .await
         .unwrap();
     git(&f.bare, &["update-ref", "refs/heads/work", &f.rival]);

--- a/crates/khive-pack-git/src/pack.rs
+++ b/crates/khive-pack-git/src/pack.rs
@@ -46,9 +46,12 @@ impl Pack for GitPack {
 impl GitPack {
     /// Create a new `GitPack` bound to the given runtime.
     pub fn new(runtime: KhiveRuntime) -> Self {
+        let remote = crate::remote_transport::GhTransport::new(
+            runtime.config().git_write.git_program().to_path_buf(),
+        );
         Self {
             runtime,
-            remote: Arc::new(crate::remote_transport::GhTransport),
+            remote: Arc::new(remote),
         }
     }
 

--- a/crates/khive-pack-git/src/remote_handlers.rs
+++ b/crates/khive-pack-git/src/remote_handlers.rs
@@ -426,13 +426,24 @@ impl GitPack {
             }
         }
         if verb == "git.push" {
-            let (version, supported) = local_git::push_marker_support(&repo).await?;
+            let (version, supported) = local_git::push_marker_support(
+                self.runtime().config().git_write.git_program(),
+                &repo,
+            )
+            .await?;
             if !supported {
-                receipt.result = json!({"toolchain":{"git_version":version,"missing_capability":"reflog write"}});
+                receipt.result = json!({"toolchain":{"git_version":version,"git_program":self.runtime().config().git_write.git_program(),"missing_capability":"reflog write"}});
                 return Err(Failure::refused("unsupported_toolchain"));
             }
             let expected = required(params, "expected_local")?.to_ascii_lowercase();
-            if local_git::branch_head(&repo, required(params, "branch")?).await? != expected {
+            if local_git::branch_head(
+                self.runtime().config().git_write.git_program(),
+                &repo,
+                required(params, "branch")?,
+            )
+            .await?
+                != expected
+            {
                 return Err(Failure::refused("expected_local_mismatch"));
             }
         }
@@ -658,7 +669,14 @@ impl GitPack {
             return Err(Failure::refused("expected_remote_mismatch"));
         }
         if let Some(old) = &old {
-            if !local_git::is_ancestor(Path::new(&receipt.repo), old, &expected).await? {
+            if !local_git::is_ancestor(
+                self.runtime().config().git_write.git_program(),
+                Path::new(&receipt.repo),
+                old,
+                &expected,
+            )
+            .await?
+            {
                 return Err(Failure::refused("non_fast_forward"));
             }
         }
@@ -686,9 +704,15 @@ impl GitPack {
             return Err(Failure::unknown("remote_readback_mismatch"));
         }
         // A marker records an acknowledged effect, never an intention to push.
-        local_git::record_push_marker(Path::new(&receipt.repo), branch, &expected, &receipt.id)
-            .await
-            .map_err(|_| Failure::unknown("marker_unavailable"))?;
+        local_git::record_push_marker(
+            self.runtime().config().git_write.git_program(),
+            Path::new(&receipt.repo),
+            branch,
+            &expected,
+            &receipt.id,
+        )
+        .await
+        .map_err(|_| Failure::unknown("marker_unavailable"))?;
         Ok(result)
     }
 
@@ -804,9 +828,15 @@ impl GitPack {
             };
             let id = column("id")?;
             if column("disposition")? != "committed"
-                && !local_git::operation_recorded(Path::new(column("repo")?), branch, expected, id)
-                    .await
-                    .unwrap_or(false)
+                && !local_git::operation_recorded(
+                    self.runtime().config().git_write.git_program(),
+                    Path::new(column("repo")?),
+                    branch,
+                    expected,
+                    id,
+                )
+                .await
+                .unwrap_or(false)
             {
                 // A durable intent or a lost transport ACK is not push evidence.
                 continue;
@@ -926,9 +956,15 @@ impl GitPack {
                 if prior.result.get("remote").and_then(Value::as_str) != Some(&target.remote) {
                     return Ok(());
                 }
-                local_git::operation_recorded(repo, branch, &sha, &prior.id)
-                    .await
-                    .unwrap_or(false)
+                local_git::operation_recorded(
+                    self.runtime().config().git_write.git_program(),
+                    repo,
+                    branch,
+                    &sha,
+                    &prior.id,
+                )
+                .await
+                .unwrap_or(false)
                     && self
                         .remote_transport()
                         .remote_ref(

--- a/crates/khive-pack-git/src/remote_tests.rs
+++ b/crates/khive-pack-git/src/remote_tests.rs
@@ -148,7 +148,7 @@ impl RemoteTransport for Recording {
             git(&self.bare, &["update-ref", "refs/heads/work", &sha]);
         }
         request.remote = self.bare.display().to_string();
-        crate::remote_transport::push_native(token, request, true).await?;
+        crate::remote_transport::push_native(Path::new("git"), token, request, true).await?;
         self.state.lock().unwrap().writes += 1;
         if lost {
             Err(RemoteError::Unknown)
@@ -257,7 +257,17 @@ impl Fixture {
         fault: Option<&str>,
         merge_refusals: &[&str],
     ) -> Self {
+        Self::with_program(allowed, fault, merge_refusals, || None).await
+    }
+
+    async fn with_program(
+        allowed: bool,
+        fault: Option<&str>,
+        merge_refusals: &[&str],
+        program: impl FnOnce() -> Option<PathBuf>,
+    ) -> Self {
         let env_guard = crate::cache::ENV_MUTEX.lock().await;
+        let program = program();
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path().join("repo");
         std::fs::create_dir(&repo).unwrap();
@@ -324,6 +334,7 @@ impl Fixture {
         let rt = KhiveRuntime::new(RuntimeConfig {
             db_path: None,
             git_write: GitWriteSectionConfig {
+                program,
                 allowed: if allowed {
                     vec![GitWriteEntryConfig {
                         repo: repo.display().to_string(),
@@ -1029,7 +1040,7 @@ async fn push_cases_require_a_git_that_advertises_reflog_write() {
         "git init: {}",
         String::from_utf8_lossy(&init.stderr)
     );
-    let (version, supported) = crate::local_git::push_marker_support(&repo)
+    let (version, supported) = crate::local_git::push_marker_support(Path::new("git"), &repo)
         .await
         .expect("capability probe");
     assert!(
@@ -1045,26 +1056,18 @@ async fn push_cases_require_a_git_that_advertises_reflog_write() {
 
 #[tokio::test]
 async fn remote_unsupported_git_is_receipted_before_credentials_or_network() {
-    struct RestorePath(std::ffi::OsString);
-    impl Drop for RestorePath {
-        fn drop(&mut self) {
-            std::env::set_var("PATH", &self.0);
-        }
-    }
-    let f = Fixture::new(true, None).await;
-    let old_path = std::env::var_os("PATH").unwrap();
-    let git_path = Command::new("/usr/bin/which").arg("git").output().unwrap();
-    assert!(git_path.status.success());
-    let git_path = PathBuf::from(String::from_utf8(git_path.stdout).unwrap().trim());
-    let bin = f.dir.path().join("old-git");
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("old-git");
     std::fs::create_dir(&bin).unwrap();
     let wrapper = bin.join("git");
-    std::fs::write(&wrapper, format!("#!/bin/sh\ncase \"$*\" in\n*' --version') echo 'git version 2.40.0'; exit 0;;\n*' reflog -h') echo 'usage: git reflog show'; exit 129;;\nesac\nexec {} \"$@\"\n", quote(&git_path))).unwrap();
-    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o700)).unwrap();
-    let mut paths = vec![bin];
-    paths.extend(std::env::split_paths(&old_path));
-    let _restore = RestorePath(old_path);
-    std::env::set_var("PATH", std::env::join_paths(paths).unwrap());
+    let f = Fixture::with_program(true, None, &[], || {
+        let git_path = Command::new("/usr/bin/which").arg("git").output().unwrap();
+        assert!(git_path.status.success());
+        let git_path = PathBuf::from(String::from_utf8(git_path.stdout).unwrap().trim());
+        std::fs::write(&wrapper, format!("#!/bin/sh\ncase \"$*\" in\n*' --version') echo 'git version 2.40.0'; exit 0;;\n*' reflog -h') echo 'usage: git reflog show'; exit 129;;\nesac\nexec {} \"$@\"\n", quote(&git_path))).unwrap();
+        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o700)).unwrap();
+        Some(wrapper.clone())
+    }).await;
     f.refusal(&f.actor, "git.push", f.push(), "unsupported_toolchain")
         .await;
     let receipt = f.last(&f.actor).await;
@@ -1076,6 +1079,7 @@ async fn remote_unsupported_git_is_receipted_before_credentials_or_network() {
         receipt.result["toolchain"]["missing_capability"],
         "reflog write"
     );
+    assert_eq!(receipt.result["toolchain"]["git_program"], json!(wrapper));
     assert!(receipt.credential.is_null());
     assert!(f.remote.state.lock().unwrap().calls.is_empty());
     assert_eq!(remote_head(&f.remote.bare), Some(f.base.clone()));

--- a/crates/khive-pack-git/src/remote_transport.rs
+++ b/crates/khive-pack-git/src/remote_transport.rs
@@ -55,9 +55,11 @@ pub trait RemoteTransport: Send + Sync {
     async fn push(&self, token: Option<&str>, request: PushRequest) -> Result<(), RemoteError>;
 }
 
-pub struct GhTransport;
+pub struct GhTransport {
+    program: PathBuf,
+}
 
-fn isolated(program: &str) -> Command {
+fn isolated(program: impl AsRef<std::ffi::OsStr>) -> Command {
     let mut command = Command::new(program);
     command.env_clear();
     if let Some(path) = std::env::var_os("PATH") {
@@ -79,8 +81,8 @@ fn isolated(program: &str) -> Command {
     command
 }
 
-fn git_command(repo: &Path, token: Option<&str>) -> Command {
-    let mut command = isolated("git");
+fn git_command(program: &Path, repo: &Path, token: Option<&str>) -> Command {
+    let mut command = isolated(program.as_os_str());
     for setting in [
         "core.hooksPath=/dev/null",
         "core.fsmonitor=false",
@@ -156,9 +158,9 @@ async fn run(
     Ok(result)
 }
 
-async fn bare() -> Result<tempfile::TempDir, RemoteError> {
+async fn bare(program: &Path) -> Result<tempfile::TempDir, RemoteError> {
     let dir = tempfile::tempdir().map_err(|_| RemoteError::Unavailable)?;
-    let mut command = git_command(dir.path(), None);
+    let mut command = git_command(program, dir.path(), None);
     command.args(["init", "--bare", "--quiet", "--template="]);
     if !run(command, None, false).await?.0 {
         return Err(RemoteError::Unavailable);
@@ -171,6 +173,10 @@ fn valid_oid(value: &str) -> bool {
 }
 
 impl GhTransport {
+    pub fn new(program: PathBuf) -> Self {
+        Self { program }
+    }
+
     async fn call_api(
         &self,
         token: &str,
@@ -252,9 +258,9 @@ impl RemoteTransport for GhTransport {
         remote: &str,
         branch: &str,
     ) -> Result<Option<String>, RemoteError> {
-        let scratch = bare().await?;
+        let scratch = bare(&self.program).await?;
         let reference = format!("refs/heads/{branch}");
-        let mut command = git_command(scratch.path(), token);
+        let mut command = git_command(&self.program, scratch.path(), token);
         if token.is_none() {
             command.args([
                 "-c",
@@ -284,17 +290,18 @@ impl RemoteTransport for GhTransport {
     }
 
     async fn push(&self, token: Option<&str>, request: PushRequest) -> Result<(), RemoteError> {
-        push_native(token, request, token.is_none()).await
+        push_native(&self.program, token, request, token.is_none()).await
     }
 }
 
 pub(crate) async fn push_native(
+    program: &Path,
     token: Option<&str>,
     request: PushRequest,
     allow_file: bool,
 ) -> Result<(), RemoteError> {
-    let scratch = bare().await?;
-    let objects = crate::local_git::object_directory(&request.repo)
+    let scratch = bare(program).await?;
+    let objects = crate::local_git::object_directory(program, &request.repo)
         .await
         .map_err(|_| RemoteError::Unavailable)?;
     let reference = format!("refs/heads/{}", request.branch);
@@ -303,7 +310,8 @@ pub(crate) async fn push_native(
         "--force-with-lease={reference}:{}",
         request.expected_remote.as_deref().unwrap_or("")
     );
-    let mut command = git_command(scratch.path(), token);
+    let mut command = git_command(program, scratch.path(), token);
+    let receive_pack;
     if allow_file {
         command.args([
             "-c",
@@ -325,7 +333,12 @@ pub(crate) async fn push_native(
         // Local transport runs the destination's receive-pack as this process, and the
         // client-side hooks path above does not reach it: the destination's own hooks would
         // run. The receive-pack invocation carries its own hooks path instead.
-        args.push("--receive-pack=git -c core.hooksPath=/dev/null receive-pack");
+        let program = program.to_str().ok_or(RemoteError::Unavailable)?;
+        receive_pack = format!(
+            "--receive-pack='{}' -c core.hooksPath=/dev/null receive-pack",
+            program.replace('\'', "'\\''")
+        );
+        args.push(&receive_pack);
     }
     args.extend([
         lease.as_str(),
@@ -502,7 +515,7 @@ mod tests {
             ),
         ] {
             std::fs::write(dir.path().join("response"), response).unwrap();
-            let actual = GhTransport
+            let actual = GhTransport::new("git".into())
                 .review_decision("fixture-secret", "owner/project", 42)
                 .await;
             assert_eq!(actual, expected);

--- a/crates/khive-pack-git/src/write_argv.rs
+++ b/crates/khive-pack-git/src/write_argv.rs
@@ -2,8 +2,8 @@
 //!
 //! Every caller-supplied value that can reach `std::process::Command::args`
 //! for `git.commit` / `git.branch` / `git.push` passes through this module
-//! first. Nothing here ever touches a shell: `Command::new("git")` spawns the
-//! binary directly and `.args([...])` passes each element as one literal,
+//! first. Nothing here ever touches a shell: `Command::new(program)` spawns the
+//! operator-selected binary directly and `.args([...])` passes each element as one literal,
 //! unparsed argv entry — there is no string interpolation anywhere in this
 //! crate's write path for a caller-supplied value to escape.
 //!

--- a/crates/khive-pack-git/src/write_handlers.rs
+++ b/crates/khive-pack-git/src/write_handlers.rs
@@ -135,8 +135,8 @@ fn parse_paths_param(params: &Value) -> Result<Vec<String>, RuntimeError> {
 /// credential config is not). Unit-test builds override both config sources
 /// below so handler tests remain hermetic; that override is not compiled into
 /// production builds.
-fn run_git(repo: &Path, argv: &[String]) -> Result<String, RuntimeError> {
-    let mut command = Command::new("git");
+fn run_git(program: &Path, repo: &Path, argv: &[String]) -> Result<String, RuntimeError> {
+    let mut command = Command::new(program);
     command
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
@@ -164,8 +164,9 @@ fn run_git(repo: &Path, argv: &[String]) -> Result<String, RuntimeError> {
 /// writes to is whatever is checked out — so this is what
 /// `enforce_write_policy` checks the allowlist against for that verb.
 /// Errors (e.g. detached HEAD) surface as an ordinary handler error.
-fn current_branch(repo: &Path) -> Result<String, RuntimeError> {
+fn current_branch(program: &Path, repo: &Path) -> Result<String, RuntimeError> {
     let out = run_git(
+        program,
         repo,
         &[
             "symbolic-ref".to_string(),
@@ -206,11 +207,15 @@ struct CommitPreflight {
     commit_argv: Vec<String>,
 }
 
-fn prepare_commit(repo: &Path, params: &Value) -> Result<CommitPreflight, WritePreflightError> {
+fn prepare_commit(
+    program: &Path,
+    repo: &Path,
+    params: &Value,
+) -> Result<CommitPreflight, WritePreflightError> {
     validate_repo_path(repo)
         .map_err(to_invalid_input)
         .map_err(|e| WritePreflightError::denied(e, None))?;
-    let branch = current_branch(repo).map_err(WritePreflightError::runtime)?;
+    let branch = current_branch(program, repo).map_err(WritePreflightError::runtime)?;
     let message = params
         .get("message")
         .and_then(Value::as_str)
@@ -307,6 +312,32 @@ impl GitPack {
         let repo = self
             .parse_audited_repo(token, "git.commit", &params)
             .await?;
+        if let Err(failure) = crate::local_handlers::validate_keys(
+            &params,
+            &[
+                "repo",
+                "message",
+                "paths",
+                "author",
+                "session_id",
+                "branch",
+                "expected_head",
+            ],
+        ) {
+            return Err(self
+                .audit_early_failure(
+                    token,
+                    "git.commit",
+                    &repo,
+                    None,
+                    EventOutcome::Denied,
+                    RuntimeError::InvalidInput(
+                        failure.detail.unwrap_or_else(|| failure.reason.into()),
+                    ),
+                )
+                .await);
+        }
+        let program = self.runtime().config().git_write.git_program();
 
         // #2572: every other git verb, including the `tree` form of this one,
         // refuses unless `tool.check` answers `allow`; the `paths` form consulted
@@ -344,7 +375,7 @@ impl GitPack {
             branch,
             add_argv,
             commit_argv,
-        } = match prepare_commit(&repo, &params) {
+        } = match prepare_commit(program, &repo, &params) {
             Ok(preflight) => preflight,
             Err(failure) => {
                 return Err(self
@@ -379,10 +410,11 @@ impl GitPack {
 
         let exec: Result<String, RuntimeError> = (|| {
             if let Some(add_argv) = &add_argv {
-                run_git(&canonical_repo, add_argv)?;
+                run_git(program, &canonical_repo, add_argv)?;
             }
-            run_git(&canonical_repo, &commit_argv)?;
+            run_git(program, &canonical_repo, &commit_argv)?;
             let sha = run_git(
+                program,
                 &canonical_repo,
                 &["rev-parse".to_string(), "HEAD".to_string()],
             )?

--- a/crates/khive-pack-git/tests/dev_loop.rs
+++ b/crates/khive-pack-git/tests/dev_loop.rs
@@ -503,6 +503,94 @@ impl Fixture {
 
 #[tokio::test]
 #[serial_test::serial(git_dev_loop_env)]
+async fn amendment12_arm5_program_is_unknown_on_every_repository_verb() {
+    let f = Fixture::new(true, true).await;
+    let manifest = f.tree(&[("a.txt", b"caller program control\n", 644)]).await;
+    let refs = f.git_bytes(&["show-ref"]);
+    let index = std::fs::read(f.repo.join(".git/index")).expect("index before refused calls");
+    let handlers: Vec<_> = f
+        .registry
+        .pack_verbs("git")
+        .expect("registered Git handlers")
+        .iter()
+        .filter(|handler| handler.params.iter().any(|param| param.name == "repo"))
+        .collect();
+    assert!(!handlers.is_empty());
+    for handler in handlers {
+        let verb = handler.name;
+        let cases = match verb {
+            "git.init" => vec![json!({"repo":f.blank,"branch":"main"})],
+            "git.checkout" => vec![json!({"repo":f.repo,"ref":f.base})],
+            "git.diff" => {
+                vec![json!({"repo":f.repo,"input_kind":"commits","base":f.base,"head":f.base})]
+            }
+            "git.branch" => {
+                vec![
+                    json!({"repo":f.repo,"name":"program-control","from":f.base,"expected":f.base}),
+                ]
+            }
+            "git.commit" => vec![
+                f.commit_params(&manifest),
+                json!({"repo":f.repo,"paths":["a.txt"],"message":"legacy program control"}),
+            ],
+            "git.push" => {
+                vec![
+                    json!({"repo":f.repo,"branch":"work","expected_local":f.base,"expected_remote":null}),
+                ]
+            }
+            "git.pr_open" => {
+                vec![
+                    json!({"repo":f.repo,"head":"work","base":"main","title":"Program control","body":"","expected_head":f.base}),
+                ]
+            }
+            "git.pr_review" => {
+                vec![
+                    json!({"repo":f.repo,"number":1,"verdict":"comment","body":"Program control","expected_head":f.base}),
+                ]
+            }
+            "git.pr_merge" => {
+                vec![
+                    json!({"repo":f.repo,"number":1,"method":"squash","subject":"Program control","body":"","expected_head":f.base}),
+                ]
+            }
+            "git.receipts" | "git.gates" | "git.status" | "git.log" => {
+                vec![json!({"repo":f.repo})]
+            }
+            _ => panic!("repository-taking Git verb needs an arm 5 payload: {verb}"),
+        };
+        f.policy(verb, "allow").await;
+        let help = f.registry.describe_verb(verb).expect("Git verb schema");
+        let schema = &help["input_schema"];
+        assert_eq!(schema["additionalProperties"], false, "{verb}");
+        let properties = schema["properties"].as_object().expect("schema properties");
+        assert!(!properties.contains_key("program"), "{verb}");
+        for mut params in cases {
+            for key in params.as_object().expect("object payload").keys() {
+                assert!(
+                    properties.contains_key(key),
+                    "{verb}: undeclared fixture field {key}"
+                );
+            }
+            for required in schema["required"].as_array().expect("required fields") {
+                let required = required.as_str().expect("required field name");
+                assert!(
+                    params.get(required).is_some(),
+                    "{verb}: missing fixture field {required}"
+                );
+            }
+            params["program"] = json!(f.git);
+            let error = f.err(verb, params.clone()).await;
+            assert!(error.contains("invalid_params"), "{verb} {params}: {error}");
+        }
+    }
+    assert_eq!(f.git_bytes(&["show-ref"]), refs);
+    assert_eq!(std::fs::read(f.repo.join(".git/index")).unwrap(), index);
+    assert!(!f.blank.join(".git").exists());
+    assert_eq!(f.resolver_count(), 0);
+}
+
+#[tokio::test]
+#[serial_test::serial(git_dev_loop_env)]
 async fn arm13_existing_branch_refuses_without_repository_changes() {
     let f = Fixture::new(true, false).await;
     f.policy("git.branch", "allow").await;
@@ -1466,7 +1554,7 @@ async fn arm30_tool_pack_absence_refuses_tree_commit_but_preserves_legacy_paths(
     let legacy = f
         .call(
             "git.commit",
-            json!({"repo":f.repo,"paths":["a.txt"],"message":"legacy paths commit"}),
+            json!({"repo":f.repo,"paths":["a.txt"],"message":"legacy paths commit","branch":"work","expected_head":f.base}),
         )
         .await;
     let sha = legacy["sha"].as_str().expect("legacy commit SHA");

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -450,6 +450,9 @@ pub struct GitWriteEntryConfig {
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GitWriteSectionConfig {
+    /// Absolute git executable override; absent preserves PATH resolution.
+    #[serde(default)]
+    pub program: Option<PathBuf>,
     #[serde(default)]
     pub allowed: Vec<GitWriteEntryConfig>,
     #[serde(default)]
@@ -515,6 +518,7 @@ fn default_git_credential_resolver() -> Vec<String> {
 impl Default for GitWriteSectionConfig {
     fn default() -> Self {
         Self {
+            program: None,
             allowed: Vec::new(),
             actors: BTreeMap::new(),
             repositories: BTreeMap::new(),
@@ -526,11 +530,44 @@ impl Default for GitWriteSectionConfig {
 }
 
 impl GitWriteSectionConfig {
+    pub fn git_program(&self) -> &Path {
+        self.program.as_deref().unwrap_or_else(|| Path::new("git"))
+    }
+
     pub fn validate_dev_loop(&self) -> Result<(), ConfigError> {
         let invalid = |key: &str, reason: &str| ConfigError::InvalidGitWriteConfig {
             key: key.to_string(),
             reason: reason.to_string(),
         };
+        if let Some(program) = &self.program {
+            if !program.is_absolute() {
+                return Err(invalid("git_write.program", "must be absolute"));
+            }
+            let metadata = std::fs::metadata(program).map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    invalid("git_write.program", "does not exist")
+                } else {
+                    invalid("git_write.program", &format!("is not executable: {error}"))
+                }
+            })?;
+            #[cfg(unix)]
+            let executable = {
+                use std::os::unix::fs::PermissionsExt;
+                metadata.permissions().mode() & 0o111 != 0
+            };
+            #[cfg(windows)]
+            let executable = program
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| {
+                    extension.eq_ignore_ascii_case("exe") || extension.eq_ignore_ascii_case("com")
+                });
+            #[cfg(not(any(unix, windows)))]
+            let executable = false;
+            if !metadata.is_file() || !executable {
+                return Err(invalid("git_write.program", "is not executable"));
+            }
+        }
         if self.contract_faults && !cfg!(feature = "contract-faults") {
             tracing::error!(
                 target: "khive.boot",
@@ -2886,6 +2923,106 @@ grant_unattributed = false
             .expect("no error")
             .expect("file found");
         assert!(cfg.git_write.allowed.is_empty());
+    }
+
+    fn write_git_program_config(dir: &tempfile::TempDir, program: &Path) -> PathBuf {
+        let program = toml::Value::String(program.to_str().unwrap().to_string());
+        write_toml(dir, &format!("[git_write]\nprogram = {program}\n"))
+    }
+
+    #[test]
+    fn git_program_absent_preserves_path_default() {
+        let dir = tempfile::tempdir().unwrap();
+        for content in ["# no git_write section\n", "[git_write]\n"] {
+            let path = write_toml(&dir, content);
+            let cfg = KhiveConfig::load(Some(&path)).unwrap().unwrap();
+            assert!(cfg.git_write.program.is_none());
+            assert_eq!(cfg.git_write.git_program(), Path::new("git"));
+        }
+        assert!(GitWriteSectionConfig::default().program.is_none());
+        assert_eq!(
+            GitWriteSectionConfig::default().git_program(),
+            Path::new("git")
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn git_program_absolute_executable_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let program = std::env::current_exe().unwrap();
+        let path = write_git_program_config(&dir, &program);
+        let cfg = KhiveConfig::load(Some(&path)).unwrap().unwrap();
+        assert_eq!(cfg.git_write.program.as_deref(), Some(program.as_path()));
+        assert_eq!(cfg.git_write.git_program(), program);
+    }
+
+    #[test]
+    fn git_program_relative_path_is_rejected_at_load() {
+        let dir = tempfile::tempdir().unwrap();
+        for program in ["git", "relative/git"] {
+            let path = write_git_program_config(&dir, Path::new(program));
+            let error = KhiveConfig::load(Some(&path)).expect_err("relative program must fail");
+            assert!(
+                matches!(config_error_root(&error), ConfigError::InvalidGitWriteConfig { key, reason }
+                    if key == "git_write.program" && reason == "must be absolute"),
+                "unexpected error: {error}"
+            );
+            assert!(error.to_string().contains("git_write.program"));
+        }
+    }
+
+    #[test]
+    fn git_program_missing_file_is_rejected_at_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_git_program_config(&dir, &dir.path().join("missing-git"));
+        let error = KhiveConfig::load(Some(&path)).expect_err("missing program must fail");
+        assert!(
+            matches!(config_error_root(&error), ConfigError::InvalidGitWriteConfig { key, reason }
+                if key == "git_write.program" && reason == "does not exist"),
+            "unexpected error: {error}"
+        );
+        assert!(error.to_string().contains("git_write.program"));
+    }
+
+    #[test]
+    fn git_program_nonexecutable_file_is_rejected_at_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let program = dir.path().join("git.txt");
+        std::fs::write(&program, "not executable\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        let path = write_git_program_config(&dir, &program);
+        let error = KhiveConfig::load(Some(&path)).expect_err("nonexecutable program must fail");
+        assert!(
+            matches!(config_error_root(&error), ConfigError::InvalidGitWriteConfig { key, reason }
+                if key == "git_write.program" && reason == "is not executable"),
+            "unexpected error: {error}"
+        );
+        assert!(error.to_string().contains("git_write.program"));
+    }
+
+    #[test]
+    fn git_program_directory_is_rejected_at_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let program = dir.path().join("git.exe");
+        std::fs::create_dir(&program).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let path = write_git_program_config(&dir, &program);
+        let error = KhiveConfig::load(Some(&path)).expect_err("directory program must fail");
+        assert!(
+            matches!(config_error_root(&error), ConfigError::InvalidGitWriteConfig { key, reason }
+                if key == "git_write.program" && reason == "is not executable"),
+            "unexpected error: {error}"
+        );
+        assert!(error.to_string().contains("git_write.program"));
     }
 
     // A well-formed [[git_write.allowed]] entry parses correctly.


### PR DESCRIPTION
## What

Implements ADR-182 Amendment 12: an operator may name the git executable the
write surface runs, as an absolute path under `[git_write] program`. When it is
absent the surface resolves `git` from `PATH` exactly as before.

## Why

The daemon's `PATH` is whatever its launcher gave it, and on one host that
resolved an Apple git without `reflog write` ahead of a Homebrew git that has
it. The push verbs need the capability, and the only knob was the daemon's
environment, which the write surface does not own. A configured program is a
statement about the surface rather than about the process that happens to host
it.

## Change

- `git_write.program` is validated at config load with three distinct refusals:
  not absolute, does not exist, not executable. No `PATH` fallback when it is
  set and wrong; the refusal names the key.
- The program reaches every place the surface spawns git: preparation, local
  read and write commands, the legacy commit path, remote scratch repositories,
  native pushes, the receiver, readback and reconciliation.
- The unsupported-toolchain receipt names the program that was selected.
- The caller-facing verbs reject a caller-supplied program on every repository
  verb (13 verbs, 14 payloads); it is never a request parameter.
- The existing old-toolchain test configures its wrapper through the new field
  instead of mutating the process environment.
- An ignored host test drives four child processes across the two real git
  installations in both `PATH` orders.

## Verification

Five acceptance arms from the amendment plus the startup refusals. Mutation
control stated before running: making the relative-path refusal succeed must
fail exactly `git_program_relative_path_is_rejected_at_load`.
