### PR TITLE
ci: cache the embedding model and make the cache load-bearing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,10 @@ jobs:
       # footprint that filled the ubuntu runner disk (ENOSPC surfaces as
       # `ld terminated with signal 7 [Bus error]`, e.g. run 28604091732).
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      # The model cache below is load-bearing, not an optimisation: with this
+      # set, a phase whose model is missing fails naming the directory instead
+      # of fetching from huggingface.co.
+      LATTICE_OFFLINE: "1"
     steps:
       - uses: actions/checkout@v7
       # ubuntu-latest runners start with ~21GB free on /. The workspace's
@@ -158,6 +162,43 @@ jobs:
           # of the job; the first to finish wins and the second is a no-op
           # (actions/cache skips saving over an existing key), which is fine.
           key: line-tables
+      # EMBEDDING MODEL CACHE. The embedder fetches its weights from
+      # huggingface.co the first time it is built. Fetching per run made this
+      # workflow depend on a third-party CDN's rate limiter, which on
+      # 2026-09-12 answered 429 twelve times in one job and reddened unrelated
+      # pull requests. Restore the cache, fill it only on a miss, and then run
+      # every test phase with LATTICE_OFFLINE set (see the job env above) so the
+      # cache is load-bearing: a phase that would have fetched fails at once,
+      # naming the directory it expected, instead of reaching the network.
+      #
+      # The key carries the locked lattice-inference version because that crate
+      # owns both the cache layout and the checksum set the files are verified
+      # against, so a version change is the event that can invalidate a cache
+      # entry. There is no upstream revision to pin: the crate resolves against
+      # the repository's main branch.
+      - name: Resolve the embedding model cache key
+        id: model-cache-key
+        working-directory: ${{ github.workspace }}
+        run: |
+          version=$(awk '/^name = "lattice-inference"$/{found=1; next} found && /^version = /{gsub(/[",]/,"",$3); print $3; exit}' crates/Cargo.lock)
+          # An empty version would silently produce a key that never matches and
+          # a cache that never restores, which reads exactly like a cold runner.
+          if [ -z "$version" ]; then
+            echo "could not read the locked lattice-inference version from crates/Cargo.lock" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "resolved lattice-inference $version"
+      - name: Restore the embedding model cache
+        id: model-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.lattice/models
+          key: lattice-models-${{ runner.os }}-all-minilm-l6-v2-${{ steps.model-cache-key.outputs.version }}
+      - name: Warm the embedding model cache
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        working-directory: ${{ github.workspace }}
+        run: scripts/warm-model-cache.sh all-minilm-l6-v2
       - uses: denoland/setup-deno@v2
         if: env.CI_SUITE == 'full' && matrix.shard == 1
         with:
@@ -296,6 +337,8 @@ jobs:
       KKERNEL: ${{ github.workspace }}/crates/target/debug/kkernel
       PYTHONPATH: ${{ github.workspace }}/python
       TMPDIR: /tmp
+      # See the model cache steps below: with this set the cache is load-bearing.
+      LATTICE_OFFLINE: "1"
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -310,6 +353,41 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v5
+      # EMBEDDING MODEL CACHE. The embedder fetches its weights from
+      # huggingface.co the first time it is built. Fetching per run made this
+      # workflow depend on a third-party CDN's rate limiter, which on
+      # 2026-09-12 answered 429 twelve times in one job and reddened unrelated
+      # pull requests. Restore the cache, fill it only on a miss, and then run
+      # every test phase with LATTICE_OFFLINE set (see the job env above) so the
+      # cache is load-bearing: a phase that would have fetched fails at once,
+      # naming the directory it expected, instead of reaching the network.
+      #
+      # The key carries the locked lattice-inference version because that crate
+      # owns both the cache layout and the checksum set the files are verified
+      # against, so a version change is the event that can invalidate a cache
+      # entry. There is no upstream revision to pin: the crate resolves against
+      # the repository's main branch.
+      - name: Resolve the embedding model cache key
+        id: model-cache-key
+        run: |
+          version=$(awk '/^name = "lattice-inference"$/{found=1; next} found && /^version = /{gsub(/[",]/,"",$3); print $3; exit}' crates/Cargo.lock)
+          # An empty version would silently produce a key that never matches and
+          # a cache that never restores, which reads exactly like a cold runner.
+          if [ -z "$version" ]; then
+            echo "could not read the locked lattice-inference version from crates/Cargo.lock" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "resolved lattice-inference $version"
+      - name: Restore the embedding model cache
+        id: model-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.lattice/models
+          key: lattice-models-${{ runner.os }}-all-minilm-l6-v2-${{ steps.model-cache-key.outputs.version }}
+      - name: Warm the embedding model cache
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        run: scripts/warm-model-cache.sh all-minilm-l6-v2
       - name: No-stub placeholder scan (before any cargo)
         run: scripts/ci.sh no-stubs-scan
       - name: Build debug kkernel
@@ -856,6 +934,9 @@ jobs:
     outputs:
       available: ${{ steps.compute_coverage.outcome == 'success' }}
       current: ${{ steps.compute_coverage.outputs.current }}
+    env:
+      # See the model cache steps below: with this set the cache is load-bearing.
+      LATTICE_OFFLINE: "1"
     steps:
       - uses: actions/checkout@v7
       # `cargo llvm-cov --workspace` is the disk-heaviest command in CI: it
@@ -883,6 +964,41 @@ jobs:
       - uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-llvm-cov
+      # EMBEDDING MODEL CACHE. The embedder fetches its weights from
+      # huggingface.co the first time it is built. Fetching per run made this
+      # workflow depend on a third-party CDN's rate limiter, which on
+      # 2026-09-12 answered 429 twelve times in one job and reddened unrelated
+      # pull requests. Restore the cache, fill it only on a miss, and then run
+      # every test phase with LATTICE_OFFLINE set (see the job env above) so the
+      # cache is load-bearing: a phase that would have fetched fails at once,
+      # naming the directory it expected, instead of reaching the network.
+      #
+      # The key carries the locked lattice-inference version because that crate
+      # owns both the cache layout and the checksum set the files are verified
+      # against, so a version change is the event that can invalidate a cache
+      # entry. There is no upstream revision to pin: the crate resolves against
+      # the repository's main branch.
+      - name: Resolve the embedding model cache key
+        id: model-cache-key
+        run: |
+          version=$(awk '/^name = "lattice-inference"$/{found=1; next} found && /^version = /{gsub(/[",]/,"",$3); print $3; exit}' crates/Cargo.lock)
+          # An empty version would silently produce a key that never matches and
+          # a cache that never restores, which reads exactly like a cold runner.
+          if [ -z "$version" ]; then
+            echo "could not read the locked lattice-inference version from crates/Cargo.lock" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "resolved lattice-inference $version"
+      - name: Restore the embedding model cache
+        id: model-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.lattice/models
+          key: lattice-models-${{ runner.os }}-all-minilm-l6-v2-${{ steps.model-cache-key.outputs.version }}
+      - name: Warm the embedding model cache
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        run: scripts/warm-model-cache.sh all-minilm-l6-v2
       - name: Compute coverage
         id: compute_coverage
         continue-on-error: true

--- a/scripts/warm-model-cache.sh
+++ b/scripts/warm-model-cache.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Pre-fetch embedding model files into the lattice model cache.
+#
+# WHY THIS EXISTS. The embedder fetches its weights from huggingface.co the first
+# time it is built. CI built it on every run, and on 2026-09-12 Hugging Face
+# answered with HTTP 429 twelve times in a single job, turning an unrelated pull
+# request red. A rate limit on a third-party CDN is not a signal about the change
+# under test, and while it is intermittent it makes a real red indistinguishable
+# from an infrastructure one at a glance.
+#
+# The fix is not a retry loop. It is to fetch once, cache the result, and then run
+# the tests with LATTICE_OFFLINE set so the cache is load-bearing: a run that would
+# have fetched fails immediately, naming the directory it expected, instead of
+# reaching the network at all.
+#
+# WHAT IT MIRRORS, AND WHY THAT IS SAFE. The cache layout and the model-name to
+# repository mapping below are lattice-inference's, in its `download` module. This
+# script is a second copy of that table and can drift from it. It is safe to copy
+# because the crate checksum-verifies a pre-fetched cache before using it (with the
+# artifact preserved rather than deleted), so a drifted mapping here surfaces as a
+# named checksum failure at the first use, never as wrong bytes served quietly.
+#
+# Usage: scripts/warm-model-cache.sh <model-name> [model-name...]
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <model-name> [model-name...]" >&2
+  exit 2
+fi
+
+CACHE_ROOT="${LATTICE_MODEL_CACHE:-$HOME/.lattice/models}"
+
+# Deliberately NOT honouring LATTICE_OFFLINE: this script is the thing that fills
+# the cache, so it is the one caller that must be allowed to reach the network.
+# Every consumer of the cache runs with the flag set.
+hf_repo_for() {
+  case "$1" in
+    all-minilm-l6-v2) echo "sentence-transformers/all-MiniLM-L6-v2" ;;
+    bge-small-en-v1.5) echo "BAAI/bge-small-en-v1.5" ;;
+    bge-base-en-v1.5) echo "BAAI/bge-base-en-v1.5" ;;
+    bge-large-en-v1.5) echo "BAAI/bge-large-en-v1.5" ;;
+    multilingual-e5-small) echo "intfloat/multilingual-e5-small" ;;
+    multilingual-e5-base) echo "intfloat/multilingual-e5-base" ;;
+    paraphrase-multilingual-minilm-l12-v2) echo "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2" ;;
+    *) return 1 ;;
+  esac
+}
+
+# The tokenizer file a model ships is selected by substring, not by family: a name
+# containing "e5-" or "multilingual" carries tokenizer.json, everything else
+# carries vocab.txt.
+tokenizer_file_for() {
+  case "$1" in
+    *e5-*|*multilingual*) echo "tokenizer.json" ;;
+    *) echo "vocab.txt" ;;
+  esac
+}
+
+fetch() {
+  local url="$1" dest="$2"
+  if [ -s "$dest" ]; then
+    echo "present  $dest"
+    return 0
+  fi
+  echo "fetching $url"
+  # --fail so an HTML error page never lands as a weights file; the retry budget
+  # covers the rate limit this script exists for, and 429 is retryable only with
+  # --retry-all-errors on curl's default list.
+  curl --fail --location --silent --show-error \
+       --retry 5 --retry-delay 5 --retry-all-errors \
+       --output "$dest.partial" "$url"
+  mv "$dest.partial" "$dest"
+  echo "fetched  $dest ($(wc -c < "$dest") bytes)"
+}
+
+for model in "$@"; do
+  repo="$(hf_repo_for "$model")" || {
+    echo "unsupported model name: $model" >&2
+    exit 3
+  }
+  dir="$CACHE_ROOT/$model"
+  mkdir -p "$dir"
+  base="https://huggingface.co/$repo/resolve/main"
+  fetch "$base/model.safetensors" "$dir/model.safetensors"
+  fetch "$base/$(tokenizer_file_for "$model")" "$dir/$(tokenizer_file_for "$model")"
+done
+
+echo "cache root: $CACHE_ROOT"


### PR DESCRIPTION
The embedder fetches its weights from huggingface.co the first time it is built, and CI built it fresh on every run. On 2026-09-12 Hugging Face answered with HTTP 429 twelve times inside a single job: twelve tests failed with `EmbedderProvider build() failed`, 521 passed, and nothing in the branch under test touched embedding. A third-party CDN's rate limiter was deciding whether unrelated pull requests were red, and because it is intermittent it makes a real failure indistinguishable from an infrastructure one at a glance.

**Why not a retry loop.** That leaves the network on the critical path of every run and converts a hard failure into a slow one. The three jobs that exercise the runtime now restore a cache of the model files, fill it only on a miss, and run every test phase with `LATTICE_OFFLINE` set.

That flag is what makes this a fix rather than an optimisation. With it set, a phase whose model is missing fails immediately, naming the directory it expected, instead of quietly reaching the network. A cache that stops working becomes a loud and specific failure rather than a gradual return to the old behaviour.

**The key.** It carries the locked `lattice-inference` version, because that crate owns both the cache layout and the checksum set the files are verified against, so a version change is the event that can invalidate an entry. There is no upstream revision to pin: the crate resolves against the repository's main branch, and the checksum table is a stronger identity than a revision string anyway. The key-resolving step fails loudly when it cannot read the version, since an empty key yields a cache that never restores and reads exactly like a cold runner.

**On the copied table.** `scripts/warm-model-cache.sh` holds a second copy of the crate's model-name to repository mapping and its tokenizer-file rule, and that copy can drift. It is safe to copy because the crate checksum-verifies a pre-fetched cache before using it, preserving rather than deleting the artifact, so drift surfaces as a named checksum failure at first use and never as wrong bytes served quietly. The script's header says this.

**Verified before opening, rather than asserted.** The script was run against a scratch cache root. It hit a live 429 on the first attempt, absorbed it on retry, and produced files byte-identical to a cache that has been serving locally since August; both digests appear in the crate's expected-checksum table. So the failure mode this exists for occurred during its own test and the retry budget covered it.

**Scope.** The three jobs whose tests build the embedder: the matrix suite, the Python client tests, and coverage. The other four test jobs run `khive-changeset`, `khive-db`, `khive-quant` and `khive-vamana`, none of which reach the embedder, so they are deliberately left alone rather than handed a flag whose behaviour there is untested. The warm list is one model, the only one observed to be fetched; if a phase needs another, the offline flag reports it by name rather than fetching it.
