### PR TITLE
feat(runtime): publish a derived input_schema for every served verb

### DIFF
--- a/crates/khive-runtime/src/input_schema.rs
+++ b/crates/khive-runtime/src/input_schema.rs
@@ -1,0 +1,123 @@
+//! Derive a JSON Schema for a verb's parameters from its own [`ParamDef`] list.
+//!
+//! `help` publishes `params[].type` as a documentation string. Every machine
+//! bridge parses it as a JSON Schema type, and most of the spellings in use are
+//! not schema types: `bool` and `boolean` appear in the same verb, `array of
+//! string` and `array<string>` are one type spelled two ways, and `uuid` and
+//! `object or array of object` are not types at all. A driver that cannot read
+//! a verb's parameter types cannot call it, and only the git pack publishes a
+//! hand-authored `input_schema` to read instead.
+//!
+//! This module closes that by deriving a schema from the declarations the
+//! runtime already holds. A pack-supplied `input_schema` still wins, so the
+//! hand-authored ones are untouched; every other verb gains a derived one.
+//! `params[].type` is left exactly as it is: it is documentation, and `uuid`
+//! carries information a bare schema type does not.
+
+use serde_json::{json, Value};
+
+use khive_types::ParamDef;
+
+/// Parameters every verb accepts without declaring them, and which therefore
+/// must not be rejected by a derived schema.
+///
+/// `help` short-circuits any dispatch to the verb's own description, and
+/// `namespace` is resolved for every verb by the dispatch path whether or not
+/// the verb lists it. A schema stricter than the dispatcher turns a working
+/// call into a driver-side refusal, which is the same defect this module exists
+/// to fix pointed the other way, so `additionalProperties` stays open and these
+/// two are declared rather than merely tolerated.
+const UNIVERSAL_PARAMS: &[(&str, &str, &str)] = &[
+    (
+        "help",
+        "boolean",
+        "Return this verb's description instead of dispatching it. No side effects.",
+    ),
+    (
+        "namespace",
+        "string",
+        "Attribution namespace for this call. Defaults to the caller's resolved namespace.",
+    ),
+];
+
+/// Map one declared `param_type` spelling onto a JSON Schema fragment.
+///
+/// Total over the spellings in use, and deliberately without a wildcard arm: an
+/// unknown spelling returns `None` so the registry-wide test can name it and
+/// fail. A default arm here would silently give every future spelling whatever
+/// the fallback happened to be, which recreates the defect one verb at a time.
+pub fn json_schema_type(param_type: &str) -> Option<Value> {
+    let schema = match param_type {
+        "string" => json!({"type": "string"}),
+        "integer" => json!({"type": "integer"}),
+        "number" | "float" => json!({"type": "number"}),
+        "boolean" | "bool" => json!({"type": "boolean"}),
+        "object" => json!({"type": "object"}),
+        "array" => json!({"type": "array"}),
+        "uuid" => json!({"type": "string", "format": "uuid"}),
+        "array of string" | "array<string>" => {
+            json!({"type": "array", "items": {"type": "string"}})
+        }
+        "array of object" | "array<object>" => {
+            json!({"type": "array", "items": {"type": "object"}})
+        }
+        "array of uuid" => {
+            json!({"type": "array", "items": {"type": "string", "format": "uuid"}})
+        }
+        "object or array of object" => json!({
+            "oneOf": [{"type": "object"}, {"type": "array", "items": {"type": "object"}}]
+        }),
+        "string | array<string>" => json!({
+            "oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}]
+        }),
+        "string|null" => json!({"type": ["string", "null"]}),
+        // A parameter documented as accepting any JSON. The empty schema says
+        // exactly that, rather than picking one type and being wrong.
+        "JSON value" => json!({}),
+        _ => return None,
+    };
+    Some(schema)
+}
+
+/// Build the `input_schema` object for one verb's parameter list.
+///
+/// Returns `None` when any declared spelling has no mapping, so a verb is never
+/// published with a schema that quietly omits one of its parameters. A partial
+/// schema is worse than none: a driver would read it as complete.
+pub fn derive_input_schema(params: &[ParamDef], described: &[(String, String)]) -> Option<Value> {
+    let mut properties = serde_json::Map::new();
+    let mut required: Vec<Value> = Vec::new();
+
+    for (index, param) in params.iter().enumerate() {
+        let mut schema = json_schema_type(param.param_type)?;
+        let description = described
+            .get(index)
+            .map(|(_, d)| d.clone())
+            .unwrap_or_else(|| param.description.to_string());
+        if let Value::Object(ref mut map) = schema {
+            map.insert("description".to_string(), json!(description));
+        }
+        properties.insert(param.name.to_string(), schema);
+        if param.required {
+            required.push(json!(param.name));
+        }
+    }
+
+    for (name, spelling, description) in UNIVERSAL_PARAMS {
+        if properties.contains_key(*name) {
+            continue;
+        }
+        let mut schema = json_schema_type(spelling)?;
+        if let Value::Object(ref mut map) = schema {
+            map.insert("description".to_string(), json!(description));
+        }
+        properties.insert((*name).to_string(), schema);
+    }
+
+    Some(json!({
+        "type": "object",
+        "properties": Value::Object(properties),
+        "required": Value::Array(required),
+        "additionalProperties": true,
+    }))
+}

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -24,6 +24,7 @@ mod event_store_guard;
 pub mod events_split;
 pub mod fusion;
 pub mod graph_traversal;
+pub mod input_schema;
 pub mod keyed_memory;
 #[cfg(test)]
 mod keyed_memory_tests;

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1930,8 +1930,27 @@ impl VerbRegistry {
                         "params": params_arr,
                         "identifier_resolution": identifier_resolution_help(),
                     });
+                    // A pack that authored its own schema keeps it; every other
+                    // verb gets one derived from the declarations the runtime
+                    // already holds, so a bridged model has a schema to read
+                    // instead of parsing the prose `params[].type`.
                     if let Some(schema) = pack.input_schema(verb) {
                         envelope["input_schema"] = schema;
+                    } else {
+                        let described: Vec<(String, String)> = params_arr
+                            .iter()
+                            .map(|p| {
+                                (
+                                    p["name"].as_str().unwrap_or_default().to_string(),
+                                    p["description"].as_str().unwrap_or_default().to_string(),
+                                )
+                            })
+                            .collect();
+                        if let Some(schema) =
+                            crate::input_schema::derive_input_schema(handler.params, &described)
+                        {
+                            envelope["input_schema"] = schema;
+                        }
                     }
                     if verb == "link" {
                         envelope["endpoint_rules"] = Value::Array(edge_endpoint_table(&self.packs));

--- a/crates/kkernel/src/pack_introspect.rs
+++ b/crates/kkernel/src/pack_introspect.rs
@@ -155,6 +155,115 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    /// Every MCP-callable verb must publish a real `input_schema`.
+    ///
+    /// `params[].type` is a documentation string in eighteen spellings, most of
+    /// which are not JSON Schema types, so a bridged model has nothing it can
+    /// parse unless a schema is published beside it. Before the derivation only
+    /// the git pack published one.
+    #[test]
+    #[serial]
+    fn every_callable_verb_publishes_an_input_schema() {
+        let (registry, _runtime) = build_registry().expect("introspection registry");
+        // `all_verbs_with_names` pairs each handler with its PACK's name, so
+        // the verb name comes off the handler itself.
+        let callable: Vec<&str> = registry
+            .all_verbs()
+            .into_iter()
+            .filter(|h| !matches!(h.visibility, khive_types::Visibility::Subhandler))
+            .map(|h| h.name)
+            .collect();
+        assert!(
+            !callable.is_empty(),
+            "no callable verbs found: the registry is empty and this test would \
+             otherwise pass by having nothing to check"
+        );
+
+        let mut missing = Vec::new();
+        for verb in &callable {
+            let help = registry.describe_verb(verb).expect("describe_verb");
+            if help["input_schema"]["type"] != serde_json::json!("object") {
+                missing.push(*verb);
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "{} of {} callable verbs publish no object input_schema: {:?}",
+            missing.len(),
+            callable.len(),
+            missing
+        );
+    }
+
+    /// The spelling map is total over what the tree actually declares.
+    ///
+    /// This is the arm that fires the day someone adds a nineteenth spelling.
+    /// The map has no wildcard arm on purpose: a default would silently give a
+    /// new spelling whatever the fallback happened to be, which rebuilds the
+    /// defect one verb at a time instead of all at once.
+    #[test]
+    #[serial]
+    fn every_declared_param_spelling_maps_to_a_schema_type() {
+        let (registry, _runtime) = build_registry().expect("introspection registry");
+        let mut declared = 0usize;
+        let mut unmapped: Vec<String> = Vec::new();
+        for handler in registry.all_verbs() {
+            for param in handler.params {
+                declared += 1;
+                if khive_runtime::input_schema::json_schema_type(param.param_type).is_none() {
+                    unmapped.push(format!(
+                        "{}.{} = {:?}",
+                        handler.name, param.name, param.param_type
+                    ));
+                }
+            }
+        }
+        assert!(
+            declared > 0,
+            "no parameters were declared anywhere: the walk found nothing and \
+             an empty population cannot certify a total map"
+        );
+        assert!(
+            unmapped.is_empty(),
+            "{} declared parameters have no schema mapping (of {declared}): {unmapped:?}",
+            unmapped.len()
+        );
+    }
+
+    /// A derived schema must not reject a call the dispatcher accepts.
+    ///
+    /// `help` is accepted on every verb and `namespace` is resolved for every
+    /// verb whether or not it is declared, so a derived schema that closed
+    /// `additionalProperties` would turn working calls into driver-side
+    /// refusals. The git pack's hand-authored schemas DO close it, correctly,
+    /// because they enumerate their own surface; that contrast is the control
+    /// here, and it also proves a pack-supplied schema still wins.
+    #[test]
+    #[serial]
+    fn derived_schemas_stay_open_while_authored_ones_keep_their_own_shape() {
+        let (registry, _runtime) = build_registry().expect("introspection registry");
+
+        let authored = registry.describe_verb("git.push").expect("git.push help");
+        assert_eq!(
+            authored["input_schema"]["additionalProperties"],
+            serde_json::json!(false),
+            "the git pack's hand-authored schema must be published unchanged"
+        );
+
+        let derived = registry.describe_verb("get").expect("get help");
+        assert_eq!(
+            derived["input_schema"]["additionalProperties"],
+            serde_json::json!(true),
+            "a derived schema must stay open: it describes the declarations, not \
+             the full set of arguments dispatch accepts"
+        );
+        assert_eq!(
+            derived["input_schema"]["properties"]["help"]["type"],
+            serde_json::json!("boolean"),
+            "every derived schema declares help, which every verb accepts"
+        );
+    }
+
     /// Regression: introspection registry construction MUST succeed under
     /// `KHIVE_REQUIRE_ATTRIBUTED_ACTOR=1` with the `comm` pack registered and
     /// no actor identity configured. `build_registry` is exempt from the


### PR DESCRIPTION
## The defect

`help` publishes `params[].type` as a human-readable type description. Every
machine bridge parses it as a JSON Schema type, and most of the spellings in use
are not schema types.

Census over all served verbs: eighteen distinct spellings, seven of which are
JSON Schema type names and eleven of which are not. `bool` and `boolean` appear
inside the same verb, `create` declaring `embed`, `atomic` and `verbose` as
`bool` while neighbouring parameters read `boolean`. `array of string` and
`array<string>` are one type spelled two ways, as are `array of object` and
`array<object>`. `float` appears once where `number` appears twenty-two times.
`uuid` and `object or array of object` are not types at all.

The consequence is that 46 of the 121 parameter-publishing verbs cannot be
exposed by a model-facing driver, and they are the core surface: `create`,
`get`, `link`, `delete`, `context`, the whole of `comm`, most of `knowledge`,
and the task and git write verbs. Direct callers are unaffected, which is why
this stayed invisible: the examples work and only a bridged model fails.

The escape hatch was missing too. `help` can publish a real `input_schema`, and
only 16 of 129 verbs did: exactly the git pack, which hand-authored its own.

## The change

The schema is derived from the `ParamDef` list the runtime already holds, and
attached in `describe_verb` at the seam that already existed, as a fallback. A
pack that supplies its own `input_schema` still wins, so the hand-authored ones
are published byte-unchanged.

`params[].type` is deliberately untouched. It is documentation, and `uuid`
carries information a bare schema type does not.

Two properties are load-bearing rather than incidental:

**The spelling map is total, with no wildcard arm.** An unmapped spelling makes
the verb publish no schema at all rather than one that quietly omits a
parameter, because a partial schema is worse than none: a driver reads it as
complete. A registry-wide test walks every declared parameter and fails naming
the verb and the spelling, so a nineteenth spelling is caught when it is added
rather than when a driver breaks.

**Derived schemas keep `additionalProperties` open** and declare `help` and
`namespace`, which every verb accepts without listing them. A derived schema
stricter than the dispatcher would turn a working call into a driver-side
refusal, which is this same defect pointed the other way.

## Tests

Three registry-wide arms over a full pack registry:

1. Every callable verb publishes an `input_schema` of type `object`, with the
   population asserted non-empty so an empty registry cannot pass as clean.
2. Every declared parameter spelling maps, with the count of parameters walked
   asserted non-zero for the same reason.
3. Derived schemas are open and declare `help`, while the git pack's authored
   schema still publishes `additionalProperties: false`. That contrast is the
   control: it distinguishes derived from authored in one test.

Two mutations, expected reds stated before running and matched exactly:

- Derivation returns `None`: arms 1 and 3 fail, arm 2 stays green.
- `additionalProperties` forced closed: arm 3 alone fails, arms 1 and 2 green.

## Gates

`fmt --check`, `clippy -p khive-runtime -p kkernel --all-targets -D warnings`,
`test -p kkernel --lib pack_introspect`, and the full `test -p khive-runtime`
suite all pass on the pinned toolchain.
