### PR TITLE
fix(kg): context returns the note neighbours it already counted

### DIFF
--- a/crates/khive-pack-kg/src/handlers/context.rs
+++ b/crates/khive-pack-kg/src/handlers/context.rs
@@ -9,6 +9,12 @@
 //!      direction of `Both` uses `neighbors_with_query_directed`, which fetches
 //!      both directions in a single storage query (`UNION ALL` with a
 //!      direction literal per arm) and returns each hit tagged `Out`/`In`.
+//!   3. An edge endpoint is any record kind, so the neighbour walk returns
+//!      notes as readily as entities, while record metadata lives in two
+//!      stores. The handler hydrates entities and then the remainder from the
+//!      note store rather than reading one store and dropping what it cannot
+//!      find, which is what made a note neighbour disappear with nothing in
+//!      the response saying it had.
 //!   2. Symmetric relations (`competes_with`, `composed_with`) force
 //!      `Direction::Both` inside `neighbors_with_query` regardless of the
 //!      direction requested (existing op behavior) — the handler mirrors
@@ -31,6 +37,33 @@ use super::common::{deser, parse_direction, parse_relation, resolve_uuid_async, 
 use crate::KgPack;
 
 static CONTEXT_CALL_ID: AtomicU64 = AtomicU64::new(0);
+
+/// What a neighbour block needs about the record it points at, independent of
+/// which store holds that record.
+struct NeighborMeta {
+    substrate: &'static str,
+    kind: String,
+    name: Option<String>,
+    description: Option<String>,
+}
+
+/// A note's body stands in for an entity's description, bounded so that one
+/// long note cannot crowd every other neighbour out of the response budget.
+const NOTE_SNIPPET_CHARS: usize = 200;
+
+/// Truncation is by character and never by byte: a byte cut can land inside a
+/// UTF-8 sequence, and the result is a panic on a note nobody thought was
+/// unusual.
+fn note_snippet(content: &str) -> Option<String> {
+    if content.is_empty() {
+        return None;
+    }
+    let mut out: String = content.chars().take(NOTE_SNIPPET_CHARS).collect();
+    if content.chars().nth(NOTE_SNIPPET_CHARS).is_some() {
+        out.push('\u{2026}');
+    }
+    Some(out)
+}
 
 fn context_profile_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -443,13 +476,65 @@ impl KgPack {
                 .map_err(RuntimeError::Storage)?;
             page.items.into_iter().map(|e| (e.id, e)).collect()
         };
+
+        // The neighbour walk returns edge endpoints of every record kind, and
+        // the query above answers for entities alone. Without this second
+        // fetch a note neighbour missed the stage 4 lookup and was skipped
+        // before `assemble_within_budget` ever saw it, so the response could
+        // report an empty neighbour list beside `dropped.neighbors == 0` and
+        // both halves were true. `get_notes_batch` takes ids only, so the
+        // visible-namespace restriction the entity filter applied is applied
+        // here by hand rather than left off.
+        let visible: HashSet<String> = token
+            .visible_namespace_strs()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let unresolved: Vec<Uuid> = all_ids
+            .iter()
+            .copied()
+            .filter(|id| !entity_meta.contains_key(id))
+            .collect();
+        let note_meta: HashMap<Uuid, khive_storage::note::Note> = if unresolved.is_empty() {
+            HashMap::new()
+        } else {
+            self.runtime
+                .notes(token)?
+                .get_notes_batch(&unresolved)
+                .await
+                .map_err(RuntimeError::Storage)?
+                .into_iter()
+                .filter(|n| visible.contains(&n.namespace))
+                .map(|n| (n.id, n))
+                .collect()
+        };
+        let meta_for = |id: &Uuid| -> Option<NeighborMeta> {
+            if let Some(e) = entity_meta.get(id) {
+                return Some(NeighborMeta {
+                    substrate: "entity",
+                    kind: e.kind.clone(),
+                    name: Some(e.name.clone()),
+                    description: e.description.clone(),
+                });
+            }
+            note_meta.get(id).map(|n| NeighborMeta {
+                substrate: "note",
+                kind: n.kind.clone(),
+                name: n.name.clone(),
+                description: note_snippet(&n.content),
+            })
+        };
         if let Some(t) = t3 {
-            plog(call_id, "entity_fetch", t.elapsed().as_micros());
+            plog(call_id, "record_fetch", t.elapsed().as_micros());
         }
 
         // ---- Stage 4: assembly with budget enforcement ----
         let t4 = if prof { Some(Instant::now()) } else { None };
-        // Guards only the residual delete race; see docs/api/context-verb.md.
+        // An anchor that resolves to nothing here is the residual delete race
+        // (see docs/api/context-verb.md). Anchors stay entity-only by the
+        // verb's own contract, which refuses a note id up front with a named
+        // error; it is the NEIGHBOURS that are substrate-free, and this
+        // `continue` used to drop every one of them that was not an entity.
         let mut blocks: Vec<AnchorBlock> = Vec::with_capacity(anchor_ids.len());
         for (i, anchor) in anchor_ids.iter().enumerate() {
             let Some(e) = entity_meta.get(anchor) else {
@@ -466,12 +551,14 @@ impl KgPack {
 
             let mut neighbor_jsons = Vec::with_capacity(per_anchor_neighbors[i].len());
             for rec in &per_anchor_neighbors[i] {
-                let Some(ne) = entity_meta.get(&rec.id) else {
+                let Some(ne) = meta_for(&rec.id) else {
                     continue;
                 };
                 let nj = json!({
                     "id": rec.id.to_string(),
                     "name": ne.name,
+                    "kind": ne.kind,
+                    "substrate": ne.substrate,
                     "relation": rec.relation.as_str(),
                     "direction": rec.direction,
                     "weight": rec.weight,

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -3036,7 +3036,10 @@ async fn resolve_dispatch_on_merged_uuid_stays_bare_not_found() {
 // without saying which store they came from fails the substrate assertion; one
 // that returns them without their own kind fails the kind assertion, and kind is
 // what tells a task from an observation.
+// `handle_context` reaches the config-ledger seam, so the workspace census in
+// khive-runtime requires this group. It is the first test in this crate to take it.
 #[tokio::test]
+#[serial_test::serial(config_ledger)]
 async fn context_returns_note_neighbours_and_names_their_substrate() {
     let (rt, token, pack, registry) = configured_kg_pack().await;
 

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -3023,3 +3023,151 @@ async fn resolve_dispatch_on_merged_uuid_stays_bare_not_found() {
         "resolve has no message slot for a merge hint in this interim change; got {result:?}"
     );
 }
+
+// `context` walks edges, and an edge endpoint is any record kind, but it used to
+// hydrate record metadata from the entity store alone and silently skip whatever
+// it could not find there. The visible symptom was the worst shape available: an
+// empty neighbour list beside `dropped.neighbors == 0`, because the notes were
+// dropped in assembly before the budget stage ever counted them, so both halves
+// of the response were true and the caller had no way to tell.
+//
+// The fixture mixes substrates on purpose. An implementation that hydrates only
+// entities returns one of three and fails the count; one that returns the notes
+// without saying which store they came from fails the substrate assertion; one
+// that returns them without their own kind fails the kind assertion, and kind is
+// what tells a task from an observation.
+#[tokio::test]
+async fn context_returns_note_neighbours_and_names_their_substrate() {
+    let (rt, token, pack, registry) = configured_kg_pack().await;
+
+    let anchor = rt
+        .create_entity(
+            &token,
+            "concept",
+            None,
+            "context-substrate-anchor",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create anchor");
+    let sibling = rt
+        .create_entity(
+            &token,
+            "concept",
+            None,
+            "context-substrate-sibling",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create sibling entity neighbour");
+    let observation = rt
+        .create_note(
+            &token,
+            "observation",
+            None,
+            "an observation about the anchor",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create observation");
+    let question = rt
+        .create_note(
+            &token,
+            "question",
+            Some("a named question"),
+            "why does the anchor exist",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create question");
+
+    for (source, relation) in [
+        (sibling.id, "extends"),
+        (observation.id, "annotates"),
+        (question.id, "annotates"),
+    ] {
+        pack.handle_link(
+            &token,
+            json!({
+                "source_id": source,
+                "target_id": anchor.id,
+                "relation": relation,
+            }),
+            &registry,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("link {relation}: {e}"));
+    }
+
+    // The control: the neighbour walk itself sees all three. Any shortfall in
+    // `context` below is therefore hydration and not the edges.
+    let neighbours = pack
+        .handle_neighbors(&token, json!({"node_id": anchor.id, "direction": "both"}))
+        .await
+        .expect("neighbors");
+    assert_eq!(
+        neighbours
+            .as_array()
+            .expect("neighbors returns an array")
+            .len(),
+        3,
+        "control: the neighbour walk must see all three endpoints: {neighbours}"
+    );
+
+    let ctx = pack
+        .handle_context(
+            &token,
+            json!({"entity_ids": [anchor.id.to_string()], "hops": 1}),
+        )
+        .await
+        .expect("context");
+
+    let anchors = ctx["anchors"].as_array().expect("anchors array");
+    assert_eq!(anchors.len(), 1, "one anchor was asked for: {ctx}");
+    let returned = anchors[0]["neighbors"].as_array().expect("neighbors array");
+    assert_eq!(
+        returned.len(),
+        3,
+        "context must return every neighbour the walk found; dropped={:?} truncated={:?} got={returned:?}",
+        ctx["dropped"],
+        ctx["truncated"]
+    );
+
+    let mut by_id: std::collections::BTreeMap<String, &serde_json::Value> =
+        std::collections::BTreeMap::new();
+    for n in returned {
+        by_id.insert(n["id"].as_str().expect("neighbour id").to_string(), n);
+    }
+
+    let entity_neighbour = by_id
+        .get(&sibling.id.to_string())
+        .expect("the entity neighbour must still be there");
+    assert_eq!(entity_neighbour["substrate"], json!("entity"));
+    assert_eq!(entity_neighbour["kind"], json!("concept"));
+
+    let note_neighbour = by_id
+        .get(&observation.id.to_string())
+        .expect("the observation must be there");
+    assert_eq!(note_neighbour["substrate"], json!("note"));
+    assert_eq!(note_neighbour["kind"], json!("observation"));
+    assert_eq!(
+        note_neighbour["description"],
+        json!("an observation about the anchor"),
+        "a note's body stands in for a description"
+    );
+
+    let named_note = by_id
+        .get(&question.id.to_string())
+        .expect("the question must be there");
+    assert_eq!(named_note["substrate"], json!("note"));
+    assert_eq!(named_note["kind"], json!("question"));
+    assert_eq!(named_note["name"], json!("a named question"));
+}


### PR DESCRIPTION
`context` walks edges, and an edge endpoint is any record kind, but it hydrated record metadata from the entity store alone and skipped whatever it could not find there. The visible symptom was the worst shape available: an empty neighbour list beside `dropped.neighbors == 0`, because the notes were dropped during assembly before the budget stage ever counted them. Both halves of that response were true, and a caller had no way to tell that anything had been left out.

`annotates` is the relation that attaches a note to a record of any kind, and `context` is the call most likely to feed a model's answer, so the path that drops notes is the one where it costs most.

**What changed.** The fetch stage hydrates entities and then the remainder from the note store, restricted by hand to the same visible namespaces the entity filter applied, because the batch note getter takes ids alone. A neighbour block gains `substrate` and `kind`, so a caller can tell an observation from a task without a second call. A note's body stands in for an entity's description, bounded to 200 characters and truncated by character rather than by byte, since a byte cut can land inside a UTF-8 sequence.

**What is unchanged.** Anchors stay entity-only. The verb refuses a note id up front with a named error, and that is its declared contract; this is about the neighbours, which were never entity-only by design. The comment on the anchor lookup claimed it guarded only the residual delete race. That was true of the anchor arm and false of the neighbour arm eight lines below it, and the comment now says which is which.

**Tests.** One test builds one entity neighbour and two note neighbours, one named and one not, then asserts the count, the substrate, the kind and the body snippet. Its control is a `neighbors` call in the same pass asserting all three endpoints exist, so a shortfall in `context` is hydration and not the edges.

The mutation control was run before this was committed: with the note arm of the hydration lookup returning `None`, the test fails with one neighbour of three and reproduces the original symptom exactly — `dropped` reporting `{anchors: 0, neighbors: 0, stage: "budget"}` beside a list missing both notes.
