### PR TITLE
ci: pull the pinned MinIO image from quay.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,17 +752,25 @@ jobs:
       # Pinned to an immutable digest (H3 fix round 2), matching the repo's
       # own supply-chain-pin convention (see the `supply-chain` job above).
       # Resolved 2026-07-16 from the `minio/minio:latest` manifest list via
-      # `registry-1.docker.io`'s `Docker-Content-Digest` response header
-      # (`docker.io/v2/minio/minio/manifests/latest`). Both the server
-      # container below and the `mc` client image in the next step pin the
-      # same digest.
+      # `registry-1.docker.io`'s `Docker-Content-Digest` response header. Both
+      # the server container below and the `mc` client image in the next step
+      # pin the same digest.
+      #
+      # The registry moved to quay.io on 2026-09-11: Docker Hub now answers
+      # `minio/minio` with 401 insufficient_scope for anonymous pulls, by tag
+      # and by this digest alike, while the same request against
+      # `library/alpine` still succeeds. quay.io serves this exact digest, so
+      # the image content is unchanged and the pin still identifies one
+      # immutable manifest. Symptom before the move: `pull access denied for
+      # minio/minio`, exit 125, which fails this job and therefore the
+      # aggregate CI gate on every pull request that touches the blob store.
       - name: Start pinned MinIO
         if: steps.changed.outputs.run == 'true'
         run: |
           docker run -d --name khive-minio -p 9000:9000 \
             -e MINIO_ROOT_USER=khive-ci \
             -e MINIO_ROOT_PASSWORD=khive-ci-secret \
-            minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
+            quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
             server /data
           for _ in $(seq 1 30); do
             if curl -sf http://127.0.0.1:9000/minio/health/live >/dev/null; then
@@ -777,7 +785,7 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: |
           docker run --rm --network host --entrypoint /bin/sh \
-            minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e -c \
+            quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e -c \
             "mc alias set ci http://127.0.0.1:9000 khive-ci khive-ci-secret && \
              mc mb --ignore-existing ci/khive-blob-conformance"
       - name: Shared BlobStore conformance suite against MinIO


### PR DESCRIPTION
Docker Hub stopped serving `minio/minio` to anonymous clients. A pull of the digest this workflow
pins now returns `401 insufficient_scope`, so the blob-store compatibility job dies at `docker run`
with exit 125 and takes the aggregate CI gate down with it on every pull request that reaches the
job.

Measured against both registries in one pass, with a still-public Docker Hub repository as the
control:

| request | result |
| --- | --- |
| Docker Hub `minio/minio:latest` | 401 insufficient_scope |
| Docker Hub `minio/minio` by the pinned digest | 401 |
| Docker Hub `library/alpine:latest` (control) | 200 |
| quay.io `minio/minio:latest` | 200, digest `sha256:14cea493…` |

quay.io serves the same manifest under the same digest the workflow already pins. Only the registry
prefix changes: the image content is byte-identical and the pin still names one immutable manifest,
so the supply-chain-pin convention is preserved rather than relaxed.

Acceptance is the job itself. This change is in the workflow that gates it, so a green
`MinIO BlobStore compatibility` run on this pull request is the whole verification.
