### PR TITLE
fix(kg): emit the domain event on every create and update

### DIFF
--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -3023,3 +3023,118 @@ async fn resolve_dispatch_on_merged_uuid_stays_bare_not_found() {
         "resolve has no message slot for a merge hint in this interim change; got {result:?}"
     );
 }
+
+// The reason this change exists: before it, a create through the kg verbs left an
+// audit row at the exec layer and no domain event at all, so the event plane could
+// say what left the graph and not what entered it. This walks create, update and
+// delete for both substrates and requires all six domain kinds, each exactly once
+// and each carrying its own record as the target. Audit rows are emitted a layer
+// above the pack registry, so they are outside this test's reach by construction;
+// what is in reach is the half that was missing.
+#[tokio::test]
+async fn every_kg_write_emits_its_domain_event() {
+    use khive_storage::{event::EventFilter, PageRequest};
+    use khive_types::EventKind;
+    use std::collections::BTreeMap;
+    use uuid::Uuid;
+
+    let (rt, token, pack, registry) = configured_kg_pack().await;
+
+    let entity = pack
+        .handle_create(
+            &token,
+            json!({
+                "kind": "entity",
+                "entity_kind": "concept",
+                "name": "domain-event-arm",
+            }),
+            &registry,
+        )
+        .await
+        .expect("create entity");
+    let entity_id =
+        Uuid::parse_str(entity["id"].as_str().expect("entity id")).expect("entity uuid");
+
+    let note = pack
+        .handle_create(
+            &token,
+            json!({
+                "kind": "note",
+                "note_kind": "observation",
+                "content": "domain event arm",
+            }),
+            &registry,
+        )
+        .await
+        .expect("create note");
+    let note_id = Uuid::parse_str(note["id"].as_str().expect("note id")).expect("note uuid");
+
+    pack.handle_update(
+        &token,
+        json!({"id": entity_id, "description": "updated by the domain event arm"}),
+        &registry,
+    )
+    .await
+    .expect("update entity");
+    pack.handle_update(
+        &token,
+        json!({"id": note_id, "content": "domain event arm, updated"}),
+        &registry,
+    )
+    .await
+    .expect("update note");
+
+    pack.handle_delete(&token, json!({"id": entity_id}), &registry)
+        .await
+        .expect("delete entity");
+    pack.handle_delete(&token, json!({"id": note_id}), &registry)
+        .await
+        .expect("delete note");
+
+    let page = rt
+        .events(&token)
+        .expect("event store")
+        .query_events(
+            EventFilter::default(),
+            PageRequest {
+                offset: 0,
+                limit: 500,
+            },
+        )
+        .await
+        .expect("query every event in the namespace");
+
+    let mut by_kind: BTreeMap<String, Vec<Option<Uuid>>> = BTreeMap::new();
+    for event in &page.items {
+        by_kind
+            .entry(format!("{:?}", event.kind))
+            .or_default()
+            .push(event.target_id);
+    }
+    let census: Vec<(String, usize)> = by_kind
+        .iter()
+        .map(|(kind, targets)| (kind.clone(), targets.len()))
+        .collect();
+
+    for (kind, expected_target) in [
+        (EventKind::EntityCreated, entity_id),
+        (EventKind::EntityUpdated, entity_id),
+        (EventKind::EntityDeleted, entity_id),
+        (EventKind::NoteCreated, note_id),
+        (EventKind::NoteUpdated, note_id),
+        (EventKind::NoteDeleted, note_id),
+    ] {
+        let key = format!("{kind:?}");
+        let targets = by_kind.get(&key).cloned().unwrap_or_default();
+        assert_eq!(
+            targets.len(),
+            1,
+            "expected exactly one {key} event; kind census was {census:?}"
+        );
+        assert_eq!(
+            targets[0],
+            Some(expected_target),
+            "{key} must target the record it describes; kind census was {census:?}"
+        );
+    }
+}

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use khive_runtime::keyed_memory::{create_keyed_memory, validate_memory_key, KeyedMemorySpec};
-use khive_runtime::{micros_to_iso, KhiveRuntime, Namespace, NamespaceToken, RuntimeError};
+use khive_runtime::{micros_to_iso, Namespace, NamespaceToken, RuntimeError};
 use khive_storage::types::{Direction, NeighborQuery};
 use khive_storage::EdgeRelation;
 

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -186,9 +186,6 @@ impl MemoryPack {
             None
         };
 
-        emit_memory_remembered_event(&self.runtime, write_token, note.id, memory_type, salience)
-            .await;
-
         let mut response = json!({
             "id": note.id.to_string(),
             "kind": note.kind,
@@ -204,62 +201,6 @@ impl MemoryPack {
     }
 }
 
-/// Best-effort `NoteCreated` telemetry for `memory.remember`.
-///
-/// `EventKind` is a closed enum owned by the OSS `khive-types` crate and has
-/// no dedicated `MemoryRemembered` variant, so — same constraint documented
-/// against `brain.mark_turn`'s `PhaseStarted`/`actor_turn` reuse
-/// — this reuses `NoteCreated`: `memory.remember` always
-/// creates a `memory`-kind `Note`, so a `NoteCreated` event carrying the new
-/// note's id as `target_id` (with `substrate = Note`, matching
-/// `decode_target_observation`'s `ReferentKind` selection) is the concrete
-/// "memory_remembered" signal the issue asks for. Awaited inline rather than
-/// backgrounded like `recall.rs`'s `RecallExecuted` emission: `memory.remember`
-/// is a write path, not a latency-sensitive hot read path, and git pack's
-/// `emit_write_audit` establishes the same inline-await, swallow-on-error
-/// shape for write-time telemetry.
-async fn emit_memory_remembered_event(
-    rt: &KhiveRuntime,
-    token: &NamespaceToken,
-    note_id: Uuid,
-    memory_type: &str,
-    salience: f64,
-) {
-    let store = match rt.events(token) {
-        Ok(store) => store,
-        Err(err) => {
-            tracing::warn!(
-                error = %err,
-                namespace = token.namespace().as_str(),
-                event_kind = "note_created",
-                "memory_remembered (note_created) event store acquisition failed; remember result is unaffected"
-            );
-            return;
-        }
-    };
-    let actor = format!("{}:{}", token.actor().kind, token.actor().id);
-    let payload = json!({
-        "actor": actor,
-        "memory_type": memory_type,
-        "salience": salience,
-    });
-    let event = khive_storage::Event::new(
-        token.namespace().as_str(),
-        "memory.remember",
-        khive_types::EventKind::NoteCreated,
-        khive_types::SubstrateKind::Note,
-        actor,
-    )
-    .with_payload(payload)
-    .with_target(note_id);
-    if let Err(err) = store.append_event(event).await {
-        tracing::warn!(
-            error = %err,
-            "memory_remembered (note_created) event append failed; remember result is unaffected"
-        );
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use khive_pack_kg::KgPack;
@@ -267,10 +208,13 @@ mod tests {
 
     use crate::MemoryPack;
 
-    /// `memory.remember` must persist a `NoteCreated` event (the
-    /// "memory_remembered" signal) carrying the calling actor, the new
-    /// note's id as `target_id`, and `substrate = Note` so
-    /// `decode_target_observation` resolves it as a `Note` referent.
+    /// `memory.remember` must persist exactly ONE `NoteCreated` event carrying
+    /// the calling actor, the new note's id as `target_id`, and
+    /// `substrate = Note` so `decode_target_observation` resolves it as a `Note`
+    /// referent. That event is now the runtime's, emitted once on the single
+    /// note-create funnel. This pack used to emit a second one of its own beside
+    /// it; the count assertion below is what makes that duplicate fail, so it is
+    /// load-bearing rather than incidental.
     #[tokio::test]
     async fn remember_persists_note_created_event_with_target() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -319,13 +263,17 @@ mod tests {
             "exactly one NoteCreated event must be persisted: {page:?}"
         );
         let event = &page.items[0];
-        assert_eq!(event.verb, "memory.remember");
+        assert_eq!(event.verb, "create");
         assert_eq!(
             event.actor,
             format!("{}:{}", token.actor().kind, token.actor().id)
         );
         assert_eq!(event.target_id, Some(note_id));
         assert_eq!(event.substrate, khive_types::SubstrateKind::Note);
-        assert_eq!(event.payload["memory_type"], serde_json::json!("semantic"));
+        assert_eq!(event.payload["kind"], serde_json::json!("memory"));
+        // `memory_type` is a property of the note the event targets, not a copy
+        // in the event payload: the runtime emitter knows the note, not the verb
+        // that asked for it. The response is the caller-facing surface for it.
+        assert_eq!(result["memory_type"], serde_json::json!("semantic"));
     }
 }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -4756,11 +4756,16 @@ mod tests {
         }
     }
 
-    /// Parity boundary: atomic `update` of a note must append no event:
-    /// canonical `update_note` never calls `append_event` (unlike
-    /// `update_entity`, which always does).
+    /// Parity boundary: an atomic `update` of a note appends exactly one
+    /// `NoteUpdated` event, because this path and canonical `update_note` build
+    /// their plan through the same `prepare_versioned_note_update`, which is
+    /// where the event statements are added.
+    ///
+    /// This test used to assert the opposite. That was a faithful record of a
+    /// gap rather than a contract: notes were the substrate that recorded no
+    /// update at all, so the parity it certified was parity with nothing.
     #[tokio::test]
-    async fn atomic_update_note_appends_no_event() {
+    async fn atomic_update_note_appends_its_domain_event() {
         let runtime = scratch_runtime();
         let token = runtime
             .authorize(Namespace::parse("local").expect("ns"))
@@ -4799,14 +4804,21 @@ mod tests {
             )
             .await
             .expect("query_events");
-        assert!(
-            page.items.iter().all(|e| e.target_id != Some(note_id)),
-            "update_note must append no event; found: {:?}",
-            page.items
-                .iter()
-                .filter(|e| e.target_id == Some(note_id))
-                .collect::<Vec<_>>()
+        let for_note: Vec<_> = page
+            .items
+            .iter()
+            .filter(|e| e.target_id == Some(note_id))
+            .collect();
+        assert_eq!(
+            for_note.len(),
+            1,
+            "an atomic note update must append exactly one event; found: {for_note:?}"
         );
+        assert_eq!(for_note[0].kind, EventKind::NoteUpdated);
+        assert_eq!(for_note[0].substrate, SubstrateKind::Note);
+        assert_eq!(for_note[0].verb, "update");
+        assert_eq!(for_note[0].payload["id"], json!(note_id));
+        assert_eq!(for_note[0].payload["text_changed"], json!(true));
     }
 
     /// Atomic `link` commits its mutation and event-plane observation in the

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -401,8 +401,8 @@ async fn push_index_purge_statements(
 /// lifecycle event after their row mutation: `update_entity` ->
 /// `EntityUpdated`, `delete_entity` -> `EntityDeleted`, `delete_note` ->
 /// `NoteDeleted`, `update_edge` -> `EdgeUpdated`, `delete_edge` ->
-/// `EdgeDeleted`, and `link` -> `LinkCreated`/`EdgeUpdated`. `update_note`
-/// appends no event and must never call this. See
+/// `EdgeDeleted`, `link` -> `LinkCreated`/`EdgeUpdated`, and
+/// `update_note` -> `NoteUpdated`. See
 /// `docs/api/atomic_prepare.md#event_append_statements` for why
 /// this is a `PlanStatement` rather than a `PostCommitEffect`.
 ///
@@ -413,7 +413,7 @@ async fn push_index_purge_statements(
 /// describes strengthens canonical's guarantee: the non-atomic handlers write
 /// the event in a separate transaction, ordered but not atomic with the row
 /// mutation.
-fn event_append_statements(
+pub(crate) fn event_append_statements(
     token: &NamespaceToken,
     namespace: &str,
     verb: &str,

--- a/crates/khive-runtime/src/note_write.rs
+++ b/crates/khive-runtime/src/note_write.rs
@@ -570,6 +570,23 @@ impl KhiveRuntime {
                 });
             }
         }
+        // The note update event, in the same atomic unit as the row it
+        // describes, exactly as the entity update plan does. This is the third
+        // of the three domain kinds that had no emitter anywhere in the tree.
+        statements.extend(crate::atomic_prepare::event_append_statements(
+            token,
+            &note.namespace,
+            "update",
+            khive_types::EventKind::NoteUpdated,
+            khive_types::SubstrateKind::Note,
+            note.id,
+            serde_json::json!({
+                "id": note.id,
+                "namespace": note.namespace,
+                "version": note.version,
+                "text_changed": text_changed,
+            }),
+        )?);
         // This is a potential reindex. Inherited membership is resolved by the
         // writer because vector publication can occur without a note revision.
         let post_commit =

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1704,6 +1704,30 @@ impl KhiveRuntime {
             }
         }
 
+        // The arrival event, appended only after every compensating step has had
+        // its chance to fire: a create that rolled back returns above and never
+        // reaches here, so the event plane cannot name an entity that does not
+        // exist. Deletes and updates already emitted theirs; creates did not,
+        // which left the audit trail able to say what left the graph and not
+        // what entered it.
+        let event_store = self.events(token)?;
+        let created_event = khive_storage::event::Event::new(
+            entity.namespace.clone(),
+            "create",
+            EventKind::EntityCreated,
+            SubstrateKind::Entity,
+            "",
+        )
+        .with_target(entity.id)
+        .with_payload(serde_json::json!({
+            "id": entity.id,
+            "namespace": entity.namespace,
+            "kind": entity.kind,
+        }));
+        event_store.append_event(created_event).await.map_err(|e| {
+            RuntimeError::Internal(format!("create_entity: event store write failed: {e}"))
+        })?;
+
         Ok((entity, embedding_report))
     }
 
@@ -3964,6 +3988,29 @@ impl KhiveRuntime {
                 }
             }
         }
+
+        // Same contract as the entity arrival event above: after compensation,
+        // so a rolled-back create leaves no event. This is the single funnel for
+        // every note create in the product, which is why the memory pack's own
+        // note_created emitter was removed rather than left beside it.
+        let event_store = self.events(token)?;
+        let created_event = khive_storage::event::Event::new(
+            note.namespace.clone(),
+            "create",
+            EventKind::NoteCreated,
+            SubstrateKind::Note,
+            "",
+        )
+        .with_target(note.id)
+        .with_payload(serde_json::json!({
+            "id": note.id,
+            "namespace": note.namespace,
+            "kind": note.kind,
+            "salience": note.salience,
+        }));
+        event_store.append_event(created_event).await.map_err(|e| {
+            RuntimeError::Internal(format!("create_note: event store write failed: {e}"))
+        })?;
 
         Ok((note, embedding_report))
     }


### PR DESCRIPTION
The event plane recorded what left the graph and not what entered it. `EntityCreated` had no emitter anywhere outside the event store's own classification list, `NoteUpdated` had none either, and `NoteCreated` was emitted only by the memory pack for its own verb. Deletes and entity updates emitted theirs, so a consumer of the audit trail could answer who deleted a record and could not answer who created one.

**What changed.** Three emitters, each on the single funnel its substrate already has. `EntityCreated` and `NoteCreated` on the create paths, appended after every compensating step has had its chance to fire, so a create that rolled back leaves no event behind it. `NoteUpdated` as a statement inside the note update's own atomic unit, exactly as the entity update plan already does, so the event commits in the same transaction as the row it describes.

**The duplicate that would otherwise have shipped.** The memory pack had its own `NoteCreated` emitter, which existed only because the runtime emitted nothing. Leaving it beside the new runtime emitter would have written two `note_created` events for one note. It is removed, and its test keeps the assertion that exactly one such event exists, which is what makes that duplicate fail; that assertion is now load-bearing rather than incidental.

**Two behaviour changes, named rather than buried.** The verb on a memory write's `note_created` event becomes `create`, because the emitter is the runtime's and the runtime does not know the dispatching verb. And the new emitters fail the write when the event store write fails, which is the contract the delete and update paths already had, where the removed emitter swallowed its error instead.

**Who reads the verb on these events.** A whole-tree search for code that reads an event's `verb` field returns 38 non-test sites, and the one that groups by it is `brain.event_counts`, which builds `counts_by_verb` over every event it fetches. That is the must-match control for the search: an instrument that could not see it would not be answering the question. No reader pairs `NoteCreated` with a verb, and `EventFilter.verbs` has no non-test call site. The distinction the old verb carried — a memory write against a graph write — is preserved on two better keys: the new payload carries the note's own `kind`, which is intrinsic to the record rather than incidental to the call, and the audit row for the dispatch still carries the dispatching verb unchanged.

**Tests.** One arm walks create, update and delete for both substrates and requires all six domain kinds, each exactly once and each targeting the record it describes. One existing arm asserted that a note update appends no event; it is inverted rather than deleted, because it was the forced consumer of the gap, and its documentation now says that the parity it used to certify was parity with nothing.

One consequence for anyone watching counts: memory writes now group under `create` in `counts_by_verb` rather than under `memory.remember`. That is a step in the series, not a defect.
