### PR TITLE
feat(gtd): let the caller name the due date's timezone, and echo it back

### DIFF
--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -190,6 +190,11 @@ struct AssignParams {
     status: Option<String>,
     #[serde(default)]
     due: Option<String>,
+    /// IANA zone the date-only `due` anchors in; absent means the configured
+    /// display timezone. Both task entry points read it, or the two would
+    /// disagree about which zone a deadline means.
+    #[serde(default)]
+    timezone: Option<String>,
     #[serde(default)]
     start: Option<String>,
     #[serde(default)]
@@ -1255,6 +1260,7 @@ impl GtdPack {
             priority: p.priority,
             status: p.status,
             due: p.due,
+            timezone: p.timezone,
             start: p.start,
             end: p.end,
             depends_on: p.depends_on,

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -475,6 +475,11 @@ pub fn render_task(note: &khive_storage::note::Note) -> Value {
         .to_string();
     let assignee = props.get("assignee").cloned().unwrap_or(Value::Null);
     let due = props.get("due").cloned().unwrap_or(Value::Null);
+    // The zone the deadline was anchored in travels with the deadline. Storing it
+    // and not projecting it would leave a reader with the same unreadable instant
+    // the argument exists to fix, so the write path and this projection have to
+    // agree or neither is worth having.
+    let due_timezone = props.get("due_timezone").cloned().unwrap_or(Value::Null);
     let context_entity_id = props
         .get("context_entity_id")
         .cloned()
@@ -489,6 +494,7 @@ pub fn render_task(note: &khive_storage::note::Note) -> Value {
         "priority": priority,
         "assignee": assignee,
         "due": due,
+        "due_timezone": due_timezone,
         "context_entity_id": context_entity_id,
         "namespace": note.namespace,
         "created_at": ts_to_rfc(note.created_at),
@@ -1782,6 +1788,7 @@ impl GtdPack {
             "priority": task["priority"],
             "assignee": task["assignee"],
             "due": task["due"],
+            "due_timezone": task["due_timezone"],
             "audit_persisted": audit_persisted,
         }))
     }

--- a/crates/khive-pack-gtd/src/task_create.rs
+++ b/crates/khive-pack-gtd/src/task_create.rs
@@ -35,6 +35,10 @@ pub(crate) struct TaskCreateInput {
     pub(crate) priority: Option<String>,
     pub(crate) status: Option<String>,
     pub(crate) due: Option<String>,
+    /// IANA zone the date-only `due` is anchored in. Absent means the server's
+    /// configured display timezone, which is one process-wide value serving every
+    /// caller, so it cannot be right for two callers in different zones at once.
+    pub(crate) timezone: Option<String>,
     pub(crate) start: Option<String>,
     pub(crate) end: Option<String>,
     pub(crate) depends_on: Option<Vec<String>>,
@@ -128,6 +132,9 @@ impl TaskCreateInput {
             "due",
             "properties.due",
         )?);
+        let timezone = optional_string_field(args, "timezone", "timezone")?.or(
+            optional_string_field(&properties, "timezone", "properties.timezone")?,
+        );
         let start = optional_string_field(args, "start", "start")?.or(optional_string_field(
             &properties,
             "start",
@@ -163,6 +170,7 @@ impl TaskCreateInput {
                 "priority",
                 "status",
                 "due",
+                "timezone",
                 "start",
                 "end",
                 "depends_on",
@@ -182,6 +190,7 @@ impl TaskCreateInput {
             priority,
             status,
             due,
+            timezone,
             start,
             end,
             depends_on,
@@ -380,10 +389,22 @@ pub(crate) async fn prepare_task_create(
         obj.insert("assignee".into(), json!(assignee));
     }
     if let Some(ref due) = input.due {
-        obj.insert(
-            "due".into(),
-            json!(parse_due(due, runtime.config().display_timezone)?),
-        );
+        // The zone a deadline is anchored in is a property of whose deadline it is,
+        // and the runtime does not know whose. The configured display timezone is a
+        // fact about the host, which is the wrong shape for a process serving many
+        // callers, so the caller may name the zone and the answer echoes which one
+        // was used: without the echo a defaulted anchor and a caller-supplied one
+        // are byte-identical in the record and the ambiguity just moves to the reader.
+        let zone = match input.timezone.as_deref() {
+            None => runtime.config().display_timezone,
+            Some(name) => name.parse::<chrono_tz::Tz>().map_err(|_| {
+                RuntimeError::InvalidInput(format!(
+                    "timezone must be an IANA zone name (e.g. \"America/New_York\"); got {name:?}"
+                ))
+            })?,
+        };
+        obj.insert("due".into(), json!(parse_due(due, zone)?));
+        obj.insert("due_timezone".into(), json!(zone.name()));
     }
     if let Some(ref start) = input.start {
         obj.insert("start".into(), json!(start));

--- a/crates/khive-pack-gtd/src/vocab.rs
+++ b/crates/khive-pack-gtd/src/vocab.rs
@@ -141,7 +141,17 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 name: "due",
                 param_type: "string",
                 required: false,
-                description: "Due date (ISO-8601).",
+                description: "Due date (ISO-8601). A date-only value is anchored to the earliest \
+                              instant of that local date in `timezone`.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+            ParamDef {
+                name: "timezone",
+                param_type: "string",
+                required: false,
+                description: "IANA zone name (e.g. \"America/New_York\") the date-only `due` is \
+                              anchored in. Defaults to the server's configured display timezone. \
+                              The zone actually used is echoed back as `due_timezone`.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {

--- a/crates/khive-pack-gtd/tests/assign.rs
+++ b/crates/khive-pack-gtd/tests/assign.rs
@@ -380,7 +380,10 @@ async fn the_echo_is_present_when_the_caller_named_no_zone() {
     // a reader still could not tell a deliberate anchor from a fallen-back one.
     let pack = pack(rt());
     let resp = pack
-        .dispatch("gtd.assign", json!({"title": "unzoned due", "due": "2026-06-01"}))
+        .dispatch(
+            "gtd.assign",
+            json!({"title": "unzoned due", "due": "2026-06-01"}),
+        )
         .await
         .expect("a due with no timezone must still be accepted");
     let echoed = resp["due_timezone"]

--- a/crates/khive-pack-gtd/tests/assign.rs
+++ b/crates/khive-pack-gtd/tests/assign.rs
@@ -338,3 +338,87 @@ async fn assign_due_natural_language_rejected() {
         "expected ISO-8601 error; got: {msg}"
     );
 }
+
+// The zone a deadline is anchored in is a property of whose deadline it is, and
+// the configured display timezone is one process-wide value serving every caller.
+// A caller may name the zone; the answer always echoes the one that was used.
+
+#[tokio::test]
+async fn a_caller_supplied_timezone_anchors_the_date_and_is_echoed() {
+    let pack = pack(rt());
+    let resp = pack
+        .dispatch(
+            "gtd.assign",
+            json!({"title": "zoned due", "due": "2026-06-01", "timezone": "America/New_York"}),
+        )
+        .await
+        .expect("a caller-supplied IANA zone must be accepted");
+
+    assert_eq!(
+        resp["due_timezone"].as_str(),
+        Some("America/New_York"),
+        "the answer must say which zone it anchored in"
+    );
+    let due = resp["due"].as_str().expect("due must be a string");
+    let parsed = chrono::DateTime::parse_from_rfc3339(due)
+        .unwrap_or_else(|e| panic!("due not RFC 3339: {due} - {e}"));
+    // Read the calendar date in the named zone, never after converting to UTC:
+    // the whole point is that the caller's date survives.
+    assert_eq!(
+        parsed
+            .with_timezone(&"America/New_York".parse::<chrono_tz::Tz>().unwrap())
+            .date_naive(),
+        chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+        "got {due}"
+    );
+}
+
+#[tokio::test]
+async fn the_echo_is_present_when_the_caller_named_no_zone() {
+    // This is the arm that makes the echo useful. If the field only appeared when
+    // the caller supplied a zone, the defaulted case would be an absence again and
+    // a reader still could not tell a deliberate anchor from a fallen-back one.
+    let pack = pack(rt());
+    let resp = pack
+        .dispatch("gtd.assign", json!({"title": "unzoned due", "due": "2026-06-01"}))
+        .await
+        .expect("a due with no timezone must still be accepted");
+    let echoed = resp["due_timezone"]
+        .as_str()
+        .expect("the echo must be present on the defaulted path too");
+    echoed
+        .parse::<chrono_tz::Tz>()
+        .unwrap_or_else(|_| panic!("the echo must be a resolvable IANA zone, got {echoed}"));
+}
+
+#[tokio::test]
+async fn an_unknown_timezone_is_refused_and_names_the_value() {
+    let pack = pack(rt());
+    let error = pack
+        .dispatch(
+            "gtd.assign",
+            json!({"title": "bad zone", "due": "2026-06-01", "timezone": "Mars/Olympus"}),
+        )
+        .await
+        .expect_err("an unresolvable zone must be refused, not silently defaulted");
+    let message = error.to_string();
+    assert!(
+        message.contains("Mars/Olympus") && message.contains("timezone"),
+        "the refusal must name the parameter and the value: {message}"
+    );
+}
+
+#[tokio::test]
+async fn no_due_means_no_echo() {
+    // The echo describes a deadline. A task without one must not grow a field
+    // implying it has a deadline anchored somewhere.
+    let pack = pack(rt());
+    let resp = pack
+        .dispatch("gtd.assign", json!({"title": "no due at all"}))
+        .await
+        .expect("a task without a due must still be created");
+    assert!(
+        resp.get("due_timezone").is_none() || resp["due_timezone"].is_null(),
+        "got {resp}"
+    );
+}

--- a/docs/adr/ADR-169-timezone-correct-timestamps.md
+++ b/docs/adr/ADR-169-timezone-correct-timestamps.md
@@ -373,6 +373,33 @@ Sequencing: step 3 is the minimum that resolves the observed defect and can land
 rest. Steps 1 and 2 are its prerequisites. Step 4 closes D1's stated scope and should not lag
 step 3 by long, since until it lands D1 is true of one parser and not the other.
 
+## Amendment 1 (2026-09-12): the caller may name the zone, and the answer says which one was used
+
+D1 anchors a date-only `due` to the earliest instant of that local date in the configured
+display timezone. That resolution is unchanged. What this amendment adds is WHICH zone, because
+`display_timezone` is one `RuntimeConfig` field resolved once at construction and a single
+process serves callers in many zones. One value cannot be right for a caller in New York and a
+caller in Berlin at the same time, so configuring the host replaces UTC-for-everyone with one
+wrong zone for everyone. The zone a deadline is anchored in is a property of whose deadline it
+is, and the runtime does not know whose. The caller does.
+
+Task creation therefore takes an optional `timezone` argument, an IANA zone name, defaulting to
+the configured display timezone when absent. Nothing about D1's resolution within a zone
+changes, including the gap and ambiguous cases.
+
+The answer echoes the zone that was actually used, as `due_timezone`, and it is present whenever
+`due` is present rather than only when the caller named one. That is the load-bearing half of the
+amendment and the reason it is written down rather than left to the implementation: without the
+echo, a deadline anchored in a zone the caller chose and one anchored in whatever the host
+happened to be configured with are byte-identical in the stored record. The ambiguity the
+argument removes from the parse would reappear, unannounced, at every later reader. A field that
+appeared only on the caller-supplied path would leave the defaulted case an absence, which is the
+same defect wearing the opposite sign.
+
+An unresolvable zone name is refused with the value named. It is never silently defaulted: a
+caller that meant a zone and mistyped it would otherwise receive a correct-looking deadline
+anchored somewhere else.
+
 ## References
 
 - ADR-078: output format and shape-aware rendering.


### PR DESCRIPTION
A date-only `due` anchors to the earliest instant of that local date in the configured display timezone. That resolution is right and is unchanged here, including its gap and ambiguous cases. What was wrong is *which* zone.

`display_timezone` is a single `RuntimeConfig` field resolved once at construction, and one process serves callers in many zones. A single value cannot be right for a caller in New York and a caller in Berlin at the same time, so configuring the host does not fix anything: it replaces UTC-for-everyone with one wrong zone for everyone. The zone a deadline is anchored in is a property of whose deadline it is, and the runtime does not know whose. The caller does.

**The argument.** Task creation takes an optional `timezone`, an IANA zone name, defaulting to the configured display timezone when absent. Additive, so existing callers are unaffected. An unresolvable name is refused with the value named rather than silently defaulted, because a caller who meant a zone and mistyped it would otherwise receive a correct-looking deadline anchored somewhere else.

**The echo, which is the half that matters.** The answer reports the zone that was actually used, as `due_timezone`, and it is present whenever `due` is present, not only when the caller named one. Without it, a deadline anchored in a zone the caller chose and one anchored in whatever the host happened to be configured with are byte-identical in the stored record, so the ambiguity removed from the parse would reappear, unannounced, at every later reader. Emitting the field only on the caller-supplied path would leave the defaulted case an absence, which is the same defect with the sign flipped.

**Tests.** The named zone anchors the caller's calendar date, read in that zone rather than after converting to UTC, and is echoed. The echo is asserted present on the defaulted path, which is the arm that makes it useful. An unknown zone is refused naming the value. A task with no `due` grows no echo, so the field never implies a deadline that does not exist.

**Why the ADR amendment rides with the code.** The echo is the part a later reader will need the reason for, and the reason is not visible in the diff. Separating them would land the mechanism without the argument for it.
