### PR TITLE
fix(stats): count only edges a reader can still reach

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1145,6 +1145,33 @@ fn edge_order_clause(sort: &[SortOrder<EdgeSortField>]) -> String {
     format!(" ORDER BY {}", parts.join(", "))
 }
 
+/// Restricts an edge count to edges whose endpoints are still live.
+///
+/// A soft delete leaves incident edges in place on purpose (`KhiveRuntime::delete_entity`
+/// documents it; only a hard delete purges them). Every reader that walks the graph
+/// hydrates the endpoint records, so it cannot reach an edge whose endpoint is
+/// tombstoned. A count that includes those edges therefore reports a density no reader
+/// can walk, under a `count_scope` that says `live_only`.
+///
+/// The predicate excludes an endpoint only when it is PRESENT AND tombstoned. An id
+/// found in neither table belongs to a substrate this database does not hold, and
+/// treating its absence as a tombstone would silently under-count; erring toward
+/// counting keeps the failure in the direction the old behaviour already had.
+const LIVE_ENDPOINTS_CONDITION: &str = "NOT EXISTS (SELECT 1 FROM entities le \
+     WHERE le.id = graph_edges.source_id AND le.deleted_at IS NOT NULL) \
+     AND NOT EXISTS (SELECT 1 FROM entities le \
+     WHERE le.id = graph_edges.target_id AND le.deleted_at IS NOT NULL) \
+     AND NOT EXISTS (SELECT 1 FROM notes ln \
+     WHERE ln.id = graph_edges.source_id AND ln.deleted_at IS NOT NULL) \
+     AND NOT EXISTS (SELECT 1 FROM notes ln \
+     WHERE ln.id = graph_edges.target_id AND ln.deleted_at IS NOT NULL)";
+
+/// Append [`LIVE_ENDPOINTS_CONDITION`] to a `WHERE` clause produced by the edge filter
+/// builders, which always emit a non-empty ` WHERE ...`.
+fn with_live_endpoints(where_clause: &str) -> String {
+    format!("{where_clause} AND {LIVE_ENDPOINTS_CONDITION}")
+}
+
 fn build_edge_filter_sql(
     namespace: &str,
     filter: &EdgeFilter,
@@ -2354,7 +2381,10 @@ impl GraphStore for SqlGraphStore {
         let namespace = self.namespace.clone();
         self.with_reader("count_edges", move |conn| {
             let (where_clause, params) = build_edge_filter_sql(&namespace, &filter);
-            let sql = format!("SELECT COUNT(*) FROM graph_edges{}", where_clause);
+            let sql = format!(
+                "SELECT COUNT(*) FROM graph_edges{}",
+                with_live_endpoints(&where_clause)
+            );
             let mut stmt = conn.prepare(&sql)?;
             let param_refs: Vec<&dyn rusqlite::types::ToSql> =
                 params.iter().map(|p| p.as_ref()).collect();
@@ -2379,7 +2409,10 @@ impl GraphStore for SqlGraphStore {
             let mut total = 0;
             for chunk in namespaces.chunks(NAMESPACE_COUNT_CHUNK_SIZE) {
                 let (where_clause, params) = build_edge_filter_sql_for_namespaces(chunk, &filter);
-                let sql = format!("SELECT COUNT(*) FROM graph_edges{where_clause}");
+                let sql = format!(
+                    "SELECT COUNT(*) FROM graph_edges{}",
+                    with_live_endpoints(&where_clause)
+                );
                 let mut stmt = conn.prepare(&sql)?;
                 let param_refs: Vec<&dyn rusqlite::types::ToSql> =
                     params.iter().map(|p| p.as_ref()).collect();
@@ -2467,10 +2500,12 @@ impl GraphStore for SqlGraphStore {
     async fn count_edges_by_relation(&self) -> Result<Vec<(EdgeRelation, u64)>, StorageError> {
         let namespace = self.namespace.clone();
         self.with_reader("count_edges_by_relation", move |conn| {
-            let sql = "SELECT relation, COUNT(*) FROM graph_edges \
-                       WHERE namespace = ?1 AND deleted_at IS NULL \
-                       GROUP BY relation";
-            let mut stmt = conn.prepare(sql)?;
+            let sql = format!(
+                "SELECT relation, COUNT(*) FROM graph_edges \
+                 WHERE namespace = ?1 AND deleted_at IS NULL AND {LIVE_ENDPOINTS_CONDITION} \
+                 GROUP BY relation"
+            );
+            let mut stmt = conn.prepare(&sql)?;
             let rows = stmt.query_map([&namespace], |row| {
                 let relation_str: String = row.get(0)?;
                 let count: i64 = row.get(1)?;
@@ -2509,7 +2544,8 @@ impl GraphStore for SqlGraphStore {
                 let (where_clause, params) =
                     build_edge_filter_sql_for_namespaces(chunk, &EdgeFilter::default());
                 let sql = format!(
-                    "SELECT relation, COUNT(*) FROM graph_edges{where_clause} GROUP BY relation"
+                    "SELECT relation, COUNT(*) FROM graph_edges{} GROUP BY relation",
+                    with_live_endpoints(&where_clause)
                 );
                 let mut stmt = conn.prepare(&sql)?;
                 let param_refs: Vec<&dyn rusqlite::types::ToSql> =

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -187,19 +187,14 @@ pub(super) mod traverse_progress_seam {
     }
 }
 
+/// Memory-backed store with the substrate tables seeded.
+///
+/// The edge counts probe `entities`/`notes` for endpoint tombstones, so a database
+/// holding the graph DDL alone can no longer answer them. That shape is test-only:
+/// production applies one schema to one connection (`Backend::open`), and the guarded
+/// edge insert already reads those two tables.
 fn setup_memory_store() -> SqlGraphStore {
-    let config = PoolConfig {
-        path: None,
-        ..PoolConfig::default()
-    };
-    let pool = Arc::new(ConnectionPool::new(config).unwrap());
-
-    {
-        let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
-    }
-
-    SqlGraphStore::new_scoped(pool, false, "default")
+    setup_memory_store_with_substrates().1
 }
 
 /// File-backed store plus an attribution view unique to this test. Cleanup
@@ -266,6 +261,44 @@ fn insert_live_entity(pool: &ConnectionPool, id: Uuid) {
             rusqlite::params![id.to_string()],
         )
         .unwrap();
+}
+
+fn soft_delete_entity(pool: &ConnectionPool, id: Uuid) {
+    let writer = pool.writer().unwrap();
+    let changed = writer
+        .conn()
+        .execute(
+            "UPDATE entities SET deleted_at = ?2 WHERE id = ?1",
+            rusqlite::params![id.to_string(), Utc::now().timestamp_micros()],
+        )
+        .unwrap();
+    assert_eq!(changed, 1, "soft delete must have tombstoned a row");
+}
+
+fn insert_note(pool: &ConnectionPool, id: Uuid, deleted: bool) {
+    let writer = pool.writer().unwrap();
+    writer
+        .conn()
+        .execute(
+            "INSERT INTO notes (id, deleted_at) VALUES (?1, ?2)",
+            rusqlite::params![
+                id.to_string(),
+                deleted.then(|| Utc::now().timestamp_micros())
+            ],
+        )
+        .unwrap();
+}
+
+fn soft_delete_note(pool: &ConnectionPool, id: Uuid) {
+    let writer = pool.writer().unwrap();
+    let changed = writer
+        .conn()
+        .execute(
+            "UPDATE notes SET deleted_at = ?2 WHERE id = ?1",
+            rusqlite::params![id.to_string(), Utc::now().timestamp_micros()],
+        )
+        .unwrap();
+    assert_eq!(changed, 1, "soft delete must have tombstoned a note row");
 }
 
 fn hard_delete_entity(pool: &ConnectionPool, id: Uuid) {
@@ -933,6 +966,108 @@ async fn test_count_edges() {
     }
 
     assert_eq!(store.count_edges(EdgeFilter::default()).await.unwrap(), 5);
+}
+
+/// A soft delete leaves incident edges in place, so an edge can outlive its endpoint. Every
+/// reader that walks the graph hydrates endpoints and cannot reach such an edge, so the
+/// counts must not report it either.
+///
+/// The fixture is built so that one plausible wrong implementation fails each arm: an
+/// implementation that ignores endpoints fails the drop; one that excludes an endpoint
+/// merely for being absent from `entities`/`notes` fails the ghost arm; one that checks
+/// only `source_id` fails the inbound arm; one that checks only entities fails the note
+/// arm. The live pair is the control, and it is read in the same pass that produces each
+/// absence.
+#[tokio::test]
+async fn edge_counts_skip_edges_whose_endpoint_is_tombstoned() {
+    let (pool, store) = setup_memory_store_with_substrates();
+
+    let (out_src, out_dst) = (Uuid::new_v4(), Uuid::new_v4());
+    let (in_src, in_dst) = (Uuid::new_v4(), Uuid::new_v4());
+    let (live_src, live_dst) = (Uuid::new_v4(), Uuid::new_v4());
+    for id in [out_src, out_dst, in_src, in_dst, live_src, live_dst] {
+        insert_live_entity(&pool, id);
+    }
+    let (note_live, note_doomed) = (Uuid::new_v4(), Uuid::new_v4());
+    insert_live_entity(&pool, note_live);
+    insert_note(&pool, note_doomed, false);
+    // Endpoints this database holds in neither table: a different substrate's ids. Absence
+    // is not a tombstone, so these stay counted.
+    let (ghost_a, ghost_b) = (Uuid::new_v4(), Uuid::new_v4());
+
+    for edge in [
+        make_edge(out_src, out_dst, EdgeRelation::Contains, 1.0),
+        make_edge(in_src, in_dst, EdgeRelation::Contains, 1.0),
+        make_edge(live_src, live_dst, EdgeRelation::Contains, 1.0),
+        make_edge(note_doomed, note_live, EdgeRelation::Annotates, 1.0),
+        make_edge(ghost_a, ghost_b, EdgeRelation::DependsOn, 1.0),
+    ] {
+        store.upsert_edge(edge).await.unwrap();
+    }
+
+    let namespaces = vec!["default".to_string()];
+
+    assert_eq!(store.count_edges(EdgeFilter::default()).await.unwrap(), 5);
+    let pre: HashMap<_, _> = store
+        .count_edges_by_relation()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(
+        pre.get(&EdgeRelation::Contains),
+        Some(&3),
+        "pre-state: all three entity-to-entity edges are counted"
+    );
+
+    // Outbound endpoint, then inbound endpoint, then a note endpoint. After each, the live
+    // pair and the ghost pair must still be there.
+    soft_delete_entity(&pool, out_src);
+    assert_eq!(store.count_edges(EdgeFilter::default()).await.unwrap(), 4);
+
+    soft_delete_entity(&pool, in_dst);
+    assert_eq!(store.count_edges(EdgeFilter::default()).await.unwrap(), 3);
+
+    soft_delete_note(&pool, note_doomed);
+    assert_eq!(store.count_edges(EdgeFilter::default()).await.unwrap(), 2);
+
+    let by_relation: HashMap<_, _> = store
+        .count_edges_by_relation()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(
+        by_relation.get(&EdgeRelation::Contains),
+        Some(&1),
+        "only the live entity pair survives; got {by_relation:?}"
+    );
+    assert_eq!(
+        by_relation.get(&EdgeRelation::DependsOn),
+        Some(&1),
+        "an endpoint absent from both tables is not a tombstone; got {by_relation:?}"
+    );
+    assert_eq!(
+        by_relation.get(&EdgeRelation::Annotates),
+        None,
+        "the note endpoint's tombstone removes its edge; got {by_relation:?}"
+    );
+
+    // The namespace-scoped variants answer the same question and must agree.
+    assert_eq!(
+        store
+            .count_edges_in_namespaces(&namespaces, EdgeFilter::default())
+            .await
+            .unwrap(),
+        2
+    );
+    let scoped: HashMap<_, _> = store
+        .count_edges_by_relation_in_namespaces(&namespaces)
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(scoped, by_relation, "scoped and unscoped counts must agree");
 }
 
 #[tokio::test]

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -193,6 +193,20 @@ pub(super) mod traverse_progress_seam {
 /// holding the graph DDL alone can no longer answer them. That shape is test-only:
 /// production applies one schema to one connection (`Backend::open`), and the guarded
 /// edge insert already reads those two tables.
+/// The graph DDL plus the minimal `entities`/`notes` tables the edge counts probe for
+/// endpoint tombstones, applied together because a database holding one without the other
+/// cannot answer those counts. That split is test-only: production applies one schema to
+/// one connection, and the guarded edge insert already reads both tables.
+fn apply_test_schema(conn: &rusqlite::Connection) {
+    conn.execute_batch(GRAPH_DDL).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS entities (id TEXT PRIMARY KEY, deleted_at INTEGER);
+         CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, deleted_at INTEGER);
+         CREATE TABLE IF NOT EXISTS events (id TEXT PRIMARY KEY);",
+    )
+    .unwrap();
+}
+
 fn setup_memory_store() -> SqlGraphStore {
     setup_memory_store_with_substrates().1
 }
@@ -213,7 +227,7 @@ fn setup_file_store_with_origin_view() -> (
     let pool = Arc::new(ConnectionPool::new(config).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+        apply_test_schema(writer.conn());
     }
     let identity = match pool.origin() {
         khive_storage::tx_registry::TxOrigin::Database(identity) => identity,
@@ -237,15 +251,7 @@ fn setup_memory_store_with_substrates() -> (Arc<ConnectionPool>, SqlGraphStore) 
 
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
-        writer
-            .conn()
-            .execute_batch(
-                "CREATE TABLE entities (id TEXT PRIMARY KEY, deleted_at INTEGER);
-                 CREATE TABLE notes (id TEXT PRIMARY KEY, deleted_at INTEGER);
-                 CREATE TABLE events (id TEXT PRIMARY KEY);",
-            )
-            .unwrap();
+        apply_test_schema(writer.conn());
     }
 
     let store = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "default");
@@ -343,7 +349,7 @@ async fn edge_pages_run_when_sqlite_count_is_denied() {
     );
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+        apply_test_schema(writer.conn());
     }
     // Pooled-reader mode lets the authorizer below observe the exact
     // connection used by both the control count and the page queries.
@@ -765,15 +771,7 @@ async fn observed_batch_upsert_later_refusal_preserves_earlier_replacement() {
             );
             {
                 let writer = pool.writer().unwrap();
-                writer.conn().execute_batch(GRAPH_DDL).unwrap();
-                writer
-                    .conn()
-                    .execute_batch(
-                        "CREATE TABLE entities (id TEXT PRIMARY KEY, deleted_at INTEGER);
-                 CREATE TABLE notes (id TEXT PRIMARY KEY, deleted_at INTEGER);
-                 CREATE TABLE events (id TEXT PRIMARY KEY);",
-                    )
-                    .unwrap();
+                apply_test_schema(writer.conn());
             }
             let store = SqlGraphStore::new_scoped(Arc::clone(&pool), is_file_backed, "default");
             assert_eq!(
@@ -1077,11 +1075,7 @@ async fn batched_namespace_edge_counts_exceed_sqlite_variable_limit() {
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(config).unwrap());
-    pool.writer()
-        .unwrap()
-        .conn()
-        .execute_batch(GRAPH_DDL)
-        .unwrap();
+    apply_test_schema(pool.writer().unwrap().conn());
     let store_a = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "stats-a");
     let store_b = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "stats-b");
 
@@ -1158,11 +1152,7 @@ async fn query_edges_in_namespaces_offset_paging_exceeds_sqlite_variable_limit()
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(config).unwrap());
-    pool.writer()
-        .unwrap()
-        .conn()
-        .execute_batch(GRAPH_DDL)
-        .unwrap();
+    apply_test_schema(pool.writer().unwrap().conn());
     let store_a = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "list-a");
     let store_b = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "list-b");
 
@@ -1232,11 +1222,7 @@ async fn duplicate_namespace_across_chunk_boundary_is_not_double_counted() {
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(config).unwrap());
-    pool.writer()
-        .unwrap()
-        .conn()
-        .execute_batch(GRAPH_DDL)
-        .unwrap();
+    apply_test_schema(pool.writer().unwrap().conn());
     let store_a = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "stats-a");
 
     let mut edge_a1 = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 1.0);
@@ -2111,7 +2097,7 @@ async fn graph_traverse_read_span_scoped_to_secondary_backend_visible_only_in_it
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+        apply_test_schema(writer.conn());
     }
     let secondary_identity = match pool.origin() {
         khive_storage::tx_registry::TxOrigin::Database(id) => id,
@@ -4400,7 +4386,7 @@ async fn upsert_edges_routes_through_writer_task_when_flag_enabled() {
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+        apply_test_schema(writer.conn());
     }
 
     let store = SqlGraphStore::new_scoped(Arc::clone(&pool), true, "default");
@@ -4458,7 +4444,7 @@ async fn upsert_edge_routes_through_writer_task_when_flag_enabled() {
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+        apply_test_schema(writer.conn());
     }
 
     let store = Arc::new(SqlGraphStore::new_scoped(
@@ -4965,15 +4951,7 @@ async fn upsert_edge_guarded_probe_is_atomic_with_insert_on_file_backed_singleto
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
-        writer
-            .conn()
-            .execute_batch(
-                "CREATE TABLE entities (id TEXT PRIMARY KEY, deleted_at INTEGER);
-                 CREATE TABLE notes (id TEXT PRIMARY KEY, deleted_at INTEGER);
-                 CREATE TABLE events (id TEXT PRIMARY KEY);",
-            )
-            .unwrap();
+        apply_test_schema(writer.conn());
     }
     assert!(
         pool.writer_task_handle().unwrap().is_none(),
@@ -5113,7 +5091,7 @@ fn setup_store_with_a_corrupt_relation_row(node: Uuid, good: usize) -> SqlGraphS
     let pool = Arc::new(ConnectionPool::new(config).unwrap());
     {
         let writer = pool.writer().unwrap();
-        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+        apply_test_schema(writer.conn());
         let now = Utc::now().timestamp_micros();
         for i in 0..good {
             writer


### PR DESCRIPTION
`stats()` on a store whose entities have been deleted reports edges that nothing can reach. On a deployed instance the end state read `entities 0, notes 0, edges 5`, with `edges_by_relation` still naming relations whose endpoints were all gone, and the count rose by exactly the number of edges created in a session that deleted every one of their anchors.

**Why the two disagree.** A soft delete leaves incident edges in place. That is deliberate: `KhiveRuntime::delete_entity` only cascades on a hard delete, and it says so. Every reader that walks the graph hydrates the endpoint records, so it cannot reach an edge whose endpoint is tombstoned, and it does not: `neighbors` from a deleted anchor returns nothing, `neighbors` from the surviving endpoint with `direction=in` does not return the dangling edge, and `context` declines a tombstoned anchor by name. The counts were the only reader that did not join anything, filtering on the edge row's own `deleted_at` alone. So the number was unreachable by construction, and `count_scope` reported `rows: live_only` over it, which tells a caller the count can be trusted for exactly the thing it cannot be trusted for.

**The change.** The four edge-count queries (`count_edges`, `count_edges_in_namespaces`, `count_edges_by_relation`, `count_edges_by_relation_in_namespaces`) now also require both endpoints to be live. One shared predicate, so the scoped and unscoped forms cannot drift into disagreeing.

The predicate excludes an endpoint only when it is **present and tombstoned**. An id held in neither `entities` nor `notes` belongs to a substrate this database does not own, and reading its absence as a tombstone would silently under-count; erring toward counting keeps the error in the direction the previous behaviour already had. The existing count test, which inserts edges between ids that exist in no table and expects all of them, is the standing control for that half.

**Test.** One test, built so that a different plausible implementation fails each arm: ignoring endpoints fails the drop; excluding an endpoint for being merely absent fails the ghost arm; checking only `source_id` fails the inbound arm; checking only `entities` fails the note arm. A live pair is read in the same pass that produces every absence, so a zero is a real exclusion rather than a query that stopped matching.

The memory-backed test store now seeds the minimal `entities`/`notes` tables. A database holding the graph DDL alone can no longer answer these counts, which is a test-only shape: production applies one schema to one connection, and the guarded edge insert already reads both tables.

**Scope.** The counts only. Listing edges still enumerates the rows. Whether `list` should also hide an edge whose endpoint is gone is a separate question about what enumeration means, and this change does not answer it.
