### PR TITLE
docs(adr): ADR-180 names the ordering question its crossing case leaves open

### DIFF
--- a/docs/adr/ADR-180-tool-pack.md
+++ b/docs/adr/ADR-180-tool-pack.md
@@ -367,6 +367,28 @@ was not asked for one, and getting it wrong silently widens or silently narrows 
 is named here so that nobody reads this amendment as having made scoped rules effective everywhere.
 The column is a prerequisite for that work, not a substitute for it.
 
+### A second thing this amendment does not answer (added 2026-09-11)
+
+Item 5 accepts that a row with `actor *` and an exact scope outranks a row with an exact actor and
+no scope, because the ordering is a sum of comparable weights and a sum has no dimension
+precedence. That acceptance settles what happens; it is not a claim that the sum is the right
+ordering once scoped rows are common.
+
+The consequence an operator will actually meet is worth writing down plainly. Adding a broad-actor
+scoped `allow` can outrank a narrow-actor unscoped `deny` that was already in the table, and the
+operator who wrote the allow was thinking about the scope they named, not about the actor column
+they left as `*`. Nothing in the call tells them the older row stopped deciding. Acceptance arm 34
+pins the crossing so the behaviour is asserted rather than assumed, and that is all an acceptance
+arm can do: it makes the answer stable, not obviously right.
+
+The alternative ordering, lexicographic over actor then tool then scope, is deliberately out of
+scope here. It would also change how `lambda:*` with an exact tool ranks against an exact actor
+with `tool.*`, which is a change to behaviour that predates this column entirely and should not
+ride in on it. That is a separate decision carrying its own migration question.
+
+So the crossing case is decided and tested, and the ordering that produces it is not settled. Both
+are recorded here as distinct so that neither is read as having answered the other.
+
 ## Acceptance for Amendment 4
 
 26. A table containing only unscoped rows answers every `tool.check` exactly as it did before the


### PR DESCRIPTION
Amendment 4 accepts, deliberately, that a row with a wildcard actor and an exact scope outranks a row with an exact actor and no scope. The ordering is a sum of comparable weights, so it has no dimension precedence, and acceptance arm 34 pins the crossing case.

The open-question section named exactly one residual, scope derivation for verbs that never receive a scope. A reader finishing the amendment concludes that is the only thing left open. The ordering that produces the crossing is a second one, and it belongs in the same place rather than only inside the item that decided it.

This adds that subsection. It states the consequence an operator actually meets: adding a broad-actor scoped `allow` can outrank a narrow-actor unscoped `deny` already in the table, and nothing in the call tells them the older row stopped deciding. It also records why the lexicographic alternative is out of scope, which is that it would change how unscoped rows rank against each other, and that behaviour predates this column entirely.

Addition only, 22 lines, no existing prose altered. `deno fmt --check`, `scripts/lint-adr-refs.sh` and `scripts/lint-adr-status.py` all pass.
