### PR TITLE
test(daemon): keep a cancellation receiver alive in the handover test

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -3102,6 +3102,14 @@ mod tests {
                 isolate(dir.path());
                 std::fs::write(pid_path(), std::process::id().to_string()).unwrap();
                 let (tx, rx) = tokio::sync::watch::channel(false);
+                // The scope below owns `rx` and drops it the moment the request resolves.
+                // That happens at the 60ms reconnect deadline, and on this current-thread
+                // runtime the main future can starve the canceller's 20ms sleep past it, so
+                // the send can land after the last receiver is gone -- and `watch::Sender::
+                // send` reports exactly that as an error. Holding a receiver here keeps the
+                // `unwrap` below a check on the send itself rather than a race against the
+                // thing under test; the extra receiver is inert on the path being measured.
+                let held = tx.subscribe();
                 let canceller = tokio::spawn(async move {
                     tokio::time::sleep(Duration::from_millis(20)).await;
                     if cancel {
@@ -3121,6 +3129,7 @@ mod tests {
                 assert_eq!(error.data.unwrap()["reason"], "daemon_reconnect_expired");
                 assert_eq!(KILL_COUNT.load(Ordering::SeqCst), 0);
                 canceller.await.unwrap();
+                drop(held);
             }
         }
 


### PR DESCRIPTION
A macOS test run reddened on `daemon::tests::handover::reconnect_deadline_and_cancellation_prevent_fresh_recovery` with `called Result::unwrap() on an Err value: SendError { .. }`, 604 passed and 1 failed. The failure is in the test's own scaffolding, not in the daemon: both assertions about the request result ran and passed, and the panic came from joining the helper task afterwards.

**The race.** The test creates a `watch` channel and hands the receiver to `scope_request_read_cancellation`, which stores it in a task-local context that lives exactly as long as the scoped future. That future is a request under a 60ms reconnect deadline. A spawned task sleeps 20ms, sends the cancellation, and unwraps the send.

Nothing orders those two. The test runs on a current-thread runtime, so the main future can hold the thread past 60ms without the spawned sleep ever being polled; when it resolves, the scope drops the last receiver, and the send that follows fails, because `watch::Sender::send` errors once no receivers remain. The nominal 20ms < 60ms gap is a statement about timer expiry, not about poll order under starvation.

**The change.** The test body holds a second receiver, obtained with `subscribe()` before the sender moves into the spawned task, and drops it after the join. The `unwrap` on the send stays, so a send that is genuinely refused still fails the test; what it no longer does is depend on how the runtime interleaved the two tasks. The extra receiver is never read by the code under test, so the measured path is unchanged.

**Scope.** One test. No production code changes, and no other test in this module hands a channel endpoint into a scope that owns its lifetime.
