### PR TITLE
fix(comm): bound probe count and preserve unseen pages

### DIFF
--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -41,8 +41,9 @@ make a filtered call return early with an empty page.
 
 `comm.probe` is a strictly read-only verb built for frequent polling (e.g.
 every 30s by many monitors): it never mutates the `read` flag or writes any
-row. It runs a single indexed query (`INDEXED BY idx_comm_message_to_actor`)
-over inbound messages addressed to the given `actor`.
+row. The page and stale unread count are computed in one SQL statement and
+share a snapshot. Both include only live inbound messages whose recipient
+exactly matches the given `actor` in the caller's namespace.
 
 Args:
 
@@ -54,18 +55,29 @@ Args:
 
 Returns:
 
-- `cursor_us`: an opaque, monotonically increasing token (currently backed
-  by the durable `notes_seq.seq` commit-order sequence), or `0` if no
-  inbound messages exist for the actor.
+- `cursor_us`: an opaque, nondecreasing token backed by the durable
+  `notes_seq.seq` commit-order sequence. It is the maximum sequence among
+  the rows actually returned, floored by the honored caller cursor. An
+  empty page does not advance that cursor; an empty baseline returns `0`.
   Round-trip it as the next call's `since_us`; do not treat it as a
   timestamp or compute elapsed time from it (#780).
-- `new_messages` — up to 100 newest matching rows, each `{id, created_at_us,
-  from_actor, subject?}`, ordered ascending (newest-last) by `created_at`.
+- `new_messages` — the earliest 100 unseen matching rows in commit-sequence
+  order, or all remaining rows if fewer, each `{id, created_at_us, from_actor,
+  subject?}`. The selected page is displayed ascending (newest-last) by
+  `created_at`. Round-tripping the cursor retrieves subsequent pages without
+  skipping messages when a burst exceeds 100 rows.
   `created_at_us` is a real display timestamp, useful for "how long ago did
   this arrive", but it is not the cursor and carries no ordering guarantee
   relative to `cursor_us`.
-- `stale_unread_count` — count of inbound unread messages older than
-  `stale_minutes`.
+- `stale_unread_count` — the stale unread count capped at `1000`: values
+  below `1000` are exact; `1000` means at least 1000. It covers all matching
+  inbound unread messages strictly older than the `stale_minutes` cutoff,
+  independently of the arrival cursor and returned page. Only JSON boolean
+  `true` in `properties.read` marks a message read; missing, null, or other
+  values remain unread.
+- `cursor_reset` — present as `true` only when the supplied cursor exceeds
+  the store's durable global sequence high-water mark and is discarded in
+  favor of a baseline page. It is absent for baseline and honored cursors.
 
 The response shape is frozen: it is a public polling contract and must stay
 minimal and stable. `cursor_us`/`since_us` keep their `_us`-suffixed wire

--- a/crates/khive-pack-comm/docs/api/probe-cursor.md
+++ b/crates/khive-pack-comm/docs/api/probe-cursor.md
@@ -6,10 +6,33 @@ spanning `handlers.rs` and `vocab.rs`.
 
 ## `handlers.rs::PROBE_SQL`
 
-The single indexed read powering `comm.probe` (ADR-D5). `INDEXED BY
-idx_comm_message_to_actor` is a regression fence: if a custom bootstrap skips
-comm schema-plan application, this query fails loudly instead of silently
-degrading to a table scan.
+The page and stale unread count are computed by one SQL statement in the same
+snapshot. Both are scoped to live inbound `message` notes in the caller's
+namespace whose `to_actor` exactly equals the requested actor. Missing or null
+recipients do not enter this probe through the inbox's legacy visibility rules.
+
+Page selection takes the first 100 matching rows with `notes_seq.seq` above
+the honored caller cursor, ordered by sequence ascending. The returned cursor
+is the maximum sequence among those returned rows, floored by the honored
+caller cursor. An empty page does not advance the cursor; an empty baseline
+returns zero. This lets callers drain bursts larger than 100 messages without
+advancing past rows they have not received (#2595). The selected page is then
+ordered by `created_at` ascending for display.
+
+`stale_unread_count` is `min(exact stale unread count, 1000)`: values below
+1000 are exact, and 1000 means at least 1000. It is independent of the arrival
+cursor and page limit. Staleness uses the strict predicate `created_at < cutoff`,
+where the default cutoff is 20 minutes before the probe. A note is unread unless
+`json_type(properties, '$.read')` is `true`; absent, null, and non-boolean values
+remain unread. The count uses the existing partial
+`idx_notes_unread_probe_recipient_direction` index and limits qualifying rows
+before aggregation. This bounds the stale count's work without claiming a bound
+on all page-selection work.
+
+The storage helper `count_notes_filtered_bounded_in_snapshot` is not used here:
+its filter has no before-cutoff predicate, and a separate count invocation would
+not share this statement's snapshot with the returned page. `comm.inbox`'s
+unread-count partitions and contract are unchanged.
 
 `cursor_us`/`since_us` are keyed on `notes_seq.seq`, not SQLite `rowid` and
 not `created_at` (#780, #827):
@@ -50,12 +73,15 @@ as `notes_seq` grows — a fixed ceiling would eventually reset a legitimate
 high sequence value to baseline, contradicting `comm.probe`'s opaque
 round-trip contract.
 
-`query_probe`'s cursor clamp: never let the returned cursor regress below what
-the caller already holds (#827) — if the message that previously held the
-highest `notes_seq.seq` was hard-deleted since the last probe, `MAX(seq)`
-over the remaining rows can be smaller than a cursor already handed out.
-Clamping in Rust, rather than in SQL, keeps the single indexed query a pure
-aggregate with no extra branch.
+An above-high-water cursor is discarded before page selection, and the response
+reports `cursor_reset: true` (#2400). The marker is absent when no cursor was
+supplied or the supplied cursor was honored. The global durable high-water mark
+validates a supplied cursor; it does not advance the page cursor.
+
+`query_probe` retains the caller-cursor floor (#827): deleting a previously
+returned message must not make a later cursor regress. The floor uses the
+honored cursor after any reset. It also preserves the cursor when the next
+page is empty, independently of the maximum sequence in the remaining corpus.
 
 `ProbeParams` is a public polling contract (khive #667 daemon hardening
 slice) — its shape is frozen; see the comm pack README.

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2972,35 +2972,36 @@ pub(crate) struct ProbeMessage {
     pub subject: Option<String>,
 }
 
-/// The single indexed read powering `comm.probe` (ADR-D5). `INDEXED BY
-/// idx_comm_message_to_actor` is a regression fence against silent table scans.
+/// The page and bounded stale count share one SQL snapshot (ADR-D5). The
+/// stale-count index excludes read history and seeks directly below the cutoff.
+/// The shared bounded NoteStore counter cannot express that strict upper bound
+/// or join this statement's snapshot, so this count stays inside the probe.
 /// `cursor_us`/`since_us` are keyed on `notes_seq.seq`, NOT `created_at` or
 /// SQLite `rowid` — both can regress/collide across concurrent writers, VACUUM,
 /// or hard-delete. Do not revert to either. See
 /// crates/khive-pack-comm/docs/api/probe-cursor.md#handlersrsprobe_sql for the full
 /// #780/#827 incident history.
-const PROBE_SQL: &str = "WITH \
+#[doc(hidden)]
+pub const PROBE_SQL: &str = "WITH \
 stats AS ( \
-    SELECT \
-        COALESCE(MAX(notes_seq.seq), 0) AS cursor_us, \
-        COALESCE(SUM( \
-            CASE \
-                WHEN (json_type(notes.properties, '$.read') IS NULL \
-                      OR json_type(notes.properties, '$.read') != 'true') \
-                     AND notes.created_at < ?4 \
-                THEN 1 ELSE 0 \
-            END \
-        ), 0) AS stale_unread_count \
-    FROM notes INDEXED BY idx_comm_message_to_actor \
-    JOIN notes_seq ON notes_seq.note_id = notes.id \
-    WHERE notes.namespace = ?1 \
-      AND notes.kind = 'message' \
-      AND notes.deleted_at IS NULL \
-      AND json_extract(notes.properties, '$.to_actor') = ?2 \
-      AND json_extract(notes.properties, '$.direction') = 'inbound' \
+    SELECT COUNT(*) AS stale_unread_count \
+    FROM ( \
+        SELECT 1 \
+        FROM notes INDEXED BY idx_notes_unread_probe_recipient_direction \
+        WHERE notes.namespace = ?1 \
+          AND notes.kind = 'message' \
+          AND notes.deleted_at IS NULL \
+          AND ifnull(json_extract(notes.properties, '$.to_actor'), '') = ?2 \
+          AND json_extract(notes.properties, '$.direction') = 'inbound' \
+          AND (json_type(notes.properties, '$.read') IS NULL \
+               OR json_type(notes.properties, '$.read') != 'true') \
+          AND notes.created_at < ?4 \
+        LIMIT 1000 \
+    ) AS stale_unread_rows \
 ), \
 new_rows AS ( \
     SELECT \
+        notes_seq.seq AS cursor_us, \
         notes.id, \
         notes.created_at AS created_at_us, \
         COALESCE(json_extract(notes.properties, '$.from_actor'), notes.namespace) AS from_actor, \
@@ -3013,26 +3014,23 @@ new_rows AS ( \
       AND json_extract(notes.properties, '$.to_actor') = ?2 \
       AND json_extract(notes.properties, '$.direction') = 'inbound' \
       AND (?3 IS NULL OR notes_seq.seq > ?3) \
-    ORDER BY notes.created_at DESC \
+    ORDER BY notes_seq.seq ASC \
     LIMIT 100 \
 ) \
 SELECT \
-    stats.cursor_us, \
+    new_rows.cursor_us, \
     stats.stale_unread_count, \
     new_rows.id, \
     new_rows.created_at_us, \
     new_rows.from_actor, \
     new_rows.subject \
 FROM stats \
-LEFT JOIN ( \
-    SELECT * FROM new_rows ORDER BY created_at_us ASC \
-) AS new_rows ON TRUE \
-ORDER BY new_rows.created_at_us ASC";
+LEFT JOIN new_rows ON TRUE \
+ORDER BY new_rows.created_at_us ASC, new_rows.cursor_us ASC";
 
 /// `probe` — strictly read-only poll for new inbound message metadata and a
-/// stale-unread count (ADR-D5). No read-flag mutation, no writes: this is
-/// polled every ~30s by many monitors and must stay a single cheap indexed
-/// query.
+/// stale-unread count capped at 1000 (ADR-D5). No read-flag mutation, no writes:
+/// the earliest unseen sequence page and stale count share one indexed statement.
 pub(crate) async fn handle_probe(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -3135,18 +3133,19 @@ async fn query_probe(
         .await
         .map_err(RuntimeError::Storage)?;
 
-    let mut cursor_us = 0i64;
+    let mut cursor_us = effective_since.unwrap_or(0);
     let mut stale_unread_count = 0i64;
     let mut new_messages = Vec::new();
 
     for row in &rows {
-        if let Some(SqlValue::Integer(v)) = row.get("cursor_us") {
-            cursor_us = *v;
-        }
         if let Some(SqlValue::Integer(v)) = row.get("stale_unread_count") {
             stale_unread_count = *v;
         }
 
+        let message_cursor = match row.get("cursor_us") {
+            Some(SqlValue::Integer(v)) => *v,
+            _ => continue,
+        };
         let id = match row.get("id") {
             Some(SqlValue::Text(s)) => s.clone(),
             _ => continue,
@@ -3170,10 +3169,13 @@ async fn query_probe(
             from_actor,
             subject,
         });
+        // The displayed page is timestamp-ordered, not sequence-ordered. Only
+        // emitted rows advance the cursor; unseen later pages must remain visible.
+        cursor_us = cursor_us.max(message_cursor);
     }
 
     // #827: never let the returned cursor regress below what the caller already
-    // holds (a hard-deleted high-seq row can lower MAX(seq) below a prior cursor).
+    // holds, including an empty page after a high-sequence row was hard-deleted.
     if let Some(floor) = effective_since {
         if cursor_us < floor {
             cursor_us = floor;

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -604,6 +604,15 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
     HandlerDef {
         name: "comm.probe",
         description: "Read-only poll for new inbound message metadata and stale unread count. \
+                      Selects the earliest 100 unseen messages by commit sequence, then displays \
+                      that page by created_at ascending. cursor_us advances only through rows \
+                      actually returned and never below the honored caller cursor; an empty page \
+                      does not advance it. Round-trip the cursor to drain larger bursts. The page \
+                      and count share one SQL statement's snapshot, scoped to live inbound messages \
+                      with the exact actor and namespace. stale_unread_count is capped at 1000: \
+                      smaller values are exact, and 1000 means at least 1000. It counts unread rows \
+                      strictly older than the cutoff independently of the arrival cursor. Only \
+                      JSON boolean true in properties.read marks a message read. \
                       Unlike comm.inbox, the actor is not inferred from the caller — pass it \
                       explicitly via the required `actor` param (khive #93). A `since_us` the \
                       store cannot have issued is discarded and the page comes from the \

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -2,12 +2,13 @@
 //! the daemon hardening slice (ADR-D5).
 //!
 //! INLINE TEST JUSTIFICATION: separate from `tests/integration.rs` because
-//! every test here needs `idx_comm_message_to_actor` actually created via
+//! every test here needs the comm probe indexes actually created via
 //! `VerbRegistry::apply_schema_plans` (the probe SQL uses `INDEXED BY`, which
 //! errors loudly if the index is absent) — `integration.rs`'s shared
 //! `build_registry()` fixture intentionally does not apply schema plans, and
 //! changing it would be a behavior change for unrelated tests in that file.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use khive_pack_comm::CommPack;
@@ -16,12 +17,12 @@ use khive_runtime::{
     VerbRegistryBuilder,
 };
 use khive_storage::note::Note;
-use khive_storage::types::DeleteMode;
-use serde_json::json;
+use khive_storage::types::{DeleteMode, SqlStatement, SqlValue};
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 /// Build a registry with the comm pack's auxiliary schema plan actually
-/// applied, so `idx_comm_message_to_actor` exists for `INDEXED BY` to find.
+/// applied, so the probe's history and partial unread indexes exist.
 fn build_registry() -> (VerbRegistry, KhiveRuntime) {
     let runtime = KhiveRuntime::memory().expect("in-memory runtime");
     let mut builder = VerbRegistryBuilder::new();
@@ -151,6 +152,23 @@ async fn probe_empty_inbox_returns_zeroed_response() {
     assert_eq!(result["cursor_us"], json!(0));
     assert_eq!(result["new_messages"], json!([]));
     assert_eq!(result["stale_unread_count"], json!(0));
+}
+
+#[tokio::test]
+async fn probe_empty_page_preserves_a_negative_caller_cursor() {
+    let (registry, _rt) = build_registry();
+    for cursor in [-1_i64, -100] {
+        let result = registry
+            .dispatch(
+                "comm.probe",
+                json!({"actor": "lambda:nobody", "since_us": cursor}),
+            )
+            .await
+            .expect("negative cursor is accepted");
+        assert_eq!(result["new_messages"], json!([]));
+        assert_eq!(result["cursor_us"], json!(cursor));
+        assert_eq!(result["stale_unread_count"], json!(0));
+    }
 }
 
 #[tokio::test]
@@ -285,12 +303,12 @@ async fn probe_new_messages_ordered_newest_last() {
 }
 
 #[tokio::test]
-async fn probe_caps_new_messages_at_100_newest() {
+async fn probe_caps_new_messages_at_100_earliest_unseen_sequences() {
     let (registry, rt) = build_registry();
     let actor = "lambda:leo";
 
-    // Plant 105 rows; the oldest 5 must be dropped by the LIMIT 100, and the
-    // 100 kept must still come back ascending (oldest-of-the-kept first).
+    // The first page selects the earliest unseen sequences, leaving the final
+    // five for the next page instead of skipping them behind its cursor.
     let base = 1_000_000_i64;
     for i in 0..105 {
         plant_inbound_message(&rt, actor, "a", base + i * 1_000, None, false).await;
@@ -308,14 +326,135 @@ async fn probe_caps_new_messages_at_100_newest() {
         .iter()
         .map(|m| m["created_at_us"].as_i64().unwrap())
         .collect();
-    let expected_first = base + 5 * 1_000; // the 5 oldest rows were dropped
-    let expected_last = base + 104 * 1_000;
+    let expected_first = base;
+    let expected_last = base + 99 * 1_000;
     assert_eq!(timestamps.first().copied(), Some(expected_first));
     assert_eq!(timestamps.last().copied(), Some(expected_last));
     assert!(
         timestamps.windows(2).all(|w| w[0] < w[1]),
         "kept messages must be strictly ascending: {timestamps:?}"
     );
+}
+
+async fn stored_note_sequences(rt: &KhiveRuntime) -> HashMap<String, i64> {
+    let access = rt.sql();
+    let mut reader = access.reader().await.expect("reader");
+    reader
+        .query_all(SqlStatement {
+            sql: "SELECT note_id, seq FROM notes_seq".into(),
+            params: Vec::new(),
+            label: None,
+        })
+        .await
+        .expect("read durable note sequences")
+        .into_iter()
+        .map(|row| match (row.get("note_id"), row.get("seq")) {
+            (Some(SqlValue::Text(id)), Some(SqlValue::Integer(seq))) => (id.clone(), *seq),
+            other => panic!("invalid note sequence row: {other:?}"),
+        })
+        .collect()
+}
+
+fn probe_message_ids(response: &Value) -> HashSet<String> {
+    response["new_messages"]
+        .as_array()
+        .expect("message array")
+        .iter()
+        .map(|message| message["id"].as_str().expect("message id").to_owned())
+        .collect()
+}
+
+#[tokio::test]
+async fn probe_burst_150_drains_as_100_then_50_without_cursor_skips() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:burst";
+    let mut planted = Vec::new();
+    for index in 0..150 {
+        // Reverse timestamps make sequence selection observably different
+        // from presentation order and from selecting the oldest timestamps.
+        planted.push(
+            plant_inbound_message(
+                &rt,
+                actor,
+                "sender",
+                1_000_000 + (150 - index) * 1_000,
+                None,
+                false,
+            )
+            .await
+            .to_string(),
+        );
+    }
+    let sequences = stored_note_sequences(&rt).await;
+    let population_max = planted.iter().map(|id| sequences[id]).max().unwrap();
+    let first = registry
+        .dispatch("comm.probe", json!({"actor": actor}))
+        .await
+        .expect("first burst page");
+    let first_cursor = first["cursor_us"].as_i64().expect("first cursor");
+    let second = registry
+        .dispatch(
+            "comm.probe",
+            json!({"actor": actor, "since_us": first_cursor}),
+        )
+        .await
+        .expect("second burst page");
+    let second_cursor = second["cursor_us"].as_i64().expect("second cursor");
+    // Capture both pages before checking the cursor. The population-MAX
+    // regression must report its decisive 100/0 witness, not stop earlier.
+    let page_counts = (
+        first["new_messages"].as_array().unwrap().len(),
+        second["new_messages"].as_array().unwrap().len(),
+    );
+    assert_eq!(
+        page_counts, (100, 50),
+        "burst page counts were {page_counts:?}; first_cursor={first_cursor}, population_max={population_max}"
+    );
+    let first_ids = probe_message_ids(&first);
+    let second_ids = probe_message_ids(&second);
+    assert_eq!(
+        first_ids,
+        planted[..100].iter().cloned().collect::<HashSet<_>>()
+    );
+    assert_eq!(
+        second_ids,
+        planted[100..].iter().cloned().collect::<HashSet<_>>()
+    );
+    assert!(first_ids.is_disjoint(&second_ids));
+    assert_eq!(
+        first_ids
+            .union(&second_ids)
+            .cloned()
+            .collect::<HashSet<_>>(),
+        planted.iter().cloned().collect::<HashSet<_>>()
+    );
+    assert_eq!(
+        first_cursor,
+        first_ids.iter().map(|id| sequences[id]).max().unwrap()
+    );
+    assert!(
+        first_cursor < population_max,
+        "the first cursor must not consume unreturned rows"
+    );
+    assert_eq!(second_cursor, population_max);
+    for page in [&first, &second] {
+        let times: Vec<_> = page["new_messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|message| message["created_at_us"].as_i64().unwrap())
+            .collect();
+        assert!(times.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+    let third = registry
+        .dispatch(
+            "comm.probe",
+            json!({"actor": actor, "since_us": second_cursor}),
+        )
+        .await
+        .expect("empty third burst page");
+    assert_eq!(third["new_messages"], json!([]));
+    assert_eq!(third["cursor_us"], json!(second_cursor));
 }
 
 #[tokio::test]
@@ -341,6 +480,201 @@ async fn probe_stale_unread_count_uses_default_20_minutes() {
         result["stale_unread_count"],
         json!(1),
         "only the old+unread message counts as stale: {result}"
+    );
+}
+
+fn probe_note(namespace: &str, created_at: i64, properties: Value) -> Note {
+    Note {
+        version: 1,
+        key: None,
+        id: Uuid::new_v4(),
+        namespace: namespace.into(),
+        kind: "message".into(),
+        status: "active".into(),
+        name: None,
+        content: "bounded probe fixture".into(),
+        salience: None,
+        decay_factor: None,
+        expires_at: None,
+        properties: Some(properties),
+        created_at,
+        updated_at: created_at,
+        deleted_at: None,
+    }
+}
+
+#[tokio::test]
+async fn probe_stale_count_saturates_at_1000_even_after_the_page_cursor() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:capped-stale";
+    let stale_time = chrono::Utc::now().timestamp_micros() - 60 * 60_000_000;
+    let token = rt.authorize(Namespace::local()).expect("local token");
+    let store = rt.notes(&token).expect("notes store");
+    let summary = store
+        .upsert_notes((0..1001).map(|_| probe_note("local", stale_time, json!({
+            "to_actor": actor, "from_actor": "sender", "direction": "inbound", "read": false,
+        }))).collect())
+        .await
+        .expect("seed more than the stale count cap");
+    assert_eq!(summary.affected, 1001, "{summary:?}");
+    assert_eq!(summary.failed, 0, "{summary:?}");
+    let population_max = stored_note_sequences(&rt)
+        .await
+        .into_values()
+        .max()
+        .unwrap();
+    let first = registry
+        .dispatch("comm.probe", json!({"actor": actor}))
+        .await
+        .expect("first capped stale page");
+    let exhausted = registry
+        .dispatch(
+            "comm.probe",
+            json!({"actor": actor, "since_us": population_max}),
+        )
+        .await
+        .expect("cursor beyond all stale rows");
+    assert_eq!(first["new_messages"].as_array().unwrap().len(), 100);
+    assert_eq!(exhausted["new_messages"], json!([]));
+    for response in [&first, &exhausted] {
+        assert_eq!(response["stale_unread_count"], json!(1000), "{response}");
+    }
+    assert_eq!(exhausted["cursor_us"], json!(population_max));
+}
+
+#[tokio::test]
+async fn probe_stale_count_is_independent_of_page_and_preserves_unread_eligibility() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:stale-controls";
+    let now = chrono::Utc::now().timestamp_micros();
+    let fresh_time = now + 60 * 60_000_000;
+    let stale_time = now - 60 * 60_000_000;
+    let token = rt.authorize(Namespace::local()).expect("local token");
+    let store = rt.notes(&token).expect("notes store");
+    let summary = store
+        .upsert_notes((0..120).map(|_| probe_note("local", fresh_time, json!({
+            "to_actor": actor, "from_actor": "sender", "direction": "inbound", "read": false,
+        }))).collect())
+        .await
+        .expect("seed fresh first page");
+    assert_eq!(summary.affected, 120, "{summary:?}");
+    assert_eq!(summary.failed, 0, "{summary:?}");
+    for read in [
+        None,
+        Some(Value::Null),
+        Some(json!(1)),
+        Some(json!("true")),
+        Some(json!(false)),
+    ] {
+        let mut properties =
+            json!({"to_actor": actor, "from_actor": "sender", "direction": "inbound"});
+        if let Some(read) = read {
+            properties["read"] = read;
+        }
+        store
+            .upsert_note(probe_note("local", stale_time, properties))
+            .await
+            .expect("seed non-true unread flag");
+    }
+    plant_inbound_message(&rt, actor, "sender", stale_time, None, true).await;
+    plant_inbound_message(
+        &rt,
+        "lambda:someone-else",
+        "sender",
+        stale_time,
+        None,
+        false,
+    )
+    .await;
+    plant_inbound_message_in_namespace(&rt, "tenant-b", actor, "sender", stale_time, None, false)
+        .await;
+    store
+        .upsert_note(probe_note(
+            "local",
+            stale_time,
+            json!({
+                "to_actor": actor, "from_actor": "sender", "direction": "outbound", "read": false,
+            }),
+        ))
+        .await
+        .expect("seed outbound control");
+    let deleted = plant_inbound_message(&rt, actor, "sender", stale_time, None, false).await;
+    assert!(store
+        .delete_note(deleted, DeleteMode::Soft)
+        .await
+        .expect("soft-delete control"));
+
+    let sequences = stored_note_sequences(&rt).await;
+    let first = registry
+        .dispatch("comm.probe", json!({"actor": actor}))
+        .await
+        .expect("fresh page");
+    // Cursor correctness has its own burst regression; use stored page
+    // boundaries here so a bad response cursor cannot hide count assertions.
+    let first_boundary = probe_message_ids(&first)
+        .iter()
+        .map(|id| sequences[id])
+        .max()
+        .expect("fresh page has rows");
+    let second = registry
+        .dispatch(
+            "comm.probe",
+            json!({"actor": actor, "since_us": first_boundary}),
+        )
+        .await
+        .expect("stale page");
+    let second_boundary = probe_message_ids(&second)
+        .iter()
+        .map(|id| sequences[id])
+        .max()
+        .expect("stale page has rows");
+    let third = registry
+        .dispatch(
+            "comm.probe",
+            json!({"actor": actor, "since_us": second_boundary}),
+        )
+        .await
+        .expect("empty page");
+    assert_eq!(first["new_messages"].as_array().unwrap().len(), 100);
+    assert!(first["new_messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|message| message["created_at_us"] == json!(fresh_time)));
+    assert_eq!(second["new_messages"].as_array().unwrap().len(), 26);
+    assert_eq!(third["new_messages"], json!([]));
+    for response in [&first, &second, &third] {
+        assert_eq!(response["stale_unread_count"], json!(5), "count must ignore page/cursor and reject fresh, read, outbound, foreign and deleted controls: {response}");
+    }
+}
+
+#[tokio::test]
+async fn probe_production_sql_stale_cutoff_is_strict() {
+    let (_registry, rt) = build_registry();
+    let actor = "lambda:cutoff";
+    for created_at in [999, 1000, 1001] {
+        plant_inbound_message(&rt, actor, "sender", created_at, None, false).await;
+    }
+    let access = rt.sql();
+    let mut reader = access.reader().await.expect("reader");
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: khive_pack_comm::handlers::PROBE_SQL.into(),
+            params: vec![
+                SqlValue::Text("local".into()),
+                SqlValue::Text(actor.into()),
+                SqlValue::Null,
+                SqlValue::Integer(1000),
+            ],
+            label: None,
+        })
+        .await
+        .expect("production SQL with exact cutoff");
+    assert_eq!(rows.len(), 3);
+    assert!(
+        rows.iter()
+            .all(|row| matches!(row.get("stale_unread_count"), Some(SqlValue::Integer(1)))),
+        "only the row strictly before the cutoff is stale: {rows:?}"
     );
 }
 
@@ -598,39 +932,76 @@ async fn probe_rejects_unknown_fields() {
 }
 
 #[tokio::test]
-async fn probe_query_plan_uses_the_to_actor_index() {
+async fn probe_production_sql_stale_count_plan_uses_partial_index_and_cutoff() {
     let (_registry, rt) = build_registry();
 
     let sql = rt.sql();
     let mut reader = sql.reader().await.expect("reader");
     let plan = reader
-        .explain(khive_storage::types::SqlStatement {
-            sql: "SELECT id FROM notes INDEXED BY idx_comm_message_to_actor \
-                  WHERE namespace = ?1 AND kind = 'message' AND deleted_at IS NULL \
-                  AND json_extract(properties, '$.to_actor') = ?2 \
-                  AND json_extract(properties, '$.direction') = 'inbound'"
-                .to_string(),
+        .explain(SqlStatement {
+            sql: khive_pack_comm::handlers::PROBE_SQL.into(),
             params: vec![
-                khive_storage::types::SqlValue::Text("local".into()),
-                khive_storage::types::SqlValue::Text("lambda:leo".into()),
+                SqlValue::Text("local".into()),
+                SqlValue::Text("lambda:leo".into()),
+                SqlValue::Null,
+                SqlValue::Integer(1_000_000),
             ],
             label: Some("comm_probe_plan_check".into()),
         })
         .await
         .expect("EXPLAIN QUERY PLAN succeeds when the index exists");
 
-    let plan_text: String = plan
+    let nodes: Vec<_> = plan
         .iter()
-        .flat_map(|row| row.columns.iter())
-        .filter_map(|c| match &c.value {
-            khive_storage::types::SqlValue::Text(s) => Some(s.clone()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
+        .map(
+            |row| match (row.get("id"), row.get("parent"), row.get("detail")) {
+                (
+                    Some(SqlValue::Integer(id)),
+                    Some(SqlValue::Integer(parent)),
+                    Some(SqlValue::Text(detail)),
+                ) => (*id, *parent, detail.as_str()),
+                other => panic!("invalid EXPLAIN QUERY PLAN row: {other:?}"),
+            },
+        )
+        .collect();
+    let stats_id = nodes
+        .iter()
+        .find(|(_, _, detail)| matches!(*detail, "CO-ROUTINE stats" | "MATERIALIZE stats"))
+        .map(|(id, _, _)| *id)
+        .unwrap_or_else(|| panic!("production stale-count subtree is missing: {nodes:?}"));
+
+    // The page legitimately joins notes_seq; only the independent count subtree
+    // must avoid the full message-history index and sequence join.
+    let mut stats_ids = HashSet::from([stats_id]);
+    loop {
+        let previous_len = stats_ids.len();
+        for (id, parent, _) in &nodes {
+            if stats_ids.contains(parent) {
+                stats_ids.insert(*id);
+            }
+        }
+        if stats_ids.len() == previous_len {
+            break;
+        }
+    }
+    let stats_details: Vec<_> = nodes
+        .iter()
+        .filter(|(id, _, _)| stats_ids.contains(id))
+        .map(|(_, _, detail)| *detail)
+        .collect();
     assert!(
-        plan_text.contains("idx_comm_message_to_actor"),
-        "query plan must use idx_comm_message_to_actor: {plan_text}"
+        stats_details.iter().any(|detail| {
+            detail.starts_with("SEARCH ")
+                && detail.contains("idx_notes_unread_probe_recipient_direction")
+                && detail.contains("created_at<?")
+        }),
+        "stale count must seek the partial index with its strict cutoff: {nodes:?}"
+    );
+    assert!(
+        stats_details.iter().all(|detail| {
+            !detail.contains("idx_comm_message_to_actor") && !detail.contains("notes_seq")
+        }),
+        "stale count must not join sequence rows or scan full message history: {nodes:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

`comm.probe` now pages a burst and bounds its stale count.

- `new_messages` is the earliest 100 unseen matching rows in commit-sequence order (all remaining rows if fewer), displayed ascending by `created_at`. `cursor_us` is the maximum sequence among the rows actually returned, floored by the honored caller cursor, so a caller drains a burst larger than 100 messages by round-tripping the cursor without skipping rows. An empty page does not advance the cursor.
- `stale_unread_count` is `min(exact stale unread count, 1000)`: values below 1000 are exact, 1000 means at least 1000. It is independent of the arrival cursor and the returned page, uses the strict `created_at < cutoff` predicate, and counts through the existing partial unread-probe index with a row limit before aggregation.
- The page and the count still come from one SQL statement in one snapshot; `cursor_reset` semantics and the caller-cursor floor are unchanged. No schema, index, or `comm.inbox` change.

## Tests

- A 150-message burst drains as a page of 100 then 50 with no cursor skips.
- The stale count saturates at 1000 and stays independent of the page cursor and unread eligibility.
- An empty page preserves a negative caller cursor.
- The production SQL is exercised directly: the cutoff is strict, and `EXPLAIN QUERY PLAN` shows the count using the partial index with the cutoff and no sequence join.

## Docs

The comm pack README and the probe-cursor API note describe the paging contract and the count cap.
