### PR TITLE
feat(brain): state the namespace an event count covered

### DIFF
--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -107,7 +107,11 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             bound `until` in the past for a closed population. Exhaustive windows matching more than \
             2,000,000 events are rejected rather than returned as partial aggregates; narrow \
             since/until or add actor/kind filters. Scope defaults to the caller; named foreign \
-            actors must be visible, and all_actors=true requires the serving brain.fleet_readers allowlist.",
+            actors must be visible, and all_actors=true requires the serving brain.fleet_readers \
+            allowlist. The window covers exactly one namespace: the caller's own, or the one named \
+            by an explicit `namespace=` argument. The result's `scope` states which namespace the \
+            answer covered and which others this caller may ask for the same way; rows written to \
+            any other namespace are absent from these counts rather than counted as zero.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -1025,6 +1029,22 @@ impl BrainPack {
             None => vec![caller.clone()],
         };
 
+        // The event plane is read through a store scoped to exactly one
+        // namespace (`Runtime::events` opens `token.namespace()` and the SQL
+        // pins `namespace = ?`), so a visibility set does not widen this
+        // window the way it widens a note read. Name the namespace the answer
+        // covers, and name the others this caller may ask for by passing
+        // `namespace=`, so an undercount is legible from the result itself.
+        let scope_namespace = token.namespace().as_str().to_string();
+        let mut scope_other: Vec<String> = token
+            .visible_namespace_strs()
+            .iter()
+            .map(|n| n.to_string())
+            .filter(|n| n != &scope_namespace)
+            .collect();
+        scope_other.sort();
+        scope_other.dedup();
+
         let store = self.runtime.events(token)?;
         let base_filter = EventFilter {
             actors: actor_filters,
@@ -1144,6 +1164,16 @@ impl BrainPack {
             "truncated": truncated,
             "window_event_total": window_event_total,
             "exhaustive": exhaustive,
+            // The scope the answer was computed under, stated rather than
+            // implied. `namespace` is the single namespace this window covers;
+            // `other_namespaces` are the ones this caller may read by asking
+            // for them explicitly, and whose rows are absent here. A caller can
+            // therefore tell a real zero from an out-of-scope population, and
+            // knows what to pass to reach the rest.
+            "scope": {
+                "namespace": scope_namespace,
+                "other_namespaces": scope_other,
+            },
         });
         result[Self::truncatable_total_key("total", truncated)] = json!(items.len() as u64);
         if !by_profile.is_empty() {

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -7973,6 +7973,112 @@ mod event_counts_tests {
         assert_eq!(result["counts_by_kind"]["search_executed"], json!(2));
     }
 
+    /// A count covering one namespace must say which one, and say what else
+    /// the caller could ask for.
+    ///
+    /// Memory and brain verbs stamp the acting identity's namespace whenever a
+    /// call carries one, so a caller reading the default scope can be missing a
+    /// whole population of its own activity. The event window is opened on a
+    /// single namespace, so a visibility set does NOT widen it the way it
+    /// widens a note read: arm three below is the falsifier for that belief,
+    /// and it is the reason the disclosure has to name the reachable
+    /// namespaces rather than let the caller infer them from what came back.
+    #[tokio::test]
+    async fn counts_disclose_the_namespace_they_covered_and_the_way_to_ask() {
+        let (pack, rt) = make_pack_with_actor("lambda:a");
+        let registry = empty_registry();
+        let here = rt.authorize(Namespace::local()).unwrap();
+        let elsewhere = rt
+            .authorize(Namespace::parse("other").expect("namespace"))
+            .expect("authorize other");
+
+        for at in [1_000_000_i64, 1_100_000] {
+            seed_event(
+                &rt,
+                &here,
+                "search",
+                EventKind::SearchExecuted,
+                "lambda:a",
+                at,
+                json!({}),
+            )
+            .await;
+        }
+        seed_event(
+            &rt,
+            &elsewhere,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            1_200_000,
+            json!({}),
+        )
+        .await;
+
+        let window = json!({
+            "since": micros_to_iso(900_000),
+            "until": micros_to_iso(2_000_000),
+        });
+
+        // Arm 1: the default read. It covers `local` and names it.
+        let narrow = pack
+            .dispatch("brain.event_counts", window.clone(), &registry, &here)
+            .await
+            .expect("narrow read must succeed");
+        assert_eq!(
+            narrow["scope"]["namespace"],
+            json!("local"),
+            "the scope must state the namespace the answer was computed under: {narrow}"
+        );
+        assert_eq!(
+            narrow["total"],
+            json!(2),
+            "the narrow read counts only what it could see: {narrow}"
+        );
+
+        // Arm 2: the way to ask. A token scoped to the other namespace returns
+        // that namespace's row and nothing from `local`, so the population the
+        // narrow read omitted is reachable rather than lost.
+        let asked = pack
+            .dispatch("brain.event_counts", window.clone(), &registry, &elsewhere)
+            .await
+            .expect("explicit-namespace read must succeed");
+        assert_eq!(
+            asked["scope"]["namespace"],
+            json!("other"),
+            "asking for a namespace must move the scope to it: {asked}"
+        );
+        assert_eq!(
+            asked["total"],
+            json!(1),
+            "the asked-for namespace returns its own row, not the caller's: {asked}"
+        );
+
+        // Arm 3: visibility does not widen this window. The token below may
+        // read `other`, and the count is still the `local` two — which is
+        // exactly why `other_namespaces` has to be stated instead of inferred.
+        let wide_token = rt
+            .authorize_with_visibility(
+                Namespace::local(),
+                vec![Namespace::parse("other").expect("namespace")],
+            )
+            .expect("authorize with visibility");
+        let wide = pack
+            .dispatch("brain.event_counts", window, &registry, &wide_token)
+            .await
+            .expect("wide read must succeed");
+        assert_eq!(
+            wide["total"],
+            json!(2),
+            "a visibility set must not widen a single-namespace event window: {wide}"
+        );
+        assert_eq!(
+            wide["scope"]["other_namespaces"],
+            json!(["other"]),
+            "the scope must name the namespaces this caller can ask for: {wide}"
+        );
+    }
+
     #[tokio::test]
     async fn empty_window_returns_zero_counts_not_error() {
         let (pack, rt) = make_pack();


### PR DESCRIPTION
A windowed event count is computed through a store opened on exactly one namespace: `Runtime::events`
opens `token.namespace()` and the SQL pins `namespace = ?` as its first condition. The result gave no
sign of which namespace that was, so a caller reading the default scope could be missing a whole
population of its own activity with nothing in the answer to say so, and could not tell a real zero
from an out-of-scope one.

Every result now carries:

```json
"scope": {"namespace": "<the one namespace this window covered>",
          "other_namespaces": ["<namespaces this caller may ask for>"]}
```

The verb description states the same contract, including that rows written to another namespace are
absent from the counts rather than counted as zero, and that an explicit `namespace=` argument moves
the window.

Three arms, and the third is the one worth reading. Arm one is the default read naming `local`. Arm two
asks for another namespace and gets that namespace's row and none of the caller's. Arm three gives the
token visibility over the second namespace and asserts the count is still the caller's two, because a
visibility set widens a note read and does not widen this one. That asymmetry is the whole reason the
reachable namespaces have to be stated rather than inferred from what came back, and an earlier draft
of this change asserted the opposite before the arm was written.

No behaviour changes for existing callers: the counts, totals and truncation keys are untouched.
