### PR TITLE
fix(packs): close the parameter type vocabulary to one spelling each

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -80,7 +80,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
         category: VerbCategory::Commissive,
         params: &[
             ParamDef { name: "key", param_type: "string", required: false, description: "Singleton notes only: immutable live namespace/kind identity, at most 512 UTF-8 bytes without U+0000. An occupied key fails with key_conflict; existing_id is disclosed only when list is allowed.", resolution_mode: IdResolutionMode::NotApplicable },
-            ParamDef { name: "embed", param_type: "bool", required: false, description: "Singleton notes only: defaults false for head and true otherwise. False skips inference and vector insertion while retaining lexical indexing.", resolution_mode: IdResolutionMode::NotApplicable },
+            ParamDef { name: "embed", param_type: "boolean", required: false, description: "Singleton notes only: defaults false for head and true otherwise. False skips inference and vector insertion while retaining lexical indexing.", resolution_mode: IdResolutionMode::NotApplicable },
             ParamDef { name: "fence", param_type: "object or array of object", required: false, description: "Singleton notes only. A fence object {key, kind, expected_version} or a non-empty list of at most 100 distinct (kind, key) objects, checked in order in the same writer transaction. Each expected_version is required: an integer >=1 asserts the live note's version in the write namespace; null asserts no live holder of (kind, key), so missing or soft-deleted notes satisfy it. Input alias version is accepted instead; serialization (including null) and refusal details use expected_version. Both names together or unknown fields are invalid, as is outer fence:null. Oversized lists return invalid_input naming the cap and count sent before entry interpretation or writer admission. A mismatch returns fence_conflict; absence conflicts carry expected_version='absent' and the live current_version. List refusals also carry string index (zero-based).", resolution_mode: IdResolutionMode::NotApplicable },
             ParamDef {
                 name: "kind",
@@ -176,7 +176,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "atomic",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "Bulk path only. When true (default), all items succeed or \
                               none are written. When false, items are attempted individually \
@@ -185,7 +185,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "verbose",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "Bulk path only. When true, the response includes the full \
                               entity objects in an `entities` array.",
@@ -217,7 +217,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "include_deleted",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description:
                     "If true, return soft-deleted entities (with deleted_at populated). Default false. \
@@ -431,14 +431,14 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "read",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "Filter messages by read status (kind=\"message\" only): true = read, false = unread.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
                 name: "delivered",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "Filter messages by delivery status (kind=\"message\" only): true = delivered, false = undelivered (missing or null delivered_at).",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -468,7 +468,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
         params: &[
             ParamDef { name: "expected_version", param_type: "integer", required: false, description: "Notes only: positive persisted version required inside the writer transaction. A stale version fails without mutation, with reason=version_conflict and expected_version/current_version details. Omission preserves unconditional caller semantics.", resolution_mode: IdResolutionMode::NotApplicable },
             ParamDef { name: "fence", param_type: "object or array of object", required: false, description: "Singleton notes only. A fence object {key, kind, expected_version} or a non-empty list of at most 100 distinct (kind, key) objects, checked in order in the same writer transaction. Each expected_version is required: an integer >=1 asserts the live note's version in the write namespace; null asserts no live holder of (kind, key), so missing or soft-deleted notes satisfy it. Input alias version is accepted instead; serialization (including null) and refusal details use expected_version. Both names together or unknown fields are invalid, as is outer fence:null. Oversized lists return invalid_input naming the cap and count sent before entry interpretation or writer admission. A mismatch returns fence_conflict; absence conflicts carry expected_version='absent' and the live current_version. List refusals also carry string index (zero-based).", resolution_mode: IdResolutionMode::NotApplicable },
-            ParamDef { name: "embed", param_type: "bool", required: false, description: "Notes only: omission retains embedding state. True enables reindexing; false performs no inference, removes existing vector rows transactionally and retains lexical indexing. Delayed reindex work cannot restore a stale revision.", resolution_mode: IdResolutionMode::NotApplicable },
+            ParamDef { name: "embed", param_type: "boolean", required: false, description: "Notes only: omission retains embedding state. True enables reindexing; false performs no inference, removes existing vector rows transactionally and retains lexical indexing. Delayed reindex work cannot restore a stale revision.", resolution_mode: IdResolutionMode::NotApplicable },
             ParamDef {
                 name: "id",
                 param_type: "uuid",
@@ -580,7 +580,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "hard",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "If true, permanently remove with edge cascade (default false = soft delete).",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -634,14 +634,14 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "dry_run",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "If true, return the planned summary without mutating records or emitting an event.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
                 name: "force",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "If true, bypass entity merge safety guards; the caller accepts responsibility for the merge.",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -706,7 +706,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "include_superseded",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "When true, include notes that are targeted by a supersedes edge (kind=\"note\" only). Default false — superseded notes are excluded from results.",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -837,7 +837,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "resurrect",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "Allow this singleton link to restore an existing soft-deleted \
                               natural-key edge (default false). Explicit restoration returns \
@@ -846,7 +846,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "verbose",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "Bulk mode only. When true, include successfully written edges and \
                               each row's mutation (created | updated | resurrected) in an edges \
@@ -865,7 +865,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "atomic",
-                param_type: "bool",
+                param_type: "boolean",
                 required: false,
                 description: "Bulk mode only. When true (default), all entries succeed or none \
                               are written. When false, entries are attempted individually and \
@@ -1147,7 +1147,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
             },
             ParamDef {
                 name: "reviewers",
-                param_type: "array<string>",
+                param_type: "array of string",
                 required: false,
                 description: "Actor IDs requested as reviewers. Default: empty list.",
                 resolution_mode: IdResolutionMode::NotApplicable,

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -33,7 +33,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
         params: &[
             ParamDef {
                 name: "atoms",
-                param_type: "array<object>",
+                param_type: "array of object",
                 required: true,
                 description: "List of atoms: {slug, name, content, tags?, properties?, source_uri?, source_type?, finalized?}. On update, omitted source/finalized fields are preserved; null clears a source or resets finalized to false without demoting lifecycle status.",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -54,7 +54,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
         category: VerbCategory::Commissive,
         params: &[ParamDef {
             name: "domains",
-            param_type: "array<object>",
+            param_type: "array of object",
             required: true,
             description: "List of domains: {slug, name, description?, tags?, members?}",
             resolution_mode: IdResolutionMode::NotApplicable,
@@ -129,7 +129,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
             },
             ParamDef {
                 name: "fields",
-                param_type: "array<string>",
+                param_type: "array of string",
                 required: false,
                 description: "Non-empty exact response projection. Atom fields: id, namespace, slug, \
                               name, content, tags, properties, status, source_uri, source_type, finalized, \
@@ -163,7 +163,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
         params: &[
             ParamDef {
                 name: "ids",
-                param_type: "array<string>",
+                param_type: "array of string",
                 required: true,
                 description: "Atom slugs or UUIDs to delete",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -205,7 +205,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
         params: &[
             ParamDef {
                 name: "ids",
-                param_type: "array<string>",
+                param_type: "array of string",
                 required: false,
                 description: "Atom slugs/IDs to index. Omit to index all.",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -241,7 +241,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
         params: &[
             ParamDef {
                 name: "candidates",
-                param_type: "array<object>",
+                param_type: "array of object",
                 required: true,
                 description: "Scored items: {id, score, size, name?, members?, content?, category?, information_gain?}. `members` is an optional live member count; candidates with members=0 are not selected. `knowledge.suggest`'s `results` feed this directly.",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -435,14 +435,14 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
             },
             ParamDef {
                 name: "domain_ids",
-                param_type: "array<string>",
+                param_type: "array of string",
                 required: false,
                 description: "Domain UUIDs or slugs whose member atoms should be included",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
                 name: "atom_ids",
-                param_type: "array<string>",
+                param_type: "array of string",
                 required: false,
                 description: "Atom UUIDs or slugs to include directly",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -500,7 +500,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
             },
             ParamDef {
                 name: "sections",
-                param_type: "array<object>",
+                param_type: "array of object",
                 required: true,
                 description: "Sections to upsert: [{section_type, content, heading?, sort_order?}]. \
                     section_type is a closed enum — valid values: overview | core_model | boundary_conditions | formalism | operational_guidance | examples | failure_modes | expert_lens | references | other. \
@@ -641,7 +641,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
             },
             ParamDef {
                 name: "tags",
-                param_type: "array<string>",
+                param_type: "array of string",
                 required: false,
                 description: "Optional tag list",
                 resolution_mode: IdResolutionMode::NotApplicable,
@@ -674,7 +674,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 20] = [
             },
             ParamDef {
                 name: "weight",
-                param_type: "float",
+                param_type: "number",
                 required: false,
                 description: "Edge weight; defaults to 1.0, clamped 0.0-1.0",
                 resolution_mode: IdResolutionMode::NotApplicable,

--- a/crates/khive-runtime/src/input_schema.rs
+++ b/crates/khive-runtime/src/input_schema.rs
@@ -1,12 +1,17 @@
 //! Derive a JSON Schema for a verb's parameters from its own [`ParamDef`] list.
 //!
 //! `help` publishes `params[].type` as a documentation string. Every machine
-//! bridge parses it as a JSON Schema type, and most of the spellings in use are
-//! not schema types: `bool` and `boolean` appear in the same verb, `array of
-//! string` and `array<string>` are one type spelled two ways, and `uuid` and
-//! `object or array of object` are not types at all. A driver that cannot read
-//! a verb's parameter types cannot call it, and only the git pack publishes a
+//! bridge parses it as a JSON Schema type, and several of the spellings in use
+//! are not schema types: `uuid` names a format, `array` names no element type,
+//! and `object or array of object` is a union. A driver that cannot read a
+//! verb's parameter types cannot call it, and only the git pack publishes a
 //! hand-authored `input_schema` to read instead.
+//!
+//! The duplicate spellings this module used to absorb are gone: one type is
+//! written one way, and the registry-wide test in `kkernel` asserts the exact
+//! set. The map below therefore has one arm per spelling, and adding an
+//! alternation to an arm is the shape to refuse, because it lets a second
+//! spelling of an existing type back in without anything failing.
 //!
 //! This module closes that by deriving a schema from the declarations the
 //! runtime already holds. A pack-supplied `input_schema` still wins, so the
@@ -50,15 +55,15 @@ pub fn json_schema_type(param_type: &str) -> Option<Value> {
     let schema = match param_type {
         "string" => json!({"type": "string"}),
         "integer" => json!({"type": "integer"}),
-        "number" | "float" => json!({"type": "number"}),
-        "boolean" | "bool" => json!({"type": "boolean"}),
+        "number" => json!({"type": "number"}),
+        "boolean" => json!({"type": "boolean"}),
         "object" => json!({"type": "object"}),
         "array" => json!({"type": "array"}),
         "uuid" => json!({"type": "string", "format": "uuid"}),
-        "array of string" | "array<string>" => {
+        "array of string" => {
             json!({"type": "array", "items": {"type": "string"}})
         }
-        "array of object" | "array<object>" => {
+        "array of object" => {
             json!({"type": "array", "items": {"type": "object"}})
         }
         "array of uuid" => {

--- a/crates/khive-types/src/pack.rs
+++ b/crates/khive-types/src/pack.rs
@@ -143,14 +143,16 @@ pub enum IdResolutionMode {
 /// a single verb parameter. Stored as a `&'static` slice on [`HandlerDef`] so
 /// the registry can return it without any allocation at call time.
 ///
-/// The `param_type` field is a free-form string (e.g. `"string"`, `"uuid"`,
-/// `"bool"`, `"integer"`, `"string | null"`) — it is documentation-only and
-/// not used for validation.
+/// The `param_type` field is drawn from a closed vocabulary (e.g. `"string"`,
+/// `"uuid"`, `"boolean"`, `"integer"`), asserted as an exact set by a
+/// registry-wide test. It does not validate the argument, but it is not
+/// documentation-only either: the runtime derives each verb's published JSON
+/// Schema from it, so an unmapped spelling withholds that verb's schema.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ParamDef {
     /// Parameter name as used in the DSL (e.g. `"id"`, `"kind"`, `"query"`).
     pub name: &'static str,
-    /// Free-form type hint for documentation (e.g. `"string"`, `"uuid"`, `"bool"`).
+    /// Type hint from the closed vocabulary (e.g. `"string"`, `"uuid"`, `"boolean"`).
     pub param_type: &'static str,
     /// Whether the caller must supply this parameter.
     pub required: bool,

--- a/crates/kkernel/src/pack_introspect.rs
+++ b/crates/kkernel/src/pack_introspect.rs
@@ -230,6 +230,74 @@ mod tests {
         );
     }
 
+    /// The vocabulary is closed: one spelling per type, and the exact set is
+    /// written down here.
+    ///
+    /// The test above asks whether every spelling maps to something. This one
+    /// asks the harder question, whether the set is the one we meant, and it
+    /// fails in both directions. A new spelling shows up in `unexpected`; a
+    /// spelling that stops being declared shows up in `retired`. The second half
+    /// is the load-bearing one: without it a duplicate can be reintroduced the
+    /// moment someone renames the last site that used the survivor, which is how
+    /// two spellings of boolean came to live in the same verb.
+    ///
+    /// Five entries below are not scalar type names and are deliberately left
+    /// as they are rather than renamed into the list: `array` declares no element
+    /// type, `JSON value` declares no type at all, and `object or array of
+    /// object`, `string | array<string>` and `string|null` are unions. Each of
+    /// them needs a decision about the parameter rather than a rename, so they
+    /// are recorded as the remainder instead of being quietly regularised.
+    #[test]
+    #[serial]
+    fn the_param_type_vocabulary_is_closed_to_one_spelling_per_type() {
+        const DECLARED: &[&str] = &[
+            "JSON value",
+            "array",
+            "array of object",
+            "array of string",
+            "array of uuid",
+            "boolean",
+            "integer",
+            "number",
+            "object",
+            "object or array of object",
+            "string",
+            "string | array<string>",
+            "string|null",
+            "uuid",
+        ];
+
+        let (registry, _runtime) = build_registry().expect("introspection registry");
+        let mut seen: std::collections::BTreeSet<&'static str> = std::collections::BTreeSet::new();
+        let mut declared = 0usize;
+        for handler in registry.all_verbs() {
+            for param in handler.params {
+                declared += 1;
+                seen.insert(param.param_type);
+            }
+        }
+        assert!(
+            declared > 0,
+            "no parameters were declared anywhere: an empty population cannot \
+             certify a closed vocabulary"
+        );
+
+        let expected: std::collections::BTreeSet<&str> = DECLARED.iter().copied().collect();
+        let unexpected: Vec<&str> = seen.difference(&expected).copied().collect();
+        let retired: Vec<&str> = expected.difference(&seen).copied().collect();
+        assert!(
+            unexpected.is_empty(),
+            "undeclared parameter type spellings are in use (of {declared} declarations): \
+             {unexpected:?}. Add the spelling to DECLARED only after checking it is not \
+             another way to write one already there"
+        );
+        assert!(
+            retired.is_empty(),
+            "DECLARED lists spellings nothing declares any more: {retired:?}. Remove them \
+             here and from the schema map, so the map stays total over what exists"
+        );
+    }
+
     /// A derived schema must not reject a call the dispatcher accepts.
     ///
     /// `help` is accepted on every verb and `namespace` is resolved for every


### PR DESCRIPTION
Every machine bridge reads a verb's declared parameter types as JSON Schema, and the same type was written more than one way: two spellings of boolean, two of an array of strings, two of an array of objects, and both `number` and `float`. The schema map absorbed the duplicates with alternation arms, so nothing ever failed and the duplication was free to grow one verb at a time.

**What changed.** Twenty-six declarations are renamed onto the surviving spelling in each pair, chosen by majority: `boolean`, `array of string`, `array of object`, `number`. The map's alternation arms go with them, so each type now has exactly one arm, and adding an alternation back is a visible shape in a diff rather than a quiet one.

**The test.** A registry-wide arm walks the live registry, collects the distinct spellings, and asserts the exact set. It fails in both directions. A spelling nothing declared before shows up as unexpected; a spelling nothing declares any more shows up as retired. The second half is the load-bearing one: without it a duplicate returns the moment someone renames the last site that used the survivor, which is how these pairs arose in the first place. It sits beside the existing arm that asserts the map is total, and answers the harder question that one cannot: whether the set is the one we meant.

**What is deliberately not closed.** Five entries in the asserted set are not scalar type names and are left as they are rather than renamed into the list: `array` declares no element type, `JSON value` declares no type at all, and `object or array of object`, `string | array<string>` and `string|null` are unions. Each of those needs a decision about the parameter it describes — an element type named, or the union refused — rather than a rename, so they are recorded as the remainder with that reason written into the test.

**Two documentation claims this falsifies, restated rather than left standing.** The `param_type` field is no longer free-form, and it was never only documentation: the published schema for every verb without a hand-authored one is derived from it, so an unmapped spelling withholds that verb's schema from the driver.
