### PR TITLE
fix(py): a Session's namespace scopes its ops, not just the request frame

### DIFF
--- a/python/khive/transport.py
+++ b/python/khive/transport.py
@@ -436,11 +436,21 @@ class Session:
         self,
         transport: Transport | None = None,
         *,
-        namespace: str = "local",
+        namespace: str | None = None,
         actor_id: str | None = None,
         visible_namespaces: list[str] | None = None,
         timeout: float = 30.0,
     ) -> None:
+        """`namespace` is this session's DEFAULT namespace for every op it sends.
+
+        It used to default to `"local"` and reach only the request frame, which
+        the registry does not read as an op argument, so a session constructed
+        with a namespace sent every op unscoped and silently answered about the
+        caller's own namespace instead. The value now falls through to each op
+        that does not name one of its own, which is what the argument reads as.
+        An explicit per-op `namespace=` still wins. `None` means "send no
+        namespace argument", the behaviour of a session that names none.
+        """
         self.transport = transport or SocketTransport()
         self.namespace = namespace
         self.actor_id = actor_id
@@ -536,7 +546,7 @@ class Session:
                         source_id=source_id,
                         tags=tags,
                         embedding_model=embedding_model,
-                        namespace=namespace,
+                        namespace=self._op_namespace(namespace),
                     )
                 ]
             ),
@@ -577,7 +587,7 @@ class Session:
                         thread_id=thread_id,
                         tags=tags,
                         self_send=self_send,
-                        namespace=namespace,
+                        namespace=self._op_namespace(namespace),
                     )
                 ]
             ),
@@ -611,7 +621,7 @@ class Session:
                         content=content,
                         idempotency_key=idempotency_key,
                         tags=tags,
-                        namespace=namespace,
+                        namespace=self._op_namespace(namespace),
                     )
                 ]
             ),
@@ -671,7 +681,7 @@ class Session:
                         full_content=full_content,
                         profile_id=profile_id,
                         embedding_model=embedding_model,
-                        namespace=namespace,
+                        namespace=self._op_namespace(namespace),
                     )
                 ]
             ),
@@ -726,6 +736,11 @@ class Session:
             "protocol_version": PROTOCOL_VERSION,
         }
 
+    def _op_namespace(self, namespace: str | None) -> str | None:
+        """Resolve one op's namespace: the op's own if it named one, else the
+        session's default, else None so no argument is sent at all."""
+        return namespace if namespace is not None else self.namespace
+
     def _base_frame(self) -> dict[str, Any]:
         return {
             "ops": "",
@@ -735,7 +750,10 @@ class Session:
             # agents reading text; a typed client needs the machine contract.
             "presentation": "verbose",
             "format": "json",
-            "namespace": self.namespace,
+            # The frame's namespace is an identity field, not a scope: it has
+            # always been a string here, so an unset session keeps sending
+            # "local" and the wire contract is unchanged by the default move.
+            "namespace": self.namespace or "local",
             "actor_id": self.actor_id,
             "visible_namespaces": self.visible_namespaces,
             "config_id": self._config_id or "",

--- a/python/tests/test_memory_keys.py
+++ b/python/tests/test_memory_keys.py
@@ -85,7 +85,11 @@ def test_remember_forwards_arguments_and_transport_timeout():
 @pytest.mark.parametrize("key", [None, ""])
 def test_remember_omits_none_but_preserves_empty_key_without_inferred_namespace(memory_type, key):
     transport = ScriptedTransport([[SUCCESS]])
-    session = Session(transport, namespace="frame-only", actor_id="test-client", timeout=9.0)
+    # No namespace on the session: this arm's subject is that nothing is
+    # INFERRED from key or memory_type, and a session that names a namespace
+    # now sends it as an op argument (test_session_namespace_default.py), so
+    # naming one here would be asserting a different contract in passing.
+    session = Session(transport, actor_id="test-client", timeout=9.0)
 
     assert session.remember("memory", key=key, memory_type=memory_type) == SUCCESS
 

--- a/python/tests/test_session_namespace_default.py
+++ b/python/tests/test_session_namespace_default.py
@@ -1,0 +1,94 @@
+"""A session's namespace is the default for its ops, not just a frame field.
+
+The constructor argument used to default to "local" and reach only the request
+frame. The registry does not read the frame as an op argument, so a session
+built with a namespace sent every op unscoped and answered about the caller's
+own namespace instead, with no error anywhere. These arms pin the argument to
+the meaning it reads as, and the frame arm pins what did NOT change.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+from khive import Transport
+from khive.transport import Session
+
+NOTE_ID = "00000000-0000-4000-8000-000000000001"
+
+
+class RecordingTransport(Transport):
+    """Records every dispatched frame and answers one successful remember."""
+
+    def __init__(self) -> None:
+        self.dispatches: list[dict] = []
+
+    def round_trip(self, frame, timeout):
+        response = {"ok": True, "served_config_id": "test-config"}
+        if not frame.get("metrics_only"):
+            self.dispatches.append(copy.deepcopy(frame))
+            response["result"] = json.dumps(
+                {
+                    "results": [
+                        {
+                            "ok": True,
+                            "tool": "memory.remember",
+                            "result": {"id": NOTE_ID},
+                        }
+                    ]
+                }
+            )
+        return response
+
+
+def dispatch(session: Session, **kwargs) -> dict:
+    """Return the dispatched op's ARGS, parsed.
+
+    The ops payload is JSON, not DSL source, so a substring check for
+    `namespace="acme"` never matches and a check for `namespace=` never
+    matches either -- which would make the absence arm below pass without
+    testing anything. The structural question gets a parse.
+    """
+    transport = session.transport
+    session.remember("a marker phrase", **kwargs)
+    assert transport.dispatches, "no frame was dispatched; the arm proves nothing"
+    ops = json.loads(transport.dispatches[-1]["ops"])
+    assert len(ops) == 1 and ops[0]["tool"] == "memory.remember"
+    return ops[0]["args"]
+
+
+def session(**kwargs) -> Session:
+    return Session(transport=RecordingTransport(), **kwargs)
+
+
+def test_session_namespace_reaches_the_op_not_only_the_frame():
+    args = dispatch(session(namespace="acme"))
+    assert args["namespace"] == "acme"
+
+
+def test_an_explicit_op_namespace_beats_the_session_default():
+    args = dispatch(session(namespace="acme"), namespace="other")
+    assert args["namespace"] == "other"
+
+
+def test_a_session_naming_no_namespace_sends_no_namespace_argument():
+    # The control for the two arms above: without this, an implementation that
+    # hard-coded "acme" would pass both of them.
+    args = dispatch(session())
+    assert "namespace" not in args
+
+
+def test_the_frame_still_carries_a_string_for_an_unset_session():
+    # The wire contract is unchanged by moving the default to None. The frame's
+    # namespace is an identity field, and it was a string before this change.
+    s = session()
+    dispatch(s)
+    assert s.transport.dispatches[-1]["namespace"] == "local"
+
+
+def test_a_named_session_puts_its_namespace_on_both_frame_and_op():
+    s = session(namespace="acme")
+    args = dispatch(s)
+    assert s.transport.dispatches[-1]["namespace"] == "acme"
+    assert args["namespace"] == "acme"


### PR DESCRIPTION
`Session(namespace="acme")` put the value on the request frame only. The registry does not read the
frame as an op argument, so every op that did not name a namespace of its own was answered in the
caller's own namespace. Nothing errored and nothing warned.

That failure is quiet in the worst way. A caller ran three sessions against three namespaces, got
identical counts back from all three, and believed the numbers for two hours. Three wrong answers
that agree read as corroboration.

**What changes.** The constructor argument defaults to `None` and, when set, becomes the default
namespace for each op that does not name one. An explicit per-op `namespace=` still wins. `None`
sends no namespace argument at all, which is what a session naming none did before. The frame keeps
sending the string `"local"` for an unset session, so the wire contract is untouched.

**The one assertion that moves, and why it is not a contract being broken quietly.**
`test_remember_omits_none_but_preserves_empty_key_without_inferred_namespace` built its session with
`namespace="frame-only"` and asserted the op carried no namespace. That arm's subject is that
nothing is inferred from `key` or `memory_type`, and it still asserts exactly that. The namespace
there was scaffolding: it arrived in a keyed-memory change that gave no reason for the frame-only
behaviour, and the surrounding docstring's "does not infer a write namespace" is about not inferring
from other arguments, which is a different claim from ignoring a default the caller set explicitly.
The session now names no namespace and the arm is unchanged otherwise.

**Coverage.** Five new arms: the session default reaches the op; an explicit op namespace beats it;
a session naming none sends no argument; the frame still carries a string; a named session puts it
on both frame and op. They parse the ops payload instead of matching substrings, because the payload
is JSON and a substring check for `namespace=` matches nothing in it. The first draft of these arms
did match substrings, and the absence arm passed while testing nothing.

Verified against a baseline rather than in isolation: the full suite on untouched `main` fails 10
daemon-integration tests on this host and passes 508. With this change it fails the same 10, by
name, and passes 513. A mutation control no-oping the resolver reddens two of the five new arms.
