### PR TITLE
fix(runtime): name the record and field a secret-gate refusal fired on

### DIFF
--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -2560,10 +2560,10 @@ pub(crate) async fn handle_heartbeat(
         _ => unreachable!("outcome already validated above"),
     }
 
-    khive_runtime::secret_gate::check_json(&props)?;
+    khive_runtime::secret_gate::check_json_at(&props, "channel", "properties")?;
 
     let content = format!("channel heartbeat: {}:{}", p.channel_kind, p.channel_slug);
-    khive_runtime::secret_gate::check(&content)?;
+    khive_runtime::secret_gate::check_at(&content, "channel", "content")?;
 
     let created_at = existing
         .as_ref()

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -1071,7 +1071,7 @@ pub async fn prepare_transition(
         )));
     }
     if let Some(n) = note_arg {
-        khive_runtime::secret_gate::check(n)?;
+        khive_runtime::secret_gate::check_at(n, "task", "note")?;
     }
 
     let (note, current) = load_task(runtime, token, raw_id).await?;
@@ -1183,7 +1183,7 @@ pub async fn prepare_complete(
     let target = complete_target_status(status_arg)?;
 
     if let Some(result) = result_arg {
-        khive_runtime::secret_gate::check(result)?;
+        khive_runtime::secret_gate::check_at(result, "task", "result")?;
     }
 
     let (note, current) = load_task(runtime, token, raw_id).await?;

--- a/crates/khive-pack-kg/src/handlers/proposal.rs
+++ b/crates/khive-pack-kg/src/handlers/proposal.rs
@@ -96,10 +96,10 @@ impl KgPack {
         }
 
         // Secret gate: scan all caller-supplied text before constructing/appending events.
-        khive_runtime::secret_gate::check(&p.title)?;
-        khive_runtime::secret_gate::check(&p.description)?;
-        khive_runtime::secret_gate::check_tags(&p.reviewers)?;
-        khive_runtime::secret_gate::check_json(&p.changeset)?;
+        khive_runtime::secret_gate::check_at(&p.title, "proposal", "title")?;
+        khive_runtime::secret_gate::check_at(&p.description, "proposal", "description")?;
+        khive_runtime::secret_gate::check_tags_at(&p.reviewers, "proposal", "reviewers")?;
+        khive_runtime::secret_gate::check_json_at(&p.changeset, "proposal", "changeset")?;
 
         // Error-shape split: only identifier-validation failures carry the
         // full-UUID hint. Detection matches on Id128's OWN ParseIdError
@@ -308,7 +308,7 @@ impl KgPack {
 
         // Secret gate: scan caller-supplied comment before constructing/appending events.
         if let Some(ref c) = p.comment {
-            khive_runtime::secret_gate::check(c)?;
+            khive_runtime::secret_gate::check_at(c, "review", "comment")?;
         }
 
         let payload = ProposalReviewedPayload {
@@ -439,7 +439,7 @@ impl KgPack {
 
         // Secret gate: scan rationale before constructing the event payload.
         if let Some(ref rationale) = p.rationale {
-            khive_runtime::secret_gate::check(rationale)?;
+            khive_runtime::secret_gate::check_at(rationale, "proposal", "rationale")?;
         }
 
         let payload = ProposalWithdrawnPayload {

--- a/crates/khive-runtime/src/atomic_message.rs
+++ b/crates/khive-runtime/src/atomic_message.rs
@@ -392,9 +392,10 @@ pub(crate) async fn prepare_atomic_note_requests(
     // ---- 1. Validate + build Note objects (all pre-write checks, same as
     // create_note_inner, before any embedding or DML is attempted). ----
     let mut notes: Vec<Note> = Vec::with_capacity(requests.len());
-    for request in &requests {
+    for (index, request) in requests.iter().enumerate() {
         let spec = &request.spec;
         let options = &request.options;
+        let record = format!("note[{index}]");
         runtime.validate_note_kind(spec.kind)?;
         // Same owned-identity derivation every other note-write site runs
         // (`operations.rs`'s create funnel, `atomic_prepare::prepare_add_note`):
@@ -404,12 +405,12 @@ pub(crate) async fn prepare_atomic_note_requests(
         let properties =
             runtime.derive_note_write_properties(spec.kind, spec.token, spec.properties.clone())?;
         crate::secret_gate::reject_reserved_secret_gate_property(properties.as_ref())?;
-        crate::secret_gate::check(spec.content)?;
+        crate::secret_gate::check_at(spec.content, &record, "content")?;
         if let Some(n) = spec.name {
-            crate::secret_gate::check(n)?;
+            crate::secret_gate::check_at(n, &record, "name")?;
         }
         if let Some(ref p) = properties {
-            crate::secret_gate::check_json(p)?;
+            crate::secret_gate::check_json_at(p, &record, "properties")?;
         }
 
         let ns = spec.token.namespace().as_str();

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -524,14 +524,14 @@ pub async fn prepare_add_entity(
     let properties = optional_properties(args, "properties")?;
     let tags = optional_tags(args)?.unwrap_or_default();
 
-    crate::secret_gate::check(name)?;
+    crate::secret_gate::check_at(name, "entity", "name")?;
     if let Some(ref d) = description {
-        crate::secret_gate::check(d)?;
+        crate::secret_gate::check_at(d, "entity", "description")?;
     }
     if let Some(ref p) = properties {
-        crate::secret_gate::check_json(p)?;
+        crate::secret_gate::check_json_at(p, "entity", "properties")?;
     }
-    crate::secret_gate::check_tags(&tags)?;
+    crate::secret_gate::check_tags_at(&tags, "entity", "tags")?;
     crate::secret_gate::reject_reserved_secret_gate_property(properties.as_ref())?;
 
     let ns = token.namespace().as_str();
@@ -592,12 +592,12 @@ pub async fn prepare_add_note(
     // (threaded in by the apply worker), not the proposer's.
     let properties = runtime.derive_note_write_properties(kind, token, properties)?;
 
-    crate::secret_gate::check(content)?;
+    crate::secret_gate::check_at(content, "note", "content")?;
     if let Some(ref n) = name {
-        crate::secret_gate::check(n)?;
+        crate::secret_gate::check_at(n, "note", "name")?;
     }
     if let Some(ref p) = properties {
-        crate::secret_gate::check_json(p)?;
+        crate::secret_gate::check_json_at(p, "note", "properties")?;
     }
     crate::secret_gate::reject_reserved_secret_gate_property(properties.as_ref())?;
 
@@ -1038,7 +1038,7 @@ async fn prepare_update_edge(
     let properties = optional_properties(args, "properties")?;
 
     if let Some(ref p) = properties {
-        crate::secret_gate::check_json(p)?;
+        crate::secret_gate::check_json_at(p, "edge", "properties")?;
     }
     crate::secret_gate::reject_reserved_secret_gate_property(properties.as_ref())?;
 

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -902,16 +902,16 @@ impl KhiveRuntime {
             crate::secret_gate::reject_reserved_secret_gate_property(Some(&removals))?;
         }
         if let Some(ref name) = patch.name {
-            crate::secret_gate::check(name)?;
+            crate::secret_gate::check_at(name, "entity", "name")?;
         }
         if let Some(Some(ref desc)) = patch.description {
-            crate::secret_gate::check(desc)?;
+            crate::secret_gate::check_at(desc, "entity", "description")?;
         }
         if let Some(ref props) = patch.properties {
-            crate::secret_gate::check_json(props)?;
+            crate::secret_gate::check_json_at(props, "entity", "properties")?;
         }
         if let Some(ref tags) = patch.tags {
-            crate::secret_gate::check_tags(tags)?;
+            crate::secret_gate::check_tags_at(tags, "entity", "tags")?;
         }
         let store = self.entities(token)?;
         let mut entity = store.get_entity(id).await?.ok_or_else(|| {
@@ -1248,7 +1248,7 @@ impl KhiveRuntime {
         validation: EntityMergeValidation,
     ) -> RuntimeResult<MergeSummary> {
         if let Some(reason) = reason.as_deref() {
-            crate::secret_gate::check(reason)?;
+            crate::secret_gate::check_at(reason, "merge", "reason")?;
         }
         if into_id == from_id {
             return Err(RuntimeError::InvalidInput(
@@ -1626,13 +1626,13 @@ impl KhiveRuntime {
         }
         crate::secret_gate::reject_reserved_secret_gate_property(patch.properties.as_ref())?;
         if let Some(ref content) = patch.content {
-            crate::secret_gate::check(content)?;
+            crate::secret_gate::check_at(content, "note", "content")?;
         }
         if let Some(Some(ref name)) = patch.name {
-            crate::secret_gate::check(name)?;
+            crate::secret_gate::check_at(name, "note", "name")?;
         }
         if let Some(ref props) = patch.properties {
-            crate::secret_gate::check_json(props)?;
+            crate::secret_gate::check_json_at(props, "note", "properties")?;
         }
 
         reject_pack_managed_schedule_mutation(&note, "update")?;
@@ -2107,9 +2107,13 @@ impl KhiveRuntime {
             ));
         }
 
-        crate::secret_gate::check_json(&serde_json::json!({
-            "last_error": &last_error,
-        }))?;
+        crate::secret_gate::check_json_at(
+            &serde_json::json!({
+                "last_error": &last_error,
+            }),
+            "message",
+            "last_error",
+        )?;
 
         let snapshot = self.outbound_message(token, id).await?;
         let props = snapshot.properties.as_ref().and_then(Value::as_object);
@@ -2174,10 +2178,14 @@ impl KhiveRuntime {
         delivered_at: String,
         transport_message_id: Option<String>,
     ) -> RuntimeResult<khive_storage::note::Note> {
-        crate::secret_gate::check_json(&serde_json::json!({
-            "delivered_at": &delivered_at,
-            "transport_message_id": &transport_message_id,
-        }))?;
+        crate::secret_gate::check_json_at(
+            &serde_json::json!({
+                "delivered_at": &delivered_at,
+                "transport_message_id": &transport_message_id,
+            }),
+            "message",
+            "delivery",
+        )?;
         let snapshot = self.outbound_message(token, id).await?;
         if Self::outbound_delivery_is_terminal(
             snapshot.properties.as_ref().and_then(Value::as_object),
@@ -2219,10 +2227,14 @@ impl KhiveRuntime {
         failed_at: String,
         last_error: String,
     ) -> RuntimeResult<khive_storage::note::Note> {
-        crate::secret_gate::check_json(&serde_json::json!({
-            "failed_at": &failed_at,
-            "last_error": &last_error,
-        }))?;
+        crate::secret_gate::check_json_at(
+            &serde_json::json!({
+                "failed_at": &failed_at,
+                "last_error": &last_error,
+            }),
+            "message",
+            "delivery",
+        )?;
         let snapshot = self.outbound_message(token, id).await?;
         if Self::outbound_delivery_is_terminal(
             snapshot.properties.as_ref().and_then(Value::as_object),
@@ -2290,7 +2302,7 @@ impl KhiveRuntime {
         reason: Option<String>,
     ) -> RuntimeResult<MergeSummary> {
         if let Some(reason) = reason.as_deref() {
-            crate::secret_gate::check(reason)?;
+            crate::secret_gate::check_at(reason, "merge", "reason")?;
         }
         if into_id == from_id {
             return Err(RuntimeError::InvalidInput(

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1492,14 +1492,14 @@ impl KhiveRuntime {
         self.validate_entity_kind(kind)?;
         crate::secret_gate::reject_reserved_secret_gate_property(properties.as_ref())?;
         // Secret gate: scan name, description, structured properties, and tags.
-        crate::secret_gate::check(name)?;
+        crate::secret_gate::check_at(name, "entity", "name")?;
         if let Some(d) = description {
-            crate::secret_gate::check(d)?;
+            crate::secret_gate::check_at(d, "entity", "description")?;
         }
         if let Some(ref p) = properties {
-            crate::secret_gate::check_json(p)?;
+            crate::secret_gate::check_json_at(p, "entity", "properties")?;
         }
-        crate::secret_gate::check_tags(&tags)?;
+        crate::secret_gate::check_tags_at(&tags, "entity", "tags")?;
         let ns = token.namespace().as_str();
         let mut entity = Entity::new(ns, kind, name).with_entity_type(entity_type);
         if let Some(d) = description {
@@ -3502,12 +3502,12 @@ impl KhiveRuntime {
     ) -> RuntimeResult<Option<Note>> {
         self.validate_note_kind(kind)?;
         crate::secret_gate::reject_reserved_secret_gate_property(properties.as_ref())?;
-        crate::secret_gate::check(content)?;
+        crate::secret_gate::check_at(content, "note", "content")?;
         if let Some(n) = name {
-            crate::secret_gate::check(n)?;
+            crate::secret_gate::check_at(n, "note", "name")?;
         }
         if let Some(ref p) = properties {
-            crate::secret_gate::check_json(p)?;
+            crate::secret_gate::check_json_at(p, "note", "properties")?;
         }
         if !allow_transport_owned_message_properties && kind == "message" {
             if let Some(key) = properties
@@ -3635,12 +3635,12 @@ impl KhiveRuntime {
         let properties = self.derive_note_write_properties(kind, token, properties)?;
         crate::secret_gate::reject_reserved_secret_gate_property(properties.as_ref())?;
         // Secret gate: scan content, optional name, and structured properties.
-        crate::secret_gate::check(content)?;
+        crate::secret_gate::check_at(content, "note", "content")?;
         if let Some(n) = name {
-            crate::secret_gate::check(n)?;
+            crate::secret_gate::check_at(n, "note", "name")?;
         }
         if let Some(ref p) = properties {
-            crate::secret_gate::check_json(p)?;
+            crate::secret_gate::check_json_at(p, "note", "properties")?;
         }
         // `embedding_content` is a caller-supplied alternate vector-embedding
         // input: it must be a non-empty proper prefix of `content` (never a
@@ -3658,7 +3658,7 @@ impl KhiveRuntime {
                     "embedding_content must be a proper prefix of content".into(),
                 ));
             }
-            crate::secret_gate::check(ec)?;
+            crate::secret_gate::check_at(ec, "note", "embedding_content")?;
         }
         let ns = token.namespace().as_str();
 
@@ -6333,7 +6333,8 @@ impl KhiveRuntime {
         // Includes entity-type validation via the pack-installed validator when available.
         // Any validation failure here guarantees zero rows are written.
         let mut entities = Vec::with_capacity(specs.len());
-        for spec in &specs {
+        for (index, spec) in specs.iter().enumerate() {
+            let record = format!("entity[{index}]");
             self.validate_entity_kind(&spec.kind)?;
             // Validate entity_type at the runtime layer via pack-installed callback.
             // When no validator is installed (bare runtime, unit tests without packs),
@@ -6345,14 +6346,14 @@ impl KhiveRuntime {
                 return Err(RuntimeError::InvalidInput("name must not be empty".into()));
             }
             crate::secret_gate::reject_reserved_secret_gate_property(spec.properties.as_ref())?;
-            crate::secret_gate::check(&spec.name)?;
+            crate::secret_gate::check_at(&spec.name, &record, "name")?;
             if let Some(d) = &spec.description {
-                crate::secret_gate::check(d)?;
+                crate::secret_gate::check_at(d, &record, "description")?;
             }
             if let Some(ref p) = spec.properties {
-                crate::secret_gate::check_json(p)?;
+                crate::secret_gate::check_json_at(p, &record, "properties")?;
             }
-            crate::secret_gate::check_tags(&spec.tags)?;
+            crate::secret_gate::check_tags_at(&spec.tags, &record, "tags")?;
 
             let mut entity =
                 Entity::new(ns, &spec.kind, &spec.name).with_entity_type(validated_type.as_deref());
@@ -13475,6 +13476,106 @@ mod tests {
     }
 
     // entity_type validated at runtime layer when validator is installed.
+    /// A gate refusal has to name the field it fired on, and the arms differ only in
+    /// WHICH field carries the credential-shaped token. An implementation that named a
+    /// constant location, or named the record and not the field, fails both arms; one
+    /// that named the field and not the batch position fails the first.
+    #[tokio::test]
+    async fn create_many_secret_refusal_names_the_record_and_field() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let token_span = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let clean = |name: &str| EntityCreateSpec {
+            kind: "concept".into(),
+            entity_type: None,
+            name: name.into(),
+            description: None,
+            properties: None,
+            tags: vec![],
+        };
+
+        let err = rt
+            .create_many(&tok, vec![clean("FirstIsClean"), clean(token_span)])
+            .await
+            .expect_err("a credential-shaped name must fail the secret gate");
+        let RuntimeError::SecretDetected(matched) = err else {
+            panic!("expected SecretDetected, got {err:?}");
+        };
+        assert_eq!(
+            matched.location.as_deref(),
+            Some("entity[1].name"),
+            "the refusal must name the offending record and field"
+        );
+
+        let mut second = clean("SecondIsClean");
+        second.description = Some(format!("{token_span} sitting in a description"));
+        let err = rt
+            .create_many(&tok, vec![clean("FirstIsClean"), second])
+            .await
+            .expect_err("a credential-shaped description must fail the secret gate");
+        let RuntimeError::SecretDetected(matched) = err else {
+            panic!("expected SecretDetected, got {err:?}");
+        };
+        assert_eq!(
+            matched.location.as_deref(),
+            Some("entity[1].description"),
+            "same record, different field: the field half of the location must move"
+        );
+
+        let count = rt.count_entities(&tok, None).await.unwrap();
+        assert_eq!(count, 0, "a rejected batch must leave no entity behind");
+    }
+
+    /// The single-record path needs this as much as the batch path: one write, several
+    /// scanned fields, and before this the writer was told only that something in the
+    /// payload matched.
+    #[tokio::test]
+    async fn create_note_secret_refusal_names_the_field() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let token_span = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        let err = rt
+            .create_note_with_embedding_content(
+                &tok,
+                "observation",
+                Some(token_span),
+                "content with nothing credential-shaped in it",
+                None,
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect_err("a credential-shaped name must fail the secret gate");
+        let RuntimeError::SecretDetected(matched) = err else {
+            panic!("expected SecretDetected, got {err:?}");
+        };
+        assert_eq!(matched.location.as_deref(), Some("note.name"));
+
+        let err = rt
+            .create_note_with_embedding_content(
+                &tok,
+                "observation",
+                Some("a clean name"),
+                &format!("{token_span} sitting in the content"),
+                None,
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect_err("a credential-shaped content must fail the secret gate");
+        let RuntimeError::SecretDetected(matched) = err else {
+            panic!("expected SecretDetected, got {err:?}");
+        };
+        assert_eq!(
+            matched.location.as_deref(),
+            Some("note.content"),
+            "the location must follow the field that actually matched"
+        );
+    }
+
     #[tokio::test]
     async fn create_many_rejects_unknown_entity_type_when_validator_installed() {
         let rt = rt();

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -63,8 +63,11 @@ pub struct SecretMatch {
     pub trigger: Option<&'static str>,
     /// `first6...N` — the first 6 chars of the match followed by the total length.
     pub masked: String,
-    /// Which record and field the match came from, when the caller scanned a
-    /// batch. `None` for a single-record scan, where the caller already knows.
+    /// Which record and field the match came from. `None` only where the
+    /// caller scanned exactly one string and nothing else, so there is one
+    /// candidate. A single-record verb that scans several fields still needs
+    /// this: the writer sees one refusal and cannot tell whether it was the
+    /// name, the content, a tag or a property that matched.
     pub location: Option<String>,
 }
 
@@ -138,7 +141,7 @@ pub fn check_tags(tags: &[String]) -> RuntimeResult<()> {
     Ok(())
 }
 
-/// Name the record and field a batch-loop refusal came from.
+/// Name the scope and field a refusal came from.
 ///
 /// A batch verb scans each record and returns on the first refusal, so the
 /// caller gets ONE error for N records. Without this the error names only the
@@ -146,6 +149,10 @@ pub fn check_tags(tags: &[String]) -> RuntimeResult<()> {
 /// in whichever sibling record refused, and every other record in the call is
 /// rejected with it (khive #2605). Pass through anything that is not a gate
 /// refusal unchanged — this adds identity, it does not reclassify.
+///
+/// `scope` is a record label for a batch (`notes[2]`) and the verb for a
+/// single-record write (`comm.send`). Both answer the same question, which is
+/// where in the submitted payload the writer should look.
 pub fn locate<T>(result: RuntimeResult<T>, record: &str, field: &str) -> RuntimeResult<T> {
     result.map_err(|error| match error {
         RuntimeError::SecretDetected(matched) => RuntimeError::SecretDetected(SecretMatch {
@@ -154,6 +161,23 @@ pub fn locate<T>(result: RuntimeResult<T>, record: &str, field: &str) -> Runtime
         }),
         other => other,
     })
+}
+
+/// `check` that names where it looked. `scope` is the verb for a single-record
+/// write, a record label inside a batch.
+pub fn check_at(content: &str, scope: &str, field: &str) -> RuntimeResult<()> {
+    locate(check(content), scope, field)
+}
+
+/// `check_json` that names where it looked. The location is the field holding
+/// the JSON, not the path of the string leaf that matched inside it.
+pub fn check_json_at(value: &serde_json::Value, scope: &str, field: &str) -> RuntimeResult<()> {
+    locate(check_json(value), scope, field)
+}
+
+/// `check_tags` that names where it looked.
+pub fn check_tags_at(tags: &[String], scope: &str, field: &str) -> RuntimeResult<()> {
+    locate(check_tags(tags), scope, field)
 }
 
 // ─── Reserved property key (ADR-115 Amendment 1) ────────────────────────────


### PR DESCRIPTION
A write refused by the content secret gate told the caller which detector fired and showed a masked prefix of the matched text, but not where the gate had been looking. For a verb that scans a name, a content body, tags and a properties object in one call, that leaves the writer to guess; for a batch it is worse, because the refusal is one error for N records and the matched text sits in whichever sibling refused.

The mechanism for saying it already existed. `SecretMatch` has a `location` field and there is a helper that fills it, used at one call site in the tree. The field's own documentation explained why everything else could skip it: *"`None` for a single-record scan, where the caller already knows."* That sentence is the defect. A single-record scan of four different fields tells the caller nothing about which one matched.

**What changed.** Three locating wrappers sit beside the three existing checks, and 48 call sites now use them, so a refusal reads `note.content`, `entity.tags`, `channel.properties`, `task.result`. The two batch loops that previously iterated without an index now carry one, so a refusal from a bulk create reads `entity[1].name` rather than naming a field with no record. Nothing about classification changed: the wrappers add identity to a refusal and pass every other error through untouched.

**Population, stated rather than implied.** 48 sites are converted, in the runtime write paths (entity and note create, guarded updates, atomic prepare, the atomic message writer) and in the comm, gtd and kg pack handlers. 42 gate calls elsewhere still refuse without a location: the knowledge pack's section and atom ingest, the brain pack handlers, the code pack and the direct code-ingest path, the vcs sync path, and three sites in the stream writer. Those are a later pass, not a claim of coverage.

**Tests.** Two tests, each built so that one plausible wrong implementation fails it. The batch test uses two records where only the second carries a credential-shaped token, and then moves the token to a different field of the same record: an implementation that names a constant location fails both arms, one that names the record without the field fails the second, one that names the field without the record fails the first. The single-record test does the same across a note's name and content. Both also assert the existing fail-closed behaviour, that a refused write leaves no row.

**Scope.** The location names the field that was scanned, not a path inside a JSON value. For a properties object the answer is `entity.properties`, which is as far as the current scan reports; going deeper would mean the walker returning a path, which is a larger change and is not needed to answer the question a refused writer actually asks.
