### PR TITLE
feat(py): awaited session over the local daemon socket

### DIFF
--- a/python/khive/__init__.py
+++ b/python/khive/__init__.py
@@ -38,10 +38,20 @@ from .models import (
     RecallOutcome,
 )
 from .ops import encode, op
-from .transport import AsyncHttpTransport, HttpTransport, Session, SocketTransport, Transport
+from .transport import (
+    AsyncHttpTransport,
+    AsyncSession,
+    AsyncSocketTransport,
+    HttpTransport,
+    Session,
+    SocketTransport,
+    Transport,
+)
 
 __all__ = [
     "AsyncHttpTransport",
+    "AsyncSession",
+    "AsyncSocketTransport",
     "Attachment",
     "AuthError",
     "BadRequest",

--- a/python/khive/transport.py
+++ b/python/khive/transport.py
@@ -24,6 +24,7 @@ is daemon-defined; a `version_mismatch` is a hard error naming both sides.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import socket
@@ -107,6 +108,69 @@ class SocketTransport(Transport):
         buf = bytearray()
         while len(buf) < n:
             chunk = sock.recv(n - len(buf))
+            if not chunk:
+                raise TransportError(f"connection closed after {len(buf)} of {n} bytes")
+            buf.extend(chunk)
+        return bytes(buf)
+
+
+class AsyncSocketTransport:
+    """`SocketTransport`'s awaited twin: same socket, same framing, no thread blocked.
+
+    Deliberately not a `Transport` subclass. That ABC declares a synchronous
+    `round_trip`, and a coroutine returned where a dict is expected fails far
+    from the call that caused it. `AsyncSession` takes this shape instead.
+
+    The framing below must stay identical to `SocketTransport`'s: same 4-byte
+    big-endian prefix, same cap enforced in both directions. It is duplicated
+    rather than shared because the sync side reads a `socket` and this side
+    reads a `StreamReader`, and an abstraction over those two would be longer
+    than either.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path is not None else default_socket_path()
+
+    async def round_trip(self, frame: dict[str, Any], timeout: float) -> dict[str, Any]:
+        payload = json.dumps(frame).encode("utf-8")
+        if len(payload) > MAX_FRAME_BYTES:
+            raise FrameTooLarge(f"request frame is {len(payload)} bytes; cap is {MAX_FRAME_BYTES}")
+        try:
+            raw = await asyncio.wait_for(self._exchange(payload), timeout)
+        except TimeoutError as exc:
+            raise TransportError(f"khived at {self.path}: timed out after {timeout}s") from exc
+        except OSError as exc:
+            raise TransportError(f"khived at {self.path}: {exc}") from exc
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except ValueError as exc:
+            raise TransportError(f"undecodable response frame ({len(raw)} bytes)") from exc
+
+    async def _exchange(self, payload: bytes) -> bytes:
+        reader, writer = await asyncio.open_unix_connection(str(self.path))
+        try:
+            writer.write(struct.pack(">I", len(payload)) + payload)
+            await writer.drain()
+            header = await self._read_exact(reader, 4)
+            (length,) = struct.unpack(">I", header)
+            if length > MAX_FRAME_BYTES:
+                raise FrameTooLarge(f"response frame of {length} bytes exceeds {MAX_FRAME_BYTES}")
+            return await self._read_exact(reader, length)
+        finally:
+            writer.close()
+            # A closed-but-undrained writer leaves the connection in the event
+            # loop's hands; the daemon serves one request per connection, so an
+            # abandoned half-closed socket is a real leak under a hot loop.
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass
+
+    @staticmethod
+    async def _read_exact(reader: asyncio.StreamReader, n: int) -> bytes:
+        buf = bytearray()
+        while len(buf) < n:
+            chunk = await reader.read(n - len(buf))
             if not chunk:
                 raise TransportError(f"connection closed after {len(buf)} of {n} bytes")
             buf.extend(chunk)
@@ -423,13 +487,14 @@ class AsyncHttpTransport:
         await self.aclose()
 
 
-class Session:
-    """A configured lane to one daemon: transport + identity + adopted config.
+class _SessionCore:
+    """State and the non-IO half of the request path, shared by both sessions.
 
-    Performs the version/config handshake lazily on the first request and
-    caches `config_id` for the connection's lifetime. If the daemon restarts
-    under a different config, the next request comes back `config_mismatch`
-    and the session re-handshakes once before failing.
+    `Session` drives it synchronously and `AsyncSession` awaits its transport;
+    everything that DECIDES anything lives here, so the two cannot classify the
+    same response differently. That is the property worth the extra class: a
+    refusal raised on one path and absorbed on the other would be invisible to
+    any test that exercises only one of them.
     """
 
     def __init__(
@@ -457,6 +522,106 @@ class Session:
         self.visible_namespaces = visible_namespaces or []
         self.timeout = timeout
         self._config_id: str | None = None
+
+
+    # -- shared with AsyncSession -----------------------------------------
+    #
+    # These two carry every classification decision on the request path: which
+    # responses are refusals, which are protocol failures, and what a success
+    # decodes to. They take no IO, so both the synchronous driver above and the
+    # awaited one below reach the same verdict on the same bytes. Keeping them
+    # here rather than inlining is what stops the two paths from drifting: a
+    # refusal absorbed on one side and raised on the other is invisible to any
+    # test that exercises only one of them.
+
+    def _request_frame(self, ops_json: str) -> dict[str, Any]:
+        return self._base_frame() | {
+            "ops": ops_json,
+            "config_id": self._config_id,
+        }
+
+    def _decode_results(self, response: dict[str, Any]) -> list[dict[str, Any]]:
+        """Classify one response frame. Raises on refusal; decodes on success."""
+        if response.get("config_mismatch"):
+            # Reached only after the caller already spent its one re-handshake.
+            raise ConfigMismatch(
+                str(response.get("error")),
+                error_detail=_validate_frame_error_detail(response, "daemon"),
+            )
+        if not response.get("ok"):
+            raise RequestRejected(
+                str(response.get("error")),
+                error_detail=_validate_frame_error_detail(response, "daemon"),
+            )
+        raw = response.get("result")
+        parsed = _decode_json_text(raw, "daemon") if isinstance(raw, str) else raw
+        envelope = _envelope_from_payload(parsed, "daemon")
+        return _validate_envelope_results(envelope, "daemon")["results"]
+
+
+    def _plan_frame(self) -> dict[str, Any]:
+        return {
+            "ops": "",
+            # Required by the frame codec; the plan path never resolves identity.
+            "namespace": "",
+            "config_id": self._config_id or "",
+            "protocol_version": PROTOCOL_VERSION,
+        }
+
+    def _op_namespace(self, namespace: str | None) -> str | None:
+        """Resolve one op's namespace: the op's own if it named one, else the
+        session's default, else None so no argument is sent at all."""
+        return namespace if namespace is not None else self.namespace
+
+    def _base_frame(self) -> dict[str, Any]:
+        return {
+            "ops": "",
+            # Verbose passes canonical JSON through unchanged: full ISO-8601
+            # timestamps, no humanized fields ("0s ago"), no redundancy
+            # pre-pass. The compact/agent renderings are for humans and
+            # agents reading text; a typed client needs the machine contract.
+            "presentation": "verbose",
+            "format": "json",
+            # The frame's namespace is an identity field, not a scope: it has
+            # always been a string here, so an unset session keeps sending
+            # "local" and the wire contract is unchanged by the default move.
+            "namespace": self.namespace or "local",
+            "actor_id": self.actor_id,
+            "visible_namespaces": self.visible_namespaces,
+            "config_id": self._config_id or "",
+            "protocol_version": PROTOCOL_VERSION,
+            "from_wire": False,
+        }
+
+    @staticmethod
+    def _check_version(response: dict[str, Any]) -> None:
+        if response.get("version_mismatch"):
+            message = str(response.get("error") or "")
+            detail = _validate_frame_error_detail(response, "daemon")
+            fields = detail.model_dump(exclude_unset=True) if detail is not None else {}
+            fields.pop("domain_result", None)
+            fields.update(
+                kind="protocol",
+                code="version_mismatch",
+                message=message,
+                domain_disposition="unknown",
+            )
+            raise ProtocolMismatch(
+                PROTOCOL_VERSION,
+                int(response.get("daemon_protocol_version") or 0),
+                message,
+                OpError.model_validate(fields),
+            )
+
+
+class Session(_SessionCore):
+    """A configured lane to one daemon: transport + identity + adopted config.
+
+    Performs the version/config handshake lazily on the first request and
+    caches `config_id` for the connection's lifetime. If the daemon restarts
+    under a different config, the next request comes back `config_mismatch`
+    and the session re-handshakes once before failing.
+    """
 
     # -- handshake ---------------------------------------------------------
 
@@ -487,10 +652,7 @@ class Session:
         """Send one ops payload; return the per-op result list."""
         if self._config_id is None:
             self.handshake()
-        frame = self._base_frame() | {
-            "ops": ops_json,
-            "config_id": self._config_id,
-        }
+        frame = self._request_frame(ops_json)
         response = self.transport.round_trip(frame, timeout or self.timeout)
         self._check_version(response)
         if response.get("config_mismatch"):
@@ -499,20 +661,7 @@ class Session:
             frame["config_id"] = self._config_id
             response = self.transport.round_trip(frame, timeout or self.timeout)
             self._check_version(response)
-            if response.get("config_mismatch"):
-                raise ConfigMismatch(
-                    str(response.get("error")),
-                    error_detail=_validate_frame_error_detail(response, "daemon"),
-                )
-        if not response.get("ok"):
-            raise RequestRejected(
-                str(response.get("error")),
-                error_detail=_validate_frame_error_detail(response, "daemon"),
-            )
-        raw = response.get("result")
-        parsed = _decode_json_text(raw, "daemon") if isinstance(raw, str) else raw
-        envelope = _envelope_from_payload(parsed, "daemon")
-        return _validate_envelope_results(envelope, "daemon")["results"]
+        return self._decode_results(response)
 
     def remember(
         self,
@@ -727,56 +876,87 @@ class Session:
         parsed = _decode_json_text(raw, "daemon") if isinstance(raw, str) else raw
         return _plan_from_payload(parsed, "daemon")
 
-    def _plan_frame(self) -> dict[str, Any]:
-        return {
-            "ops": "",
-            # Required by the frame codec; the plan path never resolves identity.
-            "namespace": "",
-            "config_id": self._config_id or "",
-            "protocol_version": PROTOCOL_VERSION,
-        }
 
-    def _op_namespace(self, namespace: str | None) -> str | None:
-        """Resolve one op's namespace: the op's own if it named one, else the
-        session's default, else None so no argument is sent at all."""
-        return namespace if namespace is not None else self.namespace
+class AsyncSession(_SessionCore):
+    """`Session`'s awaited twin over the local daemon socket.
 
-    def _base_frame(self) -> dict[str, Any]:
-        return {
-            "ops": "",
-            # Verbose passes canonical JSON through unchanged: full ISO-8601
-            # timestamps, no humanized fields ("0s ago"), no redundancy
-            # pre-pass. The compact/agent renderings are for humans and
-            # agents reading text; a typed client needs the machine contract.
-            "presentation": "verbose",
-            "format": "json",
-            # The frame's namespace is an identity field, not a scope: it has
-            # always been a string here, so an unset session keeps sending
-            # "local" and the wire contract is unchanged by the default move.
-            "namespace": self.namespace or "local",
-            "actor_id": self.actor_id,
-            "visible_namespaces": self.visible_namespaces,
-            "config_id": self._config_id or "",
-            "protocol_version": PROTOCOL_VERSION,
-            "from_wire": False,
-        }
+    Same handshake, same one re-handshake on `config_mismatch`, same refusal
+    classes, because all of that lives in `_SessionCore` and neither driver
+    owns a copy. What differs is only who waits: this one yields to the event
+    loop instead of blocking the calling thread, which is what a caller already
+    inside a loop needs.
 
-    @staticmethod
-    def _check_version(response: dict[str, Any]) -> None:
-        if response.get("version_mismatch"):
-            message = str(response.get("error") or "")
-            detail = _validate_frame_error_detail(response, "daemon")
-            fields = detail.model_dump(exclude_unset=True) if detail is not None else {}
-            fields.pop("domain_result", None)
-            fields.update(
-                kind="protocol",
-                code="version_mismatch",
-                message=message,
-                domain_disposition="unknown",
+    Local socket only, by design. The cloud transport is already awaitable
+    (`AsyncHttpTransport`), and a session that silently accepted either would
+    have to reconcile two lifecycles: this one closes nothing, an HTTP client
+    must be closed. `aclose` here exists so that stays true if that changes.
+    """
+
+    def __init__(
+        self,
+        transport: AsyncSocketTransport | None = None,
+        *,
+        namespace: str | None = None,
+        actor_id: str | None = None,
+        visible_namespaces: list[str] | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        super().__init__(
+            transport or AsyncSocketTransport(),
+            namespace=namespace,
+            actor_id=actor_id,
+            visible_namespaces=visible_namespaces,
+            timeout=timeout,
+        )
+
+    async def ahandshake(self) -> str:
+        """Learn the daemon's protocol version and adopt its config id."""
+        response = await self.transport.round_trip(
+            self._base_frame() | {"metrics_only": True}, self.timeout
+        )
+        self._check_version(response)
+        served = response.get("served_config_id")
+        if not served:
+            raise ConfigMismatch(
+                "daemon did not report a config id; it predates this client's protocol"
             )
-            raise ProtocolMismatch(
-                PROTOCOL_VERSION,
-                int(response.get("daemon_protocol_version") or 0),
-                message,
-                OpError.model_validate(fields),
-            )
+        self._config_id = served
+        return served
+
+    async def ametrics(self) -> dict[str, Any]:
+        response = await self.transport.round_trip(
+            self._base_frame() | {"metrics_only": True}, self.timeout
+        )
+        self._check_version(response)
+        return response.get("metrics") or {}
+
+    async def arequest(
+        self, ops_json: str, *, timeout: float | None = None
+    ) -> list[dict[str, Any]]:
+        """Send one ops payload; return the per-op result list."""
+        if self._config_id is None:
+            await self.ahandshake()
+        frame = self._request_frame(ops_json)
+        response = await self.transport.round_trip(frame, timeout or self.timeout)
+        self._check_version(response)
+        if response.get("config_mismatch"):
+            # One re-handshake: the daemon restarted under a new config.
+            await self.ahandshake()
+            frame["config_id"] = self._config_id
+            response = await self.transport.round_trip(frame, timeout or self.timeout)
+            self._check_version(response)
+        return self._decode_results(response)
+
+    async def aclose(self) -> None:
+        """No-op today: the socket transport opens one connection per request.
+
+        Present so callers can write the `async with` they would write for any
+        other client, and so adding a pooled transport later does not change
+        their code.
+        """
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.aclose()

--- a/python/tests/test_async_session.py
+++ b/python/tests/test_async_session.py
@@ -1,0 +1,221 @@
+"""AsyncSession over the local daemon socket: framing, handshake, and refusals.
+
+Two kinds of coverage here, because the change has two halves.
+
+`AsyncSocketTransport` is new code with no sync twin to lean on, so it is
+exercised against a real `asyncio` unix socket server speaking the daemon's
+framing. A stub cannot cover length prefixes, partial reads, or the cap.
+
+`AsyncSession` shares every classification decision with `Session` through
+`_SessionCore`. The tests that matter there are the ones that would fail if
+someone later gave the awaited path its own copy: the two drivers must reach
+the same verdict on the same response bytes.
+
+No async pytest plugin is a dev dependency, so each test drives its coroutine
+with a bare `asyncio.run`, the same pattern as `test_async_http_transport.py`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from copy import deepcopy
+
+import pytest
+
+from khive import AsyncSession, AsyncSocketTransport, Session
+from khive.errors import ConfigMismatch, FrameTooLarge, ProtocolMismatch, RequestRejected
+from khive.transport import MAX_FRAME_BYTES, PROTOCOL_VERSION
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+RESULTS = {"results": [{"ok": True, "tool": "stats"}]}
+
+
+class AsyncDaemonStub:
+    """The awaited shape of `test_session_plan.py`'s DaemonStub."""
+
+    def __init__(self, *, version=PROTOCOL_VERSION, mismatches=0, rejection=None):
+        self.version = version
+        self.mismatches = mismatches
+        self.rejection = rejection
+        self.frames = []
+        self.timeouts = []
+
+    async def round_trip(self, frame, timeout):
+        self.frames.append(deepcopy(frame))
+        self.timeouts.append(timeout)
+        if frame["protocol_version"] != self.version:
+            return {
+                "ok": False,
+                "version_mismatch": True,
+                "daemon_protocol_version": self.version,
+                "error": "protocol version mismatch",
+            }
+        if frame.get("metrics_only"):
+            return {"ok": True, "served_config_id": "catalog-config", "metrics": {"status": "ok"}}
+        if self.mismatches:
+            self.mismatches -= 1
+            return {"ok": False, "config_mismatch": True, "error": "config changed"}
+        if self.rejection is not None:
+            return {"ok": False, "error": self.rejection}
+        return {"ok": True, "served_config_id": "catalog-config", "result": json.dumps(RESULTS)}
+
+
+class SyncMirror:
+    """`AsyncDaemonStub`'s answers, delivered synchronously.
+
+    Same responses, same order, so a divergence between the two sessions can
+    only come from the sessions themselves.
+    """
+
+    def __init__(self, **kwargs):
+        self._inner = AsyncDaemonStub(**kwargs)
+
+    def round_trip(self, frame, timeout):
+        return asyncio.run(self._inner.round_trip(frame, timeout))
+
+
+# -- the shared core, asserted structurally --------------------------------
+
+
+def test_both_sessions_share_one_copy_of_every_classification():
+    # Identity, not equality: if either class grows its own override these stop
+    # being the same function and this fails, which is the whole point of the
+    # split. A behavioural test alone would pass a duplicated-but-identical copy
+    # and go on passing until the copies drifted.
+    assert Session._decode_results is AsyncSession._decode_results
+    assert Session._request_frame is AsyncSession._request_frame
+    assert Session._base_frame is AsyncSession._base_frame
+    assert Session._check_version is AsyncSession._check_version
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"rejection": "refused by policy"}, RequestRejected),
+        ({"mismatches": 5}, ConfigMismatch),
+        ({"version": PROTOCOL_VERSION + 1}, ProtocolMismatch),
+    ],
+)
+def test_both_drivers_raise_the_same_class_on_the_same_response(kwargs, expected):
+    with pytest.raises(expected):
+        Session(SyncMirror(**kwargs)).request("stats()")
+
+    async def _inner():
+        await AsyncSession(AsyncDaemonStub(**kwargs)).arequest("stats()")
+
+    with pytest.raises(expected):
+        _run(_inner())
+
+
+def test_one_rehandshake_then_the_results(  # a mismatch that clears is not an error
+):
+    stub = AsyncDaemonStub(mismatches=1)
+
+    async def _inner():
+        session = AsyncSession(stub, actor_id="test-client", namespace="project")
+        return await session.arequest("stats()")
+
+    assert _run(_inner()) == RESULTS["results"]
+    # handshake, refused request, re-handshake, accepted request: exactly one retry.
+    assert [bool(f.get("metrics_only")) for f in stub.frames] == [True, False, True, False]
+
+
+def test_ametrics_reads_without_adopting_a_config():
+    stub = AsyncDaemonStub()
+
+    async def _inner():
+        return await AsyncSession(stub).ametrics()
+
+    assert _run(_inner()) == {"status": "ok"}
+
+
+def test_async_context_manager_closes_without_error():
+    async def _inner():
+        async with AsyncSession(AsyncDaemonStub()) as session:
+            return await session.arequest("stats()")
+
+    assert _run(_inner()) == RESULTS["results"]
+
+
+# -- the new transport, against a real socket -------------------------------
+
+
+class FakeDaemon:
+    """One length-prefixed request per connection, exactly like khived."""
+
+    def __init__(self, path, responder):
+        self.path = str(path)
+        self.responder = responder
+        self.requests = []
+
+    async def __aenter__(self):
+        self._server = await asyncio.start_unix_server(self._serve, self.path)
+        return self
+
+    async def __aexit__(self, *exc_info):
+        self._server.close()
+        await self._server.wait_closed()
+
+    async def _serve(self, reader, writer):
+        header = await reader.readexactly(4)
+        (length,) = struct.unpack(">I", header)
+        body = await reader.readexactly(length)
+        frame = json.loads(body.decode("utf-8"))
+        self.requests.append(frame)
+        payload = json.dumps(self.responder(frame)).encode("utf-8")
+        writer.write(struct.pack(">I", len(payload)) + payload)
+        await writer.drain()
+        writer.close()
+
+
+def test_transport_round_trips_over_a_real_unix_socket(tmp_path):
+    sock = tmp_path / "khived.sock"
+
+    def responder(frame):
+        return {"ok": True, "served_config_id": "socket-config", "echoed": frame["ops"]}
+
+    async def _inner():
+        async with FakeDaemon(sock, responder) as daemon:
+            transport = AsyncSocketTransport(sock)
+            response = await transport.round_trip(
+                {"ops": "stats()", "protocol_version": PROTOCOL_VERSION}, timeout=5.0
+            )
+            return response, daemon.requests
+
+    response, requests = _run(_inner())
+    assert response["echoed"] == "stats()"
+    assert requests[0]["ops"] == "stats()"
+
+
+def test_session_drives_the_real_socket_end_to_end(tmp_path):
+    sock = tmp_path / "khived.sock"
+
+    def responder(frame):
+        if frame.get("metrics_only"):
+            return {"ok": True, "served_config_id": "socket-config"}
+        return {"ok": True, "served_config_id": "socket-config", "result": json.dumps(RESULTS)}
+
+    async def _inner():
+        async with FakeDaemon(sock, responder):
+            session = AsyncSession(AsyncSocketTransport(sock))
+            return await session.arequest("stats()")
+
+    assert _run(_inner()) == RESULTS["results"]
+
+
+def test_oversized_request_frame_is_refused_before_any_connection(tmp_path):
+    # No server is started: the cap must reject before the socket is touched, so
+    # a connection error here would mean the check runs too late.
+    transport = AsyncSocketTransport(tmp_path / "absent.sock")
+
+    async def _inner():
+        await transport.round_trip({"ops": "x" * (MAX_FRAME_BYTES + 1)}, timeout=5.0)
+
+    with pytest.raises(FrameTooLarge):
+        _run(_inner())


### PR DESCRIPTION
## What this adds

A caller already inside an event loop had no way to reach the local daemon without blocking its
thread. `AsyncHttpTransport` existed but speaks HTTP to a cloud deployment, and no session drove it,
so the unix socket had no awaited path at all.

- `AsyncSocketTransport` over `asyncio.open_unix_connection`, with the same 4-byte big-endian
  framing and the same 8 MiB cap enforced in both directions as the synchronous transport.
- `AsyncSession` with `arequest`, `ahandshake`, `ametrics`, `aclose` and `async with`.

## Why there is a third class

`Session` and `AsyncSession` both inherit `_SessionCore`, which holds the request path's non-IO
half: the frame builder, the version check, and the classification that decides which responses are
refusals and what a success decodes to.

That is the reason for the extra class rather than a second implementation. A refusal raised on one
path and absorbed on the other would be invisible to any test that exercises only one of them. So a
test asserts the two classes resolve to the same function objects, by identity:

```python
assert Session._decode_results is AsyncSession._decode_results
```

Adding a pass-through override that behaves identically makes that test fail while the nine
behavioural tests keep passing. That was run, not assumed: it is what a duplicated copy looks like on
the day before it drifts, and the behavioural tests alone do not see it.

## Tests

Ten new tests. The transport is exercised against a real `asyncio` unix socket server speaking the
daemon's framing, because a stub cannot cover length prefixes, partial reads, or the cap. The session
is exercised through a stub whose synchronous mirror returns the same responses in the same order, so
a divergence between the two drivers can only come from the drivers.

The oversized-frame test starts no server: the cap has to reject before the socket is touched, so a
connection error there would mean the check runs too late.

`asyncio.run` per test, matching the existing async transport tests; no async pytest plugin is a dev
dependency.

## Scope

`plan()` keeps its own near-copy of the same classification. It is untouched here and the shared
helper does not govern it, stated so nobody later assumes otherwise.

Local socket only. The cloud transport is already awaitable, and a session accepting either would
have to reconcile two lifecycles, since one closes nothing and an HTTP client must be closed.
