### PR TITLE
fix(packs): write every published description for its caller, and gate it

### DIFF
--- a/crates/khive-pack-agent/src/pack.rs
+++ b/crates/khive-pack-agent/src/pack.rs
@@ -55,10 +55,12 @@ pub(crate) static AGENT_HANDLERS: [HandlerDef; 5] = [
             },
         ],
     },
+    // MAINTENANCE, deliberately kept out of the four descriptions below: the agent
+    // process lifecycle and its transition boundaries are specified in ADR-142 §1.
     HandlerDef {
         name: "agent.observe",
-        description: "Report an agent process record's current fields without changing state \
-                       (ADR-142 §1).",
+        description: "Report an agent process record's current fields without changing \
+                       state.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[ParamDef {
@@ -72,7 +74,7 @@ pub(crate) static AGENT_HANDLERS: [HandlerDef; 5] = [
     HandlerDef {
         name: "agent.suspend",
         description: "Transition a running agent process to suspended at a message-yield \
-                       boundary (ADR-142 §1).",
+                       boundary.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Directive,
         params: &[ParamDef {
@@ -85,7 +87,7 @@ pub(crate) static AGENT_HANDLERS: [HandlerDef; 5] = [
     },
     HandlerDef {
         name: "agent.resume",
-        description: "Transition a suspended agent process back to running (ADR-142 §1).",
+        description: "Transition a suspended agent process back to running.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Directive,
         params: &[ParamDef {
@@ -99,7 +101,7 @@ pub(crate) static AGENT_HANDLERS: [HandlerDef; 5] = [
     HandlerDef {
         name: "agent.kill",
         description: "Transition an agent process to terminal/killed; a no-op returning the \
-                       current state when already terminal (ADR-142 §1).",
+                       current state when already terminal.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Directive,
         params: &[ParamDef {

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -71,19 +71,22 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             resolution_mode: IdResolutionMode::NotApplicable,
         }],
     },
+    // MAINTENANCE, deliberately kept out of the description: the event plane is
+    // ADR-103 Stage 1 (#724 Ask A) and the cost_unit stamp is ADR-103 Amendment 1,
+    // landed in PR #927.
     HandlerDef {
         name: "brain.event_counts",
         description: "Windowed event counts grouped by kind, actor, and verb over the event \
-            plane (ADR-103 Stage 1, #724 Ask A); feedback_explicit events additionally split by \
+            plane; feedback_explicit events additionally split by \
             served_by_profile_id (by_profile), originating verb \
             (feedback_by_originating_verb), by signal (counts_by_signal), and by profile crossed \
             with signal (by_profile_and_signal, for per-seat negative-share); events \
             carrying a work_class (today: phase_started / \
             phase_completed / phase_cancelled payloads, checked before any future \
             payload.resource.work_class) split by counts_by_work_class. Events carrying \
-            payload.resource.cost_unit (ADR-103 Amendment 1; stamped on every successful verb \
-            dispatch since PR #927) sum into total_cost_unit and cost_unit_by_verb; events with \
-            no resource.cost_unit (pre-Amendment-1 events, or errored/denied dispatches) simply \
+            payload.resource.cost_unit (stamped on every successful verb dispatch) sum into \
+            total_cost_unit and cost_unit_by_verb; events with no resource.cost_unit (events \
+            older than that stamp, or errored/denied dispatches) simply \
             do not contribute. total_cost_unit is omitted, not zero-filled, when no event in the \
             window carries cost_unit. When truncated=true, every scalar total (total, \
             total_cost_unit) is over the fetched page only, same as the other counts_by_* \
@@ -291,7 +294,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 required: true,
                 description: "Complete UUID or globally unique 8+ hex prefix of the memory note \
                               or entity the feedback applies to. Prefix resolution is \
-                              namespace-unfiltered under ADR-007.",
+                              searches every namespace you can see.",
                 resolution_mode: IdResolutionMode::UnscopedById,
             },
             khive_types::ParamDef {
@@ -326,14 +329,16 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "scorer_run_id",
                 param_type: "string",
                 required: false,
-                description: "ADR-081: scorer pass identifier, half of the (scorer_run_id, serve_ledger_id) dedup key. Must be supplied together with serve_ledger_id.",
+                // MAINTENANCE, deliberately kept out of the description: ADR-081.
+                description: "Scorer pass identifier, half of the (scorer_run_id, serve_ledger_id) dedup key. Must be supplied together with serve_ledger_id.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
                 name: "serve_ledger_id",
                 param_type: "string",
                 required: false,
-                description: "ADR-081: id of the brain_serve_ledger row being graded. Must be supplied together with scorer_run_id; backfills the row's grade and gates dedup.",
+                // MAINTENANCE, deliberately kept out of the description: ADR-081.
+                description: "Id of the brain_serve_ledger row being graded. Must be supplied together with scorer_run_id; backfills the row's grade and gates dedup.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
         ],
@@ -342,8 +347,8 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
         name: "brain.auto_feedback",
         description: "Emit caller-attributed feedback for one recall result. Omitting signal \
             records no judgment and emits no feedback event; when signal is present, target_id must \
-            identify exactly one object in results. Keeps memory and brain packs decoupled \
-            (#517).",
+            identify exactly one object in results. Keeps memory and brain packs \
+            decoupled.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Commissive,
         params: &[
@@ -393,21 +398,25 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "scorer_run_id",
                 param_type: "string",
                 required: false,
-                description: "ADR-081: forwarded verbatim to brain.feedback. Must be supplied together with serve_ledger_id.",
+                // MAINTENANCE, deliberately kept out of the description: ADR-081.
+                description: "Forwarded verbatim to brain.feedback. Must be supplied together with serve_ledger_id.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
                 name: "serve_ledger_id",
                 param_type: "string",
                 required: false,
-                description: "ADR-081: forwarded verbatim to brain.feedback. Must be supplied together with scorer_run_id.",
+                // MAINTENANCE, deliberately kept out of the description: ADR-081.
+                description: "Forwarded verbatim to brain.feedback. Must be supplied together with scorer_run_id.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             khive_types::ParamDef {
                 name: "namespace",
                 param_type: "string",
                 required: false,
-                description: "Exact feedback namespace override (ADR-007 Rev 6 escape hatch). The event and posterior fold are scoped to exactly this namespace; the default namespace state is unchanged. Invalid values are rejected.",
+                // MAINTENANCE, deliberately kept out of the description: this is the
+                // ADR-007 Rev 6 escape hatch.
+                description: "Exact feedback namespace override. The event and posterior fold are scoped to exactly this namespace; the default namespace state is unchanged. Invalid values are rejected.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
         ],
@@ -457,6 +466,9 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             },
         ],
     },
+    // MAINTENANCE, deliberately kept out of the description: this reuses the existing
+    // ADR-103 Stage 1 PhaseStarted/work_class vocabulary rather than adding an EventKind
+    // variant, which is why the work_class is a payload value and not a kind.
     HandlerDef {
         name: "brain.mark_turn",
         description: "Emit a PhaseStarted event (work_class=\"actor_turn\") carrying the \
@@ -464,9 +476,8 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             callers invoke this once per bounded unit of work (a wake, a turn) so \
             brain.event_counts's counts_by_work_class[\"actor_turn\"], grouped by actor, \
             gives a discipline-ratio denominator (e.g. feedback_explicit / actor_turn) that \
-            is not biased toward whichever actor issues the most raw verb calls. Reuses the \
-            existing ADR-103 Stage 1 PhaseStarted/work_class vocabulary rather than a new \
-            EventKind variant. Best-effort — never fails the caller's turn.",
+            is not biased toward whichever actor issues the most raw verb calls. \
+            Best-effort — never fails the caller's turn.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Commissive,
         params: &[khive_types::ParamDef {

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -568,7 +568,10 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
     },
     HandlerDef {
         name: "comm.health",
-        description: "Read-only per-channel health snapshot (khive #606, #1383, #1472). Returns \
+        // MAINTENANCE, deliberately kept out of the description: the surface and its
+        // namespace resolution are specified in khive #606, #877, #917, #1383 and #1472,
+        // and the namespace escape hatch is ADR-007 Rev 6 Rule 3.
+        description: "Read-only per-channel health snapshot. Returns \
                        daemon-persisted heartbeat rows plus exact channel identities found on \
                        live quarantine notes. Every channel entry includes `quarantined_count`; \
                        the response also includes namespace-wide `quarantined_count` and \
@@ -583,15 +586,15 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
                        null for legacy/malformed rows and known failure/backoff state. This is \
                        not a computed healthy bool; overall \
                        health judgment belongs to the caller. Reads from the caller's injected \
-                       namespace (khive #877) — `token.namespace()`, the same explicit \
-                       `namespace=` escape / \"local\" default every other comm verb resolves \
-                       (ADR-007 Rev 6 Rule 3). An unscoped call defaults to \"local\", matching \
+                       namespace — `token.namespace()`, the same explicit \
+                       `namespace=` escape / \"local\" default every other comm verb \
+                       resolves. An unscoped call defaults to \"local\", matching \
                        the namespace heartbeat rows are persisted under; a call with an \
                        explicit non-local `namespace=` sees only that namespace's rows, never \
                        \"local\"'s. The response carries a `namespace` field naming the \
                        namespace actually read, so `role: \"client\"` means no heartbeat rows \
                        exist under THAT namespace (even if quarantine-only channels exist), not \
-                       necessarily that no daemon exists anywhere. `comm.heartbeat` (khive #917) \
+                       necessarily that no daemon exists anywhere. `comm.heartbeat` \
                        persists under the caller's dispatch-authorized namespace, so a \
                        non-local `namespace=` scope returns that namespace's rows once an \
                        authorized per-tenant writer has run. Without a heartbeat it may still \
@@ -601,6 +604,8 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
         category: khive_types::VerbCategory::Assertive,
         params: &[],
     },
+    // MAINTENANCE, deliberately kept out of the description: the explicit-actor
+    // requirement is khive #93 and the cursor_reset signal is khive #2400.
     HandlerDef {
         name: "comm.probe",
         description: "Read-only poll for new inbound message metadata and stale unread count. \
@@ -614,9 +619,9 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 14] = [
                       strictly older than the cutoff independently of the arrival cursor. Only \
                       JSON boolean true in properties.read marks a message read. \
                       Unlike comm.inbox, the actor is not inferred from the caller — pass it \
-                      explicitly via the required `actor` param (khive #93). A `since_us` the \
+                      explicitly via the required `actor` param. A `since_us` the \
                       store cannot have issued is discarded and the page comes from the \
-                      baseline; the response then carries `cursor_reset: true` (khive #2400).",
+                      baseline; the response then carries `cursor_reset: true`.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-gtd/src/vocab.rs
+++ b/crates/khive-pack-gtd/src/vocab.rs
@@ -180,7 +180,9 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 name: "limit",
                 param_type: "integer",
                 required: false,
-                description: "Maximum tasks to return (default 10, silently clamped to 200 — issue #744: a `limit` above 200 is capped without a separate signal in the response).",
+                // MAINTENANCE, deliberately kept out of the description: khive #744.
+                description: "Maximum tasks to return (default 10). A `limit` above 200 is \
+                              capped to 200 without a separate signal in the response.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
@@ -210,7 +212,9 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 name: "id",
                 param_type: "uuid",
                 required: true,
-                description: "Full UUID or unique 8+ hex prefix of the task to complete. By-ID resolution is namespace-agnostic (ADR-007).",
+                // MAINTENANCE, deliberately kept out of the description: ADR-007.
+                description: "Full UUID or unique 8+ hex prefix of the task to complete. \
+                              By-ID resolution is namespace-agnostic.",
                 resolution_mode: IdResolutionMode::UnscopedById,
             },
             ParamDef {
@@ -230,6 +234,8 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
         ],
     },
     // Assertive: retrieves filtered task listing
+    // MAINTENANCE, deliberately kept out of the description: the `filter_excluded`
+    // signal and the default-filter rule are khive #96.
     HandlerDef {
         name: "gtd.tasks",
         description: "List tasks filtered by status, assignee, priority. DEFAULT (no `status` \
@@ -239,7 +245,7 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                        status=\"cancelled\" explicitly to see completed/cancelled tasks — an \
                        empty result under the default filter does NOT mean the task doesn't \
                        exist; the response carries `filter_excluded` when the default filter \
-                       is the reason the result is empty (issue #96). Inspect legacy records \
+                       is the reason the result is empty. Inspect legacy records \
                        through list(kind=\"task\"); they are not silently rewritten.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
@@ -272,7 +278,9 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 name: "limit",
                 param_type: "integer",
                 required: false,
-                description: "Maximum results (default 20, silently clamped to 200 — issue #744: a `limit` above 200 is capped without a separate signal in the response).",
+                // MAINTENANCE, deliberately kept out of the description: khive #744.
+                description: "Maximum results (default 20). A `limit` above 200 is capped to \
+                              200 without a separate signal in the response.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
@@ -295,7 +303,9 @@ pub(crate) static GTD_HANDLERS: [HandlerDef; 5] = [
                 name: "id",
                 param_type: "uuid",
                 required: true,
-                description: "Full UUID or unique 8+ hex prefix of the task to transition. By-ID resolution is namespace-agnostic (ADR-007).",
+                // MAINTENANCE, deliberately kept out of the description: ADR-007.
+                description: "Full UUID or unique 8+ hex prefix of the task to transition. \
+                              By-ID resolution is namespace-agnostic.",
                 resolution_mode: IdResolutionMode::UnscopedById,
             },
             ParamDef {

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -70,7 +70,12 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
     // Commissive: commits an entity or note to the namespace
     HandlerDef {
         name: "create",
-        description: "Create an entity or note (singleton) or a batch of entities (bulk via `items`).",
+        description: "Create an entity or note (singleton) or a batch of entities (bulk via \
+                      `items`). When a new entity's name resembles one that already exists, the \
+                      response carries `similar_existing`. Read it before creating another: in \
+                      most cases the right next step is to link to what is already there rather \
+                      than add a near-duplicate. The field is absent when nothing similar was \
+                      found, and suppressed entirely by `skip_dedup_check`.",
         visibility: Visibility::Verb,
         category: VerbCategory::Commissive,
         params: &[

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -753,7 +753,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                 required: false,
                 description: "Required in singleton mode. Source node complete UUID or globally \
                               unique 8+ hex prefix. UUID \
-                              and prefix lookup are namespace-unfiltered under ADR-007; \
+                              and prefix lookup search every namespace you can see; \
                               entity-name fallback uses the primary namespace. Ignored when \
                               links is supplied.",
                 resolution_mode: IdResolutionMode::UnscopedById,
@@ -764,7 +764,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                 required: false,
                 description: "Required in singleton mode. Target node complete UUID or globally \
                               unique 8+ hex prefix. UUID \
-                              and prefix lookup are namespace-unfiltered under ADR-007; \
+                              and prefix lookup search every namespace you can see; \
                               entity-name fallback uses the primary namespace. Ignored when \
                               links is supplied.",
                 resolution_mode: IdResolutionMode::UnscopedById,
@@ -773,9 +773,17 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                 name: "relation",
                 param_type: "string",
                 required: false,
+                // MAINTENANCE, deliberately kept out of the description: the
+                // entity->entity table below is a hand-maintained mirror of
+                // `base_entity_endpoint_rules()` in khive-runtime, guarded by a
+                // regression test on key rows. Enforcement reads the shared rule data
+                // through `base_entity_rule_allows()`, never this text, so the two can
+                // drift and only that test will say so. Pack extensions come from
+                // `KG_EDGE_RULES` in this crate's `pack.rs`. A crate path and an issue
+                // number cannot be acted on by the caller this text is published to.
                 description: "Required in singleton mode; ignored when links is supplied. Edge relation (contains | part_of | instance_of | extends | variant_of | introduced_by | supersedes | derived_from | precedes | depends_on | enables | implements | competes_with | composed_with | annotates | supports | refutes). \
                     Each relation only accepts specific (source_kind -> target_kind) endpoint pairs; an out-of-allowlist pair between two otherwise-valid endpoints is rejected with InvalidInput, and a missing endpoint returns NotFound — never silently accepted. \
-                    Base ADR-002 entity->entity allowlist (issue #964 — this table is a hand-maintained mirror of `base_entity_endpoint_rules()` (khive-runtime) and is guarded by a regression test on key rows; enforcement consults the shared rule data via `base_entity_rule_allows()`, not this text — `base_entity_endpoint_rules()` is just an exposed view of the same constant): \
+                    Base entity->entity allowlist: \
                     contains: concept->concept, project->project, project->artifact, org->project, org->service. \
                     part_of: concept->concept, project->project, project->org. \
                     instance_of: *->concept (any source kind), service->project. \
@@ -791,8 +799,8 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                     supersedes: concept->concept, document->document, artifact->artifact, service->service, dataset->dataset, note->note (same-substrate only). \
                     supports / refutes: concept->concept, document->concept, dataset->concept, artifact->concept (evidence -> claim), note->note (same-substrate only). \
                     annotates: note -> {entity, note, edge, event} — the only relation permitting a note source paired with ANY target substrate (supersedes/supports/refutes also permit a note source, but only same-substrate: a note source there requires a note target too). \
-                    The `kg` pack additionally allows (pack-extensible, additive-only per ADR-017): part_of/instance_of person->org, part_of/instance_of person->project, depends_on/enables/contains/part_of/precedes org->org, precedes decision-note->decision-note. \
-                    Other loaded packs may add further pairs (e.g. `gtd` allows depends_on task-note->task-note; `formal` allows typed depends_on between theorem/definition/axiom/structure/instance/goal entity_types) — pack rules only ever add allowed pairs, never remove one listed here. Full pack-rule source: `KG_EDGE_RULES` in `khive-pack-kg/src/pack.rs` (ADR-017).",
+                    The `kg` pack additionally allows (pack rules are additive only): part_of/instance_of person->org, part_of/instance_of person->project, depends_on/enables/contains/part_of/precedes org->org, precedes decision-note->decision-note. \
+                    Other loaded packs may add further pairs (e.g. `gtd` allows depends_on task-note->task-note; `formal` allows typed depends_on between theorem/definition/axiom/structure/instance/goal entity_types) — pack rules only ever add allowed pairs, never remove one listed here.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
@@ -1001,9 +1009,9 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                 name: "entity_ids",
                 param_type: "array of string",
                 required: false,
-                description: "Explicit anchor UUIDs, short prefixes, or slugs (ADR-046 \
-                              resolution). Honored in full — never clamped by `limit`. At \
-                              least one of query/entity_ids is required.",
+                description: "Explicit anchor UUIDs, short prefixes, or slugs. Honored in \
+                              full — never clamped by `limit`. At least one of \
+                              query/entity_ids is required.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
@@ -1035,8 +1043,8 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                 param_type: "string",
                 required: false,
                 description: "Edge direction during expansion: \"outgoing\" | \"incoming\" | \
-                              \"both\" (default \"both\" — diverges from `neighbors`' \
-                              \"outgoing\" default; see ADR-089).",
+                              \"both\" (default \"both\", which differs from `neighbors`, \
+                              whose default is \"outgoing\").",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
@@ -1307,7 +1315,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                       classified as ledger_behind_pre_v14_duplicate_edge_state. \
                       A bounded dbstat size composition reports per-table/per-index pages and \
                       row, index, FTS, vector, mixed row-and-embedding, and internal byte totals. \
-                      ADR-091 checkpoint counters, a PASSIVE \
+                      WAL checkpoint counters, a PASSIVE \
                       checkpoint probe, the -wal sidecar file size, and an explicitly qualified \
                       WAL-pin holder census reconciled with a bounded read-only sidecar pass. The \
                       checkpoint probe issues a real PRAGMA wal_checkpoint(PASSIVE), which \

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -428,7 +428,9 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
                 name: "namespace",
                 param_type: "string",
                 required: false,
-                description: "Exact-match read namespace override (ADR-007 Rev 6 escape hatch). When absent, compose uses the caller token's namespace. When present, atom, domain, section, KG-blend, and profile-weight reads use exactly this namespace; invalid values are rejected.",
+                // MAINTENANCE, deliberately kept out of the description: this is the
+                // ADR-007 Rev 6 escape hatch.
+                description: "Exact-match read namespace override. When absent, compose uses the caller token's namespace. When present, atom, domain, section, KG-blend, and profile-weight reads use exactly this namespace; invalid values are rejected.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -217,14 +217,14 @@ static MEMORY_HANDLERS: [HandlerDef; 10] = [
                 name: "min_score",
                 param_type: "number",
                 required: false,
-                description: "Minimum rank_score to include (default 0.0). This filters `rank_score`, not `score`: `score` (absolute/raw relevance in each result) stays in [0,1] regardless of fusion strategy, but `rank_score` (the composite used for ranking and this filter) is the weighted relevance/salience/temporal composite — nominally [0,1] — further adjusted by ADR-104 posterior terms whenever a brain profile serves the request: a weight-reprojection component, and a per-entity term bounded to clamp(1 + 0.3 * (entity_posterior_mean - 0.5), 0.85, 1.15). So a served, positively-reinforced memory's rank_score can exceed 1.0 by up to 15%. Typical production floor: 0.3–0.7.",
+                description: "Minimum rank_score to include (default 0.0). This filters `rank_score`, not `score`: `score` (absolute/raw relevance in each result) stays in [0,1] regardless of fusion strategy, but `rank_score` (the composite used for ranking and this filter) is the weighted relevance/salience/temporal composite — nominally [0,1] — further adjusted by posterior terms whenever a brain profile serves the request: a weight-reprojection component, and a per-entity term bounded to clamp(1 + 0.3 * (entity_posterior_mean - 0.5), 0.85, 1.15). So a served, positively-reinforced memory's rank_score can exceed 1.0 by up to 15%. Typical production floor: 0.3–0.7.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
                 name: "score_floor",
                 param_type: "number",
                 required: false,
-                description: "Alias for min_score. Filters by `rank_score`, not `score` — see min_score for the [0,1]-plus-up-to-15%-under-ADR-104 range of rank_score when a profile serves the request. `score` (absolute/raw relevance) stays in [0,1] regardless of fusion strategy or served profile.",
+                description: "Alias for min_score. Filters by `rank_score`, not `score` — see min_score for the [0,1]-plus-up-to-15% range of rank_score when a profile serves the request. `score` (absolute/raw relevance) stays in [0,1] regardless of fusion strategy or served profile.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
@@ -287,7 +287,8 @@ static MEMORY_HANDLERS: [HandlerDef; 10] = [
                 name: "profile_id",
                 param_type: "string",
                 required: false,
-                description: "Serving-profile override (ADR-104 §4): short-circuits binding resolution so the named profile's state serves this request; stamped and ledgered like a resolved profile. Unknown ids error.",
+                // MAINTENANCE, deliberately kept out of the description: ADR-104 §4.
+                description: "Serving-profile override: short-circuits binding resolution so the named profile's state serves this request; stamped and ledgered like a resolved profile. Unknown ids error.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
@@ -329,7 +330,9 @@ static MEMORY_HANDLERS: [HandlerDef; 10] = [
                 name: "namespace",
                 param_type: "string",
                 required: false,
-                description: "Exact-match read-namespace override (ADR-007 Rev 6 escape hatch). When absent, reads the caller's default visible namespace set (unchanged default behavior). When present, scopes the candidate fetch to exactly this namespace; invalid values are rejected.",
+                // MAINTENANCE, deliberately kept out of the description: this is the
+                // ADR-007 Rev 6 escape hatch.
+                description: "Exact-match read-namespace override. When absent, reads the caller's default visible namespace set (unchanged default behavior). When present, scopes the candidate fetch to exactly this namespace; invalid values are rejected.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
         ],
@@ -379,7 +382,9 @@ static MEMORY_HANDLERS: [HandlerDef; 10] = [
     // Commissive: curation prune of low-salience or expired memories
     HandlerDef {
         name: "memory.prune",
-        description: "Soft-delete memories below a salience threshold and/or past expires_at. Curation-layer operation per ADR-014.",
+        // MAINTENANCE, deliberately kept out of the description: ADR-014 defines the
+        // curation layer this verb belongs to.
+        description: "Soft-delete memories below a salience threshold and/or past expires_at. A curation-layer operation.",
         visibility: Visibility::Verb,
         category: VerbCategory::Commissive,
         params: &[

--- a/crates/khive-pack-schedule/src/vocab.rs
+++ b/crates/khive-pack-schedule/src/vocab.rs
@@ -53,7 +53,7 @@ pub(crate) static SCHEDULE_HANDLERS: [HandlerDef; 4] = [
     },
     HandlerDef {
         name: "schedule.schedule",
-        description: "Schedule a future verb dispatch. NESTED-ACTION EXAMPLE (issue #110): \
+        description: "Schedule a future verb dispatch. NESTED-ACTION EXAMPLE: \
                        schedule.schedule(action=\"schedule.remind(content=\\\"renew the \
                        domain\\\", at=\\\"2027-06-01T09:00:00Z\\\")\", \
                        at=\"2027-05-25T09:00:00Z\") — the OUTER `at` (2027-05-25) is when \

--- a/crates/kkernel/tests/descriptions_are_written_for_callers.rs
+++ b/crates/kkernel/tests/descriptions_are_written_for_callers.rs
@@ -1,0 +1,162 @@
+//! Every verb and parameter description a caller is handed is a published text.
+//!
+//! These strings are rendered verbatim into the schema the MCP surface serves and
+//! into the connector schema a consumer product publishes, so they reach end users
+//! and model callers, not only engineers. They were written for engineers, and a
+//! number of them still carry decision-record numbers, issue numbers, crate paths
+//! and internal function names. One shipped an entire edge endpoint rule table with
+//! a hand-maintained-mirror caveat and a source path.
+//!
+//! Nothing about that is caught by review, because the text reads correct to the
+//! person writing it: the second audience arrived after the words did. This test is
+//! the forced consumer. It scans the MCP-visible surface of every loaded pack and
+//! fails on an internal reference that is not in the recorded baseline below.
+//!
+//! The baseline may only SHRINK. An entry that no longer matches fails the test too,
+//! so the list cannot quietly rot into a permission slip.
+
+use khive_runtime::Pack;
+use khive_types::pack::{HandlerDef, Visibility};
+
+/// Patterns that mean "written for someone with the repository open".
+fn internal_reference(text: &str) -> Option<&'static str> {
+    if text.contains("ADR-") {
+        return Some("decision-record number");
+    }
+    if text.contains("crates/") || text.contains(".rs`") || text.contains(".rs ") {
+        return Some("source path");
+    }
+    if text.contains("khive#") || text.contains("issue #") {
+        return Some("issue reference");
+    }
+    // A bare `#1234` is an issue number; a `#` followed by fewer digits is not
+    // (shard labels, fragment anchors), so the threshold is deliberate.
+    let bytes = text.as_bytes();
+    for (i, b) in bytes.iter().enumerate() {
+        if *b == b'#' {
+            let digits = bytes[i + 1..]
+                .iter()
+                .take_while(|c| c.is_ascii_digit())
+                .count();
+            if digits >= 3 {
+                return Some("issue number");
+            }
+        }
+    }
+    None
+}
+
+/// One recorded offender: pack, verb, and the parameter name, or the verb's own
+/// description when the name is empty.
+type Site = (&'static str, &'static str, &'static str);
+
+/// Known at the time this test landed. Shrink it; never add to it.
+///
+/// A new description carrying one of these patterns is a defect in the new text,
+/// not a gap in this list: write the sentence for the caller and put the
+/// engineering detail in a `//` comment beside the definition, where it still
+/// reaches the engineer and does not reach the product.
+const BASELINE: &[Site] = &[];
+
+fn collect(pack: &'static str, handlers: &'static [HandlerDef], out: &mut Vec<(Site, String)>) {
+    for h in handlers {
+        // Internal handlers are not part of the published surface.
+        if h.visibility != Visibility::Mcp {
+            continue;
+        }
+        if let Some(kind) = internal_reference(h.description) {
+            out.push(((pack, h.name, ""), kind.to_string()));
+        }
+        for p in h.params {
+            if let Some(kind) = internal_reference(p.description) {
+                out.push(((pack, h.name, p.name), kind.to_string()));
+            }
+        }
+    }
+}
+
+fn offenders() -> Vec<(Site, String)> {
+    let mut out = Vec::new();
+    collect("agent", khive_pack_agent::AgentPack::HANDLERS, &mut out);
+    collect("blob", khive_pack_blob::BlobPack::HANDLERS, &mut out);
+    collect("brain", khive_pack_brain::BrainPack::HANDLERS, &mut out);
+    collect("code", khive_pack_code::CodePack::HANDLERS, &mut out);
+    collect("comm", khive_pack_comm::CommPack::HANDLERS, &mut out);
+    collect("exec", khive_pack_exec::ExecPack::HANDLERS, &mut out);
+    collect("git", khive_pack_git::GitPack::HANDLERS, &mut out);
+    collect("gtd", khive_pack_gtd::GtdPack::HANDLERS, &mut out);
+    collect("kg", khive_pack_kg::KgPack::HANDLERS, &mut out);
+    collect(
+        "knowledge",
+        khive_pack_knowledge::KnowledgePack::HANDLERS,
+        &mut out,
+    );
+    collect("memory", khive_pack_memory::MemoryPack::HANDLERS, &mut out);
+    collect(
+        "schedule",
+        khive_pack_schedule::SchedulePack::HANDLERS,
+        &mut out,
+    );
+    collect("session", khive_pack_session::SessionPack::HANDLERS, &mut out);
+    collect("tool", khive_pack_tool::ToolPack::HANDLERS, &mut out);
+    collect("web", khive_pack_web::WebPack::HANDLERS, &mut out);
+    collect(
+        "workspace",
+        khive_pack_workspace::WorkspacePack::HANDLERS,
+        &mut out,
+    );
+    out
+}
+
+#[test]
+fn no_shipped_description_carries_an_internal_reference() {
+    // Assert the instrument reads a non-empty population before believing any
+    // absence it reports: a scan that walks nothing passes silently.
+    let mut scanned = 0usize;
+    for handlers in [
+        khive_pack_kg::KgPack::HANDLERS,
+        khive_pack_gtd::GtdPack::HANDLERS,
+    ] {
+        scanned += handlers.iter().filter(|h| h.visibility == Visibility::Mcp).count();
+    }
+    assert!(
+        scanned > 5,
+        "control: the scan must see a real surface, saw {scanned} visible handlers"
+    );
+
+    // And that the detector fires on a sentence carrying each pattern.
+    assert!(internal_reference("see ADR-169 for the rule").is_some());
+    assert!(internal_reference("defined in crates/khive-runtime/src/pack.rs").is_some());
+    assert!(internal_reference("regression for #1234").is_some());
+    assert!(
+        internal_reference("An IANA zone name, e.g. America/New_York.").is_none(),
+        "the detector must not fire on ordinary caller-facing prose"
+    );
+
+    let found = offenders();
+    let unrecorded: Vec<_> = found
+        .iter()
+        .filter(|(site, _)| !BASELINE.contains(site))
+        .collect();
+    assert!(
+        unrecorded.is_empty(),
+        "these shipped descriptions carry internal references:\n{}",
+        unrecorded
+            .iter()
+            .map(|((pack, verb, param), kind)| format!(
+                "  {pack}.{verb}{}{param} — {kind}",
+                if param.is_empty() { "" } else { "." }
+            ))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    let stale: Vec<_> = BASELINE
+        .iter()
+        .filter(|site| !found.iter().any(|(f, _)| f == *site))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "baseline entries no longer match and must be deleted from the list: {stale:?}"
+    );
+}

--- a/crates/kkernel/tests/descriptions_are_written_for_callers.rs
+++ b/crates/kkernel/tests/descriptions_are_written_for_callers.rs
@@ -60,8 +60,8 @@ const BASELINE: &[Site] = &[];
 
 fn collect(pack: &'static str, handlers: &'static [HandlerDef], out: &mut Vec<(Site, String)>) {
     for h in handlers {
-        // Internal handlers are not part of the published surface.
-        if h.visibility != Visibility::Mcp {
+        // `Subhandler` is operator-only; `Verb` is what the MCP surface publishes.
+        if h.visibility != Visibility::Verb {
             continue;
         }
         if let Some(kind) = internal_reference(h.description) {
@@ -97,7 +97,11 @@ fn offenders() -> Vec<(Site, String)> {
         khive_pack_schedule::SchedulePack::HANDLERS,
         &mut out,
     );
-    collect("session", khive_pack_session::SessionPack::HANDLERS, &mut out);
+    collect(
+        "session",
+        khive_pack_session::SessionPack::HANDLERS,
+        &mut out,
+    );
     collect("tool", khive_pack_tool::ToolPack::HANDLERS, &mut out);
     collect("web", khive_pack_web::WebPack::HANDLERS, &mut out);
     collect(
@@ -117,7 +121,10 @@ fn no_shipped_description_carries_an_internal_reference() {
         khive_pack_kg::KgPack::HANDLERS,
         khive_pack_gtd::GtdPack::HANDLERS,
     ] {
-        scanned += handlers.iter().filter(|h| h.visibility == Visibility::Mcp).count();
+        scanned += handlers
+            .iter()
+            .filter(|h| h.visibility == Visibility::Verb)
+            .count();
     }
     assert!(
         scanned > 5,

--- a/crates/kkernel/tests/descriptions_are_written_for_callers.rs
+++ b/crates/kkernel/tests/descriptions_are_written_for_callers.rs
@@ -9,14 +9,18 @@
 //!
 //! Nothing about that is caught by review, because the text reads correct to the
 //! person writing it: the second audience arrived after the words did. This test is
-//! the forced consumer. It scans the MCP-visible surface of every loaded pack and
-//! fails on an internal reference that is not in the recorded baseline below.
+//! the forced consumer. It scans the published surface of every pack the server
+//! links by default and fails on an internal reference that is not in the recorded
+//! baseline below.
+//!
+//! The population is the pack list in `khive-mcp`'s `pack` module minus the two
+//! feature-gated packs. A pack added there and not here is a hole in this test, so
+//! the scan asserts it walked a real surface before believing any absence.
 //!
 //! The baseline may only SHRINK. An entry that no longer matches fails the test too,
 //! so the list cannot quietly rot into a permission slip.
 
-use khive_runtime::Pack;
-use khive_types::pack::{HandlerDef, Visibility};
+use khive_types::pack::{HandlerDef, Pack, Visibility};
 
 /// Patterns that mean "written for someone with the repository open".
 fn internal_reference(text: &str) -> Option<&'static str> {
@@ -100,6 +104,11 @@ fn offenders() -> Vec<(Site, String)> {
     collect(
         "session",
         khive_pack_session::SessionPack::HANDLERS,
+        &mut out,
+    );
+    collect(
+        "telemetry",
+        khive_pack_telemetry::TelemetryPack::HANDLERS,
         &mut out,
     );
     collect("tool", khive_pack_tool::ToolPack::HANDLERS, &mut out);

--- a/crates/kkernel/tests/descriptions_are_written_for_callers.rs
+++ b/crates/kkernel/tests/descriptions_are_written_for_callers.rs
@@ -20,7 +20,9 @@
 //! The baseline may only SHRINK. An entry that no longer matches fails the test too,
 //! so the list cannot quietly rot into a permission slip.
 
+use khive_runtime::RuntimeConfig;
 use khive_types::pack::{HandlerDef, Pack, Visibility};
+use std::collections::BTreeSet;
 
 /// Patterns that mean "written for someone with the repository open".
 fn internal_reference(text: &str) -> Option<&'static str> {
@@ -79,65 +81,82 @@ fn collect(pack: &'static str, handlers: &'static [HandlerDef], out: &mut Vec<(S
     }
 }
 
+/// Packs linked into this binary, paired with the handler table each publishes.
+///
+/// This list is a claim about the population and the test checks it against the
+/// runtime's own declaration rather than trusting it, because a hand-typed
+/// population is exactly what goes stale: an earlier revision of this file was
+/// one pack short and reported a clean scan of a surface it had not walked.
+fn packs() -> Vec<(&'static str, &'static [HandlerDef])> {
+    vec![
+        ("agent", khive_pack_agent::AgentPack::HANDLERS),
+        ("blob", khive_pack_blob::BlobPack::HANDLERS),
+        ("brain", khive_pack_brain::BrainPack::HANDLERS),
+        ("code", khive_pack_code::CodePack::HANDLERS),
+        ("comm", khive_pack_comm::CommPack::HANDLERS),
+        ("exec", khive_pack_exec::ExecPack::HANDLERS),
+        ("git", khive_pack_git::GitPack::HANDLERS),
+        ("gtd", khive_pack_gtd::GtdPack::HANDLERS),
+        ("kg", khive_pack_kg::KgPack::HANDLERS),
+        ("knowledge", khive_pack_knowledge::KnowledgePack::HANDLERS),
+        ("memory", khive_pack_memory::MemoryPack::HANDLERS),
+        ("schedule", khive_pack_schedule::SchedulePack::HANDLERS),
+        ("session", khive_pack_session::SessionPack::HANDLERS),
+        ("telemetry", khive_pack_telemetry::TelemetryPack::HANDLERS),
+        ("tool", khive_pack_tool::ToolPack::HANDLERS),
+        ("web", khive_pack_web::WebPack::HANDLERS),
+        ("workspace", khive_pack_workspace::WorkspacePack::HANDLERS),
+    ]
+}
+
+/// Linked and publishable, but outside the default set a fresh install loads.
+/// A deployment turns these on by configuration, with no rebuild, so their
+/// descriptions reach callers and belong in this scan.
+const PACKS_OUTSIDE_THE_SHIPPED_SET: [&str; 3] = ["agent", "telemetry", "web"];
+
 fn offenders() -> Vec<(Site, String)> {
     let mut out = Vec::new();
-    collect("agent", khive_pack_agent::AgentPack::HANDLERS, &mut out);
-    collect("blob", khive_pack_blob::BlobPack::HANDLERS, &mut out);
-    collect("brain", khive_pack_brain::BrainPack::HANDLERS, &mut out);
-    collect("code", khive_pack_code::CodePack::HANDLERS, &mut out);
-    collect("comm", khive_pack_comm::CommPack::HANDLERS, &mut out);
-    collect("exec", khive_pack_exec::ExecPack::HANDLERS, &mut out);
-    collect("git", khive_pack_git::GitPack::HANDLERS, &mut out);
-    collect("gtd", khive_pack_gtd::GtdPack::HANDLERS, &mut out);
-    collect("kg", khive_pack_kg::KgPack::HANDLERS, &mut out);
-    collect(
-        "knowledge",
-        khive_pack_knowledge::KnowledgePack::HANDLERS,
-        &mut out,
-    );
-    collect("memory", khive_pack_memory::MemoryPack::HANDLERS, &mut out);
-    collect(
-        "schedule",
-        khive_pack_schedule::SchedulePack::HANDLERS,
-        &mut out,
-    );
-    collect(
-        "session",
-        khive_pack_session::SessionPack::HANDLERS,
-        &mut out,
-    );
-    collect(
-        "telemetry",
-        khive_pack_telemetry::TelemetryPack::HANDLERS,
-        &mut out,
-    );
-    collect("tool", khive_pack_tool::ToolPack::HANDLERS, &mut out);
-    collect("web", khive_pack_web::WebPack::HANDLERS, &mut out);
-    collect(
-        "workspace",
-        khive_pack_workspace::WorkspacePack::HANDLERS,
-        &mut out,
-    );
+    for (name, handlers) in packs() {
+        collect(name, handlers, &mut out);
+    }
     out
 }
 
 #[test]
 fn no_shipped_description_carries_an_internal_reference() {
+    // The population this scan claims to cover, checked against the runtime's
+    // own declaration. Without this the list above is a hand-typed copy that
+    // goes quietly stale, and a pack missing from it reads as a clean surface.
+    let scanned_packs: BTreeSet<String> = packs()
+        .into_iter()
+        .map(|(name, _)| name.to_string())
+        .collect();
+    let shipped: BTreeSet<String> = RuntimeConfig::built_in_packs().into_iter().collect();
+    let unscanned: Vec<&String> = shipped.difference(&scanned_packs).collect();
+    assert!(
+        unscanned.is_empty(),
+        "these packs ship by default and this scan does not walk them: {unscanned:?}"
+    );
+    let beyond_shipped: BTreeSet<String> = scanned_packs.difference(&shipped).cloned().collect();
+    let declared_extra: BTreeSet<String> = PACKS_OUTSIDE_THE_SHIPPED_SET
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(
+        beyond_shipped, declared_extra,
+        "the packs scanned beyond the shipped set must be the ones declared above"
+    );
+
     // Assert the instrument reads a non-empty population before believing any
     // absence it reports: a scan that walks nothing passes silently.
-    let mut scanned = 0usize;
-    for handlers in [
-        khive_pack_kg::KgPack::HANDLERS,
-        khive_pack_gtd::GtdPack::HANDLERS,
-    ] {
-        scanned += handlers
-            .iter()
-            .filter(|h| h.visibility == Visibility::Verb)
-            .count();
-    }
+    let scanned: usize = packs()
+        .into_iter()
+        .flat_map(|(_, handlers)| handlers.iter())
+        .filter(|h| h.visibility == Visibility::Verb)
+        .count();
     assert!(
-        scanned > 5,
-        "control: the scan must see a real surface, saw {scanned} visible handlers"
+        scanned > 50,
+        "control: the scan must see a real surface, saw {scanned} published handlers"
     );
 
     // And that the detector fires on a sentence carrying each pattern.

--- a/scripts/tests/test_ci_workflows.py
+++ b/scripts/tests/test_ci_workflows.py
@@ -864,6 +864,10 @@ class HarnessEnvironmentTests(unittest.TestCase):
             # An enumerated contract test whose FIRST assertion is equality with
             # the declaration, so the enumeration below it cannot drift silently.
             "crates/khive-runtime/src/runtime.rs",
+            # Same shape: the description scan pairs each pack name with the
+            # handler table it publishes, and its first assertion is that the
+            # names cover built_in_packs() with a declared, checked remainder.
+            "crates/kkernel/tests/descriptions_are_written_for_callers.rs",
         }
         names = {
             "kg", "gtd", "memory", "brain", "comm", "schedule", "knowledge",


### PR DESCRIPTION
Every verb and parameter description this server carries is a published text. It is rendered verbatim into the JSON schema the MCP surface serves and into the connector schemas that consumer products publish, so it reaches model callers and end users, not only the engineer who wrote it. Two live clients read that catalogue today.

They were written for engineers. Twenty-seven of them still carried decision-record numbers, issue numbers, source paths or internal function names. The worst shipped an entire edge endpoint rule table together with a hand-maintained-mirror caveat and the path of the constant it mirrors, in the text a model is handed when it asks what a parameter means.

**What changed.** Each internal reference moved into a `// MAINTENANCE, deliberately kept out of the description:` comment beside the definition, where it still reaches the engineer who needs it and no longer reaches the product. Nothing caller-useful was dropped. The endpoint rule table stays, because a caller genuinely needs it; every behavioural sentence is preserved, or restated where the reference was load-bearing inside the sentence rather than parenthetical. The packs touched are agent, brain, comm, gtd, kg, knowledge, memory and schedule.

**The test is the forced consumer.** `crates/kkernel/tests/descriptions_are_written_for_callers.rs` walks the published surface of all seventeen packs the server links by default, applies one detector to every verb and parameter description, and fails on an internal reference. The baseline is empty. It may only shrink: an entry that no longer matches fails the test too, so the list cannot quietly become a permission slip.

The test's output is an absence, so it runs its own controls in the same invocation that produces the answer. It asserts the scan saw a real surface rather than walking an empty list, it fires the detector on a sentence carrying each pattern it claims to catch, and it hands the detector one ordinary caller-facing sentence that it must not fire on.

That mattered here. A source-level sweep written first reported the brain pack clean; the sweep keyed on the bare spelling of the visibility field and that pack writes it fully qualified, so the sweep skipped all twenty-two of its handlers while reporting a clean scan. The test found the nine it had missed. The population an instrument declares is the population it can actually see, which is the reason this check lives in the build rather than in a script someone runs.

**One addition rather than a removal.** `create` already ran a duplicate-name check and already returned `similar_existing` when it found something, and nothing in the published surface said so. A model creating entities in a loop never looked, and the graph accumulated near-duplicates the server had already spotted. The verb's description now names the field, says the usual right response is to link to what is there, and states the two cases where the field is absent so that absence reads as "nothing similar" rather than as "the check did not run".
