### PR TITLE
feat(sql): move statements into sql files, and lint them properly

### DIFF
--- a/crates/khive-pack-brain/sql/brain_event_log_insert.sql
+++ b/crates/khive-pack-brain/sql/brain_event_log_insert.sql
@@ -1,0 +1,2 @@
+INSERT INTO brain_event_log (profile_id, namespace, event_kind, payload, created_at)
+VALUES (?1, ?2, ?3, ?4, ?5)

--- a/crates/khive-pack-brain/sql/brain_event_log_since.sql
+++ b/crates/khive-pack-brain/sql/brain_event_log_since.sql
@@ -1,0 +1,5 @@
+SELECT id, profile_id, event_kind, payload, created_at
+FROM brain_event_log
+WHERE namespace = ?1
+AND created_at > ?2
+ORDER BY created_at ASC, id ASC

--- a/crates/khive-pack-brain/sql/brain_implicit_mass_read.sql
+++ b/crates/khive-pack-brain/sql/brain_implicit_mass_read.sql
@@ -1,0 +1,5 @@
+SELECT mass, last_event_at
+FROM brain_implicit_mass
+WHERE profile_id = ?1
+AND namespace = ?2
+AND target_id = ?3

--- a/crates/khive-pack-brain/sql/brain_implicit_mass_upsert.sql
+++ b/crates/khive-pack-brain/sql/brain_implicit_mass_upsert.sql
@@ -1,0 +1,5 @@
+INSERT INTO brain_implicit_mass (profile_id, namespace, target_id, mass, last_event_at, last_effective_weight)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+ON CONFLICT(profile_id, namespace, target_id)
+DO UPDATE
+SET mass = excluded.mass, last_event_at = excluded.last_event_at, last_effective_weight = excluded.last_effective_weight

--- a/crates/khive-pack-brain/sql/brain_profile_snapshot_latest.sql
+++ b/crates/khive-pack-brain/sql/brain_profile_snapshot_latest.sql
@@ -1,0 +1,6 @@
+SELECT snapshot_json, updated_at
+FROM brain_profile_snapshots
+WHERE profile_id = ?1
+AND namespace = ?2
+ORDER BY updated_at DESC
+LIMIT 1

--- a/crates/khive-pack-brain/sql/brain_profile_snapshot_upsert.sql
+++ b/crates/khive-pack-brain/sql/brain_profile_snapshot_upsert.sql
@@ -1,0 +1,5 @@
+INSERT INTO brain_profile_snapshots (profile_id, namespace, snapshot_json, updated_at)
+VALUES (?1, ?2, ?3, ?4)
+ON CONFLICT(profile_id, namespace)
+DO UPDATE
+SET snapshot_json = excluded.snapshot_json, updated_at = excluded.updated_at

--- a/crates/khive-pack-brain/sql/brain_profile_snapshot_version.sql
+++ b/crates/khive-pack-brain/sql/brain_profile_snapshot_version.sql
@@ -1,0 +1,4 @@
+SELECT updated_at
+FROM brain_profile_snapshots
+WHERE profile_id = ?1
+AND namespace = ?2

--- a/crates/khive-pack-brain/sql/brain_scorer_dedup_claim.sql
+++ b/crates/khive-pack-brain/sql/brain_scorer_dedup_claim.sql
@@ -1,0 +1,2 @@
+INSERT OR IGNORE INTO brain_scorer_dedup (scorer_run_id, serve_ledger_id, claimed_at)
+VALUES (?1, ?2, ?3)

--- a/crates/khive-pack-brain/sql/brain_serve_ledger_backfill_grade.sql
+++ b/crates/khive-pack-brain/sql/brain_serve_ledger_backfill_grade.sql
@@ -1,0 +1,3 @@
+UPDATE brain_serve_ledger
+SET grade = ?1, graded_at = ?2, scorer_run_id = ?3
+WHERE id = ?4

--- a/crates/khive-pack-brain/sql/brain_serve_ledger_insert.sql
+++ b/crates/khive-pack-brain/sql/brain_serve_ledger_insert.sql
@@ -1,0 +1,4 @@
+INSERT INTO brain_serve_ledger (id, namespace, consumer_kind, served_by_profile_id, resolved_profile_id, resolved_at, target_id, query_class, query_raw, served_at, serve_attribution)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+ON CONFLICT(namespace, target_id, query_class, served_at)
+DO NOTHING

--- a/crates/khive-pack-brain/sql/brain_serve_ledger_row.sql
+++ b/crates/khive-pack-brain/sql/brain_serve_ledger_row.sql
@@ -1,0 +1,3 @@
+SELECT id, namespace, consumer_kind, served_by_profile_id, resolved_profile_id, resolved_at, accounting_profile_id, target_id, query_class, query_raw, served_at, grade, graded_at, scorer_run_id, serve_attribution
+FROM brain_serve_ledger
+WHERE id = ?1

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -334,8 +334,7 @@ async fn claim_dedup_within_tx(
 ) -> Result<bool, RuntimeError> {
     let rows_affected = writer
         .execute(SqlStatement {
-            sql: sql!("brain_scorer_dedup_claim")
-                .into(),
+            sql: sql!("brain_scorer_dedup_claim").into(),
             params: vec![
                 SqlValue::Text(scorer_run_id.to_string()),
                 SqlValue::Text(serve_ledger_id.to_string()),
@@ -361,8 +360,7 @@ async fn fold_within_tx(
 ) -> Result<FoldGateOutcome, RuntimeError> {
     let row = writer
         .query_row(SqlStatement {
-            sql: sql!("brain_implicit_mass_read")
-                .into(),
+            sql: sql!("brain_implicit_mass_read").into(),
             params: vec![
                 SqlValue::Text(profile_id.to_string()),
                 SqlValue::Text(namespace.to_string()),
@@ -406,8 +404,7 @@ async fn fold_within_tx(
 
     writer
         .execute(SqlStatement {
-            sql: sql!("brain_implicit_mass_upsert")
-                .into(),
+            sql: sql!("brain_implicit_mass_upsert").into(),
             params: vec![
                 SqlValue::Text(profile_id.to_string()),
                 SqlValue::Text(namespace.to_string()),

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -11,6 +11,8 @@
 //! See `crates/khive-pack-brain/docs/api/fold-gate.md` for the full mass
 //! invariant, concurrency proof, why the decay math runs in Rust not SQL, and
 //! the scorer-dedup atomicity argument.
+use crate::sql::sql;
+
 use khive_runtime::{EventAttribution, RuntimeError};
 use khive_storage::event::Event;
 use khive_storage::types::{SqlStatement, SqlValue};
@@ -332,9 +334,7 @@ async fn claim_dedup_within_tx(
 ) -> Result<bool, RuntimeError> {
     let rows_affected = writer
         .execute(SqlStatement {
-            sql: "INSERT OR IGNORE INTO brain_scorer_dedup \
-                  (scorer_run_id, serve_ledger_id, claimed_at) \
-                  VALUES (?1, ?2, ?3)"
+            sql: sql!("brain_scorer_dedup_claim")
                 .into(),
             params: vec![
                 SqlValue::Text(scorer_run_id.to_string()),
@@ -361,8 +361,7 @@ async fn fold_within_tx(
 ) -> Result<FoldGateOutcome, RuntimeError> {
     let row = writer
         .query_row(SqlStatement {
-            sql: "SELECT mass, last_event_at FROM brain_implicit_mass \
-                  WHERE profile_id = ?1 AND namespace = ?2 AND target_id = ?3"
+            sql: sql!("brain_implicit_mass_read")
                 .into(),
             params: vec![
                 SqlValue::Text(profile_id.to_string()),
@@ -407,13 +406,7 @@ async fn fold_within_tx(
 
     writer
         .execute(SqlStatement {
-            sql: "INSERT INTO brain_implicit_mass \
-                  (profile_id, namespace, target_id, mass, last_event_at, last_effective_weight) \
-                  VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
-                  ON CONFLICT(profile_id, namespace, target_id) \
-                  DO UPDATE SET mass = excluded.mass, \
-                                last_event_at = excluded.last_event_at, \
-                                last_effective_weight = excluded.last_effective_weight"
+            sql: sql!("brain_implicit_mass_upsert")
                 .into(),
             params: vec![
                 SqlValue::Text(profile_id.to_string()),

--- a/crates/khive-pack-brain/src/lib.rs
+++ b/crates/khive-pack-brain/src/lib.rs
@@ -9,6 +9,7 @@ pub mod tunable;
 
 mod event;
 mod pack;
+mod sql;
 
 pub(crate) use pack::{apply_dispatch_signal, sync_balanced_recall_record};
 pub use pack::{BrainPack, ENTITY_CACHE_CAPACITY};

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -834,8 +834,7 @@ async fn load_snapshot_version_on_reader<R: SqlReader + ?Sized>(
 ) -> Result<Option<i64>, RuntimeError> {
     let row = reader
         .query_scalar(SqlStatement {
-            sql: sql!("brain_profile_snapshot_version")
-                .into(),
+            sql: sql!("brain_profile_snapshot_version").into(),
             params: vec![
                 SqlValue::Text(SNAPSHOT_PROFILE_ID.to_string()),
                 SqlValue::Text(namespace.to_string()),
@@ -1043,8 +1042,7 @@ async fn load_events_since_with_window(
     let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
     let rows = reader
         .query_all(SqlStatement {
-            sql: sql!("brain_event_log_since")
-                .into(),
+            sql: sql!("brain_event_log_since").into(),
             params: vec![
                 SqlValue::Text(namespace.to_string()),
                 SqlValue::Integer(since_us),

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -1,5 +1,7 @@
 //! Brain state persistence — snapshot upsert and namespace-scoped reload.
 
+use crate::sql::sql;
+
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -268,7 +270,7 @@ async fn append_brain_event_on_writer(
 
     writer
         .execute(SqlStatement {
-            sql: "INSERT INTO brain_event_log (profile_id, namespace, event_kind, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5)".into(),
+            sql: sql!("brain_event_log_insert").into(),
             params: vec![
                 SqlValue::Text(profile_id.to_string()),
                 SqlValue::Text(namespace.to_string()),
@@ -297,7 +299,7 @@ async fn upsert_snapshot_on_writer(
 
     writer
         .execute(SqlStatement {
-            sql: "INSERT INTO brain_profile_snapshots (profile_id, namespace, snapshot_json, updated_at) VALUES (?1, ?2, ?3, ?4) ON CONFLICT(profile_id, namespace) DO UPDATE SET snapshot_json = excluded.snapshot_json, updated_at = excluded.updated_at".into(),
+            sql: sql!("brain_profile_snapshot_upsert").into(),
             params: vec![
                 SqlValue::Text(SNAPSHOT_PROFILE_ID.to_string()),
                 SqlValue::Text(namespace.to_string()),
@@ -787,7 +789,7 @@ async fn load_latest_snapshot_on_reader<R: SqlReader + ?Sized>(
 ) -> Result<Option<(BrainStateSnapshot, i64)>, RuntimeError> {
     let row = reader
         .query_row(SqlStatement {
-            sql: "SELECT snapshot_json, updated_at FROM brain_profile_snapshots WHERE profile_id = ?1 AND namespace = ?2 ORDER BY updated_at DESC LIMIT 1".into(),
+            sql: sql!("brain_profile_snapshot_latest").into(),
             params: vec![
                 SqlValue::Text(SNAPSHOT_PROFILE_ID.to_string()),
                 SqlValue::Text(namespace.to_string()),
@@ -832,7 +834,7 @@ async fn load_snapshot_version_on_reader<R: SqlReader + ?Sized>(
 ) -> Result<Option<i64>, RuntimeError> {
     let row = reader
         .query_scalar(SqlStatement {
-            sql: "SELECT updated_at FROM brain_profile_snapshots WHERE profile_id = ?1 AND namespace = ?2"
+            sql: sql!("brain_profile_snapshot_version")
                 .into(),
             params: vec![
                 SqlValue::Text(SNAPSHOT_PROFILE_ID.to_string()),
@@ -1041,10 +1043,7 @@ async fn load_events_since_with_window(
     let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
     let rows = reader
         .query_all(SqlStatement {
-            sql: "SELECT id, profile_id, event_kind, payload, created_at \
-                  FROM brain_event_log \
-                  WHERE namespace = ?1 AND created_at > ?2 \
-                  ORDER BY created_at ASC, id ASC"
+            sql: sql!("brain_event_log_since")
                 .into(),
             params: vec![
                 SqlValue::Text(namespace.to_string()),

--- a/crates/khive-pack-brain/src/serve_ledger.rs
+++ b/crates/khive-pack-brain/src/serve_ledger.rs
@@ -8,6 +8,8 @@
 //! `brain.auto_feedback` when a caller supplies `serve_ledger_id` (ADR-081 §6):
 //! dedup by `(scorer_run_id, id)`, the `accounting_profile_id` zero-weight
 //! fail-safe, and grade backfill.
+use crate::sql::sql;
+
 use khive_runtime::RuntimeError;
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::SqlAccess;
@@ -108,11 +110,7 @@ fn serve_ledger_insert_statement(
     serve_attribution: Option<&str>,
 ) -> SqlStatement {
     SqlStatement {
-        sql: "INSERT INTO brain_serve_ledger \
-              (id, namespace, consumer_kind, served_by_profile_id, resolved_profile_id, \
-               resolved_at, target_id, query_class, query_raw, served_at, serve_attribution) \
-              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
-              ON CONFLICT(namespace, target_id, query_class, served_at) DO NOTHING"
+        sql: sql!("brain_serve_ledger_insert")
             .into(),
         params: vec![
             SqlValue::Text(row.id.clone()),
@@ -240,11 +238,7 @@ pub async fn get_serve_row(
     let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
     let row = reader
         .query_row(SqlStatement {
-            sql: "SELECT id, namespace, consumer_kind, served_by_profile_id, \
-                  resolved_profile_id, resolved_at, accounting_profile_id, target_id, \
-                  query_class, query_raw, served_at, grade, graded_at, scorer_run_id, \
-                  serve_attribution \
-                  FROM brain_serve_ledger WHERE id = ?1"
+            sql: sql!("brain_serve_ledger_row")
                 .into(),
             params: vec![SqlValue::Text(id.to_string())],
             label: Some("brain_serve_ledger_get".into()),
@@ -292,8 +286,7 @@ pub async fn backfill_grade(
     let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
     writer
         .execute(SqlStatement {
-            sql: "UPDATE brain_serve_ledger SET grade = ?1, graded_at = ?2, scorer_run_id = ?3 \
-                  WHERE id = ?4"
+            sql: sql!("brain_serve_ledger_backfill_grade")
                 .into(),
             params: vec![
                 SqlValue::Text(grade.to_string()),

--- a/crates/khive-pack-brain/src/serve_ledger.rs
+++ b/crates/khive-pack-brain/src/serve_ledger.rs
@@ -110,8 +110,7 @@ fn serve_ledger_insert_statement(
     serve_attribution: Option<&str>,
 ) -> SqlStatement {
     SqlStatement {
-        sql: sql!("brain_serve_ledger_insert")
-            .into(),
+        sql: sql!("brain_serve_ledger_insert").into(),
         params: vec![
             SqlValue::Text(row.id.clone()),
             SqlValue::Text(namespace.to_string()),
@@ -238,8 +237,7 @@ pub async fn get_serve_row(
     let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
     let row = reader
         .query_row(SqlStatement {
-            sql: sql!("brain_serve_ledger_row")
-                .into(),
+            sql: sql!("brain_serve_ledger_row").into(),
             params: vec![SqlValue::Text(id.to_string())],
             label: Some("brain_serve_ledger_get".into()),
         })
@@ -286,8 +284,7 @@ pub async fn backfill_grade(
     let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
     writer
         .execute(SqlStatement {
-            sql: sql!("brain_serve_ledger_backfill_grade")
-                .into(),
+            sql: sql!("brain_serve_ledger_backfill_grade").into(),
             params: vec![
                 SqlValue::Text(grade.to_string()),
                 SqlValue::Integer(graded_at_us),
@@ -522,9 +519,13 @@ mod tests {
         assert_eq!(batches.len(), 1);
         let statements = &batches[0];
         assert_eq!(statements.len(), rows.len());
+        // The statement now comes from `sql/brain_serve_ledger_insert.sql`, which wraps
+        // its clauses across lines. SQL does not care and neither does this assertion:
+        // what it is here to pin is that the batch upserts and swallows the duplicate
+        // rather than failing the whole batch, so it reads the clause, not the layout.
+        let one_line = |sql: &str| sql.split_whitespace().collect::<Vec<_>>().join(" ");
         for (statement, row) in statements.iter().zip(rows.iter()) {
-            assert!(statement
-                .sql
+            assert!(one_line(&statement.sql)
                 .ends_with("ON CONFLICT(namespace, target_id, query_class, served_at) DO NOTHING"));
             assert_eq!(
                 statement.label.as_deref(),

--- a/crates/khive-pack-brain/src/sql.rs
+++ b/crates/khive-pack-brain/src/sql.rs
@@ -1,0 +1,15 @@
+//! SQL lives beside the code as `sql/<name>.sql`: one statement per file,
+//! `?N` binds only, never string-built, loaded at compile time by `sql!`.
+//!
+//! `include_str!` resolves at compile time, so a renamed or missing file is a
+//! build error rather than a runtime one, and `scripts/lint-sql.sh` prepares
+//! every one of those files against the real schema, so a table or column that
+//! does not exist fails before a test ever runs.
+
+/// The statement text of `sql/<name>.sql`, checked in at compile time.
+macro_rules! sql {
+    ($name:literal) => {
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/sql/", $name, ".sql"))
+    };
+}
+pub(crate) use sql;

--- a/crates/khive-pack-brain/src/sql.rs
+++ b/crates/khive-pack-brain/src/sql.rs
@@ -7,9 +7,18 @@
 //! does not exist fails before a test ever runs.
 
 /// The statement text of `sql/<name>.sql`, checked in at compile time.
+///
+/// The trailing newline every text file carries is trimmed, in a `const` block so
+/// it costs nothing at run time and the result stays a `&'static str`. A statement
+/// that used to be a Rust literal ended at its last word, and callers and tests
+/// anchored on that: leaving the newline on would change the string a reader of
+/// this file has no reason to think changed.
 macro_rules! sql {
     ($name:literal) => {
-        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/sql/", $name, ".sql"))
+        const {
+            include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/sql/", $name, ".sql"))
+                .trim_ascii_end()
+        }
     };
 }
 pub(crate) use sql;

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -7943,6 +7943,140 @@ pub(crate) mod tests {
     /// `src/`, integration tests live under `tests/`. Anything outside those
     /// two directories per crate (benches, examples) never runs as `cargo
     /// test` and is out of scope for this census.
+    /// SQL text belongs in `sql/<name>.sql`, reached through each crate's `sql!`
+    /// macro, not in a Rust string literal. This is the burn-down instrument for that
+    /// move: a crate is added to `CONVERTED` by the pull request that extracts it, and
+    /// from then on the workspace refuses to take a statement back into Rust.
+    ///
+    /// What it can and cannot see, said plainly because the answer is load-bearing.
+    /// It selects by SPELLING: a string literal whose first word is a SQL verb. It
+    /// therefore cannot see a statement assembled from fragments, one returned by a
+    /// helper, or one built at runtime. Its population is code that COMPILES into the
+    /// crate, which means `#[cfg(test)]` module bodies are stripped along with
+    /// `tests/` and `benches/` — a test that stands a fixture table up inline is out
+    /// of scope for this program. The must-match control below is what keeps those
+    /// limits honest: an unconverted crate has to trip the same predicate in the same
+    /// pass, or the detector is broken rather than the tree clean.
+    #[test]
+    fn converted_crates_keep_their_sql_out_of_rust() {
+        /// Crates whose statements live in `sql/`. One pull request adds one name.
+        const CONVERTED: &[&str] = &["khive-pack-brain"];
+        /// A crate known to still hold SQL in Rust, used only to prove the detector
+        /// fires. When this one is converted, move the control to another unconverted
+        /// crate rather than deleting it.
+        const STILL_INLINE: &str = "khive-db";
+
+        fn strip_test_modules(text: &str) -> String {
+            let bytes = text.as_bytes();
+            let mut out = String::with_capacity(text.len());
+            let mut cursor = 0usize;
+            while let Some(found) = text[cursor..].find("#[cfg(test)]") {
+                let start = cursor + found;
+                // Only a `mod` item is stripped; `#[cfg(test)]` on a `use` or a `fn`
+                // leaves nothing to brace-match.
+                let after = &text[start..];
+                let Some(brace_rel) = after.find('{') else {
+                    out.push_str(&text[cursor..]);
+                    return out;
+                };
+                if !after[..brace_rel].contains("mod ") {
+                    out.push_str(&text[cursor..start + brace_rel]);
+                    cursor = start + brace_rel;
+                    continue;
+                }
+                out.push_str(&text[cursor..start]);
+                let mut depth = 0usize;
+                let mut i = start + brace_rel;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'{' => depth += 1,
+                        b'}' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                i += 1;
+                                break;
+                            }
+                        }
+                        _ => {}
+                    }
+                    i += 1;
+                }
+                cursor = i;
+            }
+            out.push_str(&text[cursor..]);
+            out
+        }
+
+        fn sql_literals(text: &str) -> Vec<String> {
+            const VERBS: [&str; 9] = [
+                "SELECT ", "INSERT ", "UPDATE ", "DELETE ", "CREATE ", "DROP ", "ALTER ",
+                "PRAGMA ", "REPLACE ",
+            ];
+            let mut found = Vec::new();
+            for (index, _) in text.match_indices('"') {
+                let rest = &text[index + 1..];
+                let upper: String = rest.chars().take(8).collect::<String>().to_uppercase();
+                if let Some(verb) = VERBS.iter().find(|v| upper.starts_with(**v)) {
+                    let snippet: String = rest.chars().take(60).collect();
+                    found.push(format!("{verb}… {snippet}"));
+                }
+            }
+            found
+        }
+
+        let sources = workspace_rust_sources();
+        assert!(
+            !sources.is_empty(),
+            "the workspace source walk returned nothing, so this census read no code"
+        );
+
+        let mut scanned_files = 0usize;
+        let mut offenders: Vec<String> = Vec::new();
+        let mut control_hits = 0usize;
+        for (path, text) in &sources {
+            let display = path.display().to_string();
+            if display.contains("/tests/") || display.contains("/benches/") {
+                continue;
+            }
+            let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if file_name == "tests.rs" || file_name.ends_with("_tests.rs") {
+                continue;
+            }
+            let production = strip_test_modules(text);
+            if display.contains(&format!("/{STILL_INLINE}/")) {
+                control_hits += sql_literals(&production).len();
+                continue;
+            }
+            let Some(crate_name) = CONVERTED
+                .iter()
+                .find(|name| display.contains(&format!("/{name}/")))
+            else {
+                continue;
+            };
+            scanned_files += 1;
+            for literal in sql_literals(&production) {
+                offenders.push(format!("{crate_name} {}: {literal}", path.display()));
+            }
+        }
+
+        assert!(
+            control_hits > 0,
+            "must-match control: {STILL_INLINE} still holds SQL in Rust, so a detector \
+             finding none there is broken and its clean reading of {CONVERTED:?} means nothing"
+        );
+        assert!(
+            scanned_files > 0,
+            "no source file matched {CONVERTED:?}; the crate names in that list are how this \
+             census finds its population, so an empty match reads clean for the wrong reason"
+        );
+        assert!(
+            offenders.is_empty(),
+            "SQL text belongs in sql/<name>.sql behind that crate's sql! macro; \
+             {} offender(s) across {scanned_files} file(s): {offenders:#?}",
+            offenders.len()
+        );
+    }
+
     fn workspace_rust_sources() -> Vec<(std::path::PathBuf, String)> {
         let crates_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -8007,19 +8007,96 @@ pub(crate) mod tests {
             out
         }
 
+        /// The body of the Rust string literal whose opening quote is at `open`, or
+        /// `None` if it does not terminate. Escapes are skipped rather than decoded:
+        /// this only has to find the end and hand back text to match against.
+        fn literal_body(text: &str, open: usize) -> Option<&str> {
+            let bytes = text.as_bytes();
+            let mut i = open + 1;
+            while i < bytes.len() {
+                match bytes[i] {
+                    b'\\' => i += 2,
+                    b'"' => return text.get(open + 1..i),
+                    _ => i += 1,
+                }
+            }
+            None
+        }
+
+        /// One line, single-spaced. A statement in Rust wears its line breaks three
+        /// ways — a real newline in a raw string, a `\n` escape, or a backslash line
+        /// continuation — and this scan reads source text, so all three have to read as
+        /// one space before any keyword after the first can be matched. `\n` is two
+        /// characters here, and dropping only the backslash would leave `nFROM`, which
+        /// is exactly how this check first failed its own must-fail control.
+        fn flatten(body: &str) -> String {
+            let mut out = String::with_capacity(body.len());
+            let mut chars = body.chars();
+            while let Some(c) = chars.next() {
+                if c != '\\' {
+                    out.push(c);
+                    continue;
+                }
+                match chars.clone().next() {
+                    // An escape that stands for whitespace: consume both characters.
+                    Some('n' | 't' | 'r') => {
+                        chars.next();
+                        out.push(' ');
+                    }
+                    // A line continuation, or any other escape: the backslash goes,
+                    // what follows is kept and judged on its own.
+                    _ => out.push(' '),
+                }
+            }
+            out.split_whitespace().collect::<Vec<_>>().join(" ")
+        }
+
         fn sql_literals(text: &str) -> Vec<String> {
-            const VERBS: [&str; 9] = [
-                "SELECT ", "INSERT ", "UPDATE ", "DELETE ", "CREATE ", "DROP ", "ALTER ",
-                "PRAGMA ", "REPLACE ",
+            // A leading verb alone is a heuristic, and it is wrong often enough to
+            // matter: "insert serve batch" is an error label and "Create a new brain
+            // profile with given name" is a verb description, and both start with a
+            // SQL verb. So a literal has to carry a second structural keyword too, and
+            // both are matched CASE-SENSITIVELY, because every statement in this tree
+            // writes its keywords in upper case and English prose does not.
+            const SHAPES: [(&str, &[&str]); 9] = [
+                ("SELECT ", &[" FROM "]),
+                ("INSERT ", &["INSERT INTO ", "INSERT OR "]),
+                ("UPDATE ", &[" SET "]),
+                ("DELETE ", &["DELETE FROM "]),
+                (
+                    "CREATE ",
+                    &[
+                        "CREATE TABLE",
+                        "CREATE INDEX",
+                        "CREATE UNIQUE",
+                        "CREATE VIEW",
+                        "CREATE VIRTUAL",
+                        "CREATE TRIGGER",
+                    ],
+                ),
+                (
+                    "DROP ",
+                    &["DROP TABLE", "DROP INDEX", "DROP VIEW", "DROP TRIGGER"],
+                ),
+                ("ALTER ", &["ALTER TABLE"]),
+                ("PRAGMA ", &["PRAGMA "]),
+                ("REPLACE ", &["REPLACE INTO "]),
             ];
             let mut found = Vec::new();
             for (index, _) in text.match_indices('"') {
-                let rest = &text[index + 1..];
-                let upper: String = rest.chars().take(8).collect::<String>().to_uppercase();
-                if let Some(verb) = VERBS.iter().find(|v| upper.starts_with(**v)) {
-                    let snippet: String = rest.chars().take(60).collect();
-                    found.push(format!("{verb}… {snippet}"));
+                let Some(body) = literal_body(text, index) else {
+                    continue;
+                };
+                let flat = flatten(body);
+                let Some((verb, seconds)) = SHAPES.iter().find(|(v, _)| flat.starts_with(*v))
+                else {
+                    continue;
+                };
+                if !seconds.iter().any(|second| flat.contains(second)) {
+                    continue;
                 }
+                let snippet: String = flat.chars().take(70).collect();
+                found.push(format!("{verb}… {snippet}"));
             }
             found
         }

--- a/scripts/lint-sql.sh
+++ b/scripts/lint-sql.sh
@@ -3,14 +3,22 @@
 #
 # sqlfluff cannot parse the fts5/vec0 virtual-table extension syntax these files
 # use (and has no working auto-formatter for it), so the checks are:
-#   1. execution  — files must load cleanly into in-memory SQLite (fts5 is built
-#                   into the stdlib sqlite3 module). Migration files under
+#   1. execution  — DDL files must load cleanly into in-memory SQLite (fts5 is
+#                   built into the stdlib sqlite3 module). Migration files under
 #                   crates/khive-db/sql/ form a forward chain: schema.sql is the
 #                   V1 baseline and later NNN-<name>.sql migrations ALTER/extend
 #                   it, so they are replayed cumulatively in version order on one
 #                   database. Other directories each load their fragments in sorted
 #                   filename order into one fresh database, so indexes see tables
 #                   declared by earlier fragments. One-file directories stand alone.
+#   1b. preparation — a QUERY file (one that does not start with DDL) is prepared,
+#                   not executed, against a database carrying the migration chain
+#                   plus every DDL fragment in the tree. Preparation is what
+#                   resolves table and column names, so a typo in either fails
+#                   here rather than in a test run. Positional binds are filled
+#                   with NULL and the statement runs under EXPLAIN, so nothing is
+#                   evaluated and no row is touched. A file is classified by its
+#                   first keyword, not by its name or its directory.
 #   2. hygiene    — no trailing whitespace, no tabs.
 #   3. format     — multi-column CREATE TABLE must be one column per line
 #                   (catches comma-jammed single-line tables).
@@ -70,8 +78,24 @@ def chain_order(path):
     m = re.match(r"(\d+)", base)
     return int(m.group(1)) if m else 10**9
 
+# Classification is by content, not by path: the first keyword decides. A file that
+# opens with CREATE/ALTER/DROP/PRAGMA/BEGIN declares schema; anything else is a
+# statement that a caller binds and runs.
+ddl_re = re.compile(r"\s*(CREATE|ALTER|DROP|PRAGMA|BEGIN|COMMIT)\b", re.IGNORECASE)
+
+def is_ddl(path):
+    with open(path) as fh:
+        for line in fh:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("--"):
+                continue
+            return bool(ddl_re.match(line))
+    return True  # an empty file has nothing to prepare
+
 chain = sorted([f for f in files if in_db_chain(f)], key=chain_order)
 others = [f for f in files if not in_db_chain(f)]
+ddl_files = [f for f in others if is_ddl(f)]
+query_files = [f for f in others if not is_ddl(f)]
 
 # Replay the migration chain cumulatively in one database so a forward migration
 # (e.g. ALTER TABLE / CREATE INDEX on a baseline table) sees prior schema.
@@ -92,7 +116,7 @@ finally:
 # sorted table/index fragments see prior DDL; unrelated packs never see each other.
 # A directory with one file preserves standalone validation.
 fragment_groups = {}
-for path in others:
+for path in ddl_files:
     fragment_groups.setdefault(os.path.dirname(path), []).append(path)
 for directory in sorted(fragment_groups):
     con = sqlite3.connect(":memory:")
@@ -108,8 +132,62 @@ for directory in sorted(fragment_groups):
     finally:
         con.close()
 
+# ── Preparation (query files) ──────────────────────────────────────────────
+# Statements extracted out of Rust are queries, not DDL. Executing one is both
+# wrong and impossible (executescript refuses bound parameters), so they are
+# PREPARED instead, against a database holding every table this tree declares.
+if query_files:
+    con = sqlite3.connect(":memory:")
+    try:
+        for path in chain:
+            with open(path) as fh:
+                try:
+                    con.executescript(fh.read())
+                except sqlite3.Error:
+                    pass  # already reported by the chain replay above
+        for path in ddl_files:
+            with open(path) as fh:
+                try:
+                    con.executescript(fh.read())
+                except sqlite3.Error:
+                    pass  # already reported by its own directory group
+        # The population control: if the schema did not come up, every query below
+        # fails for one shared reason and the run reads like 300 broken files.
+        tables = con.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'"
+        ).fetchone()[0]
+        if tables == 0:
+            print("SQL lint: no tables built, so no query file can be prepared")
+            failed += 1
+        else:
+            for path in query_files:
+                with open(path) as fh:
+                    sql = fh.read()
+                if sql.count(";") > 1 or (sql.count(";") == 1 and not sql.rstrip().endswith(";")):
+                    print(f"{path}: more than one statement — one statement per file")
+                    failed += 1
+                    continue
+                binds = re.findall(r"\?(\d+)", sql)
+                highest = max((int(b) for b in binds), default=0)
+                if binds and sorted({int(b) for b in binds}) != list(range(1, highest + 1)):
+                    print(f"{path}: positional binds must run 1..N with no gaps")
+                    failed += 1
+                    continue
+                if re.search(r"\?(?!\d)", sql) or re.search(r"[:@$][A-Za-z_]", sql):
+                    print(f"{path}: use numbered binds (?1, ?2), not anonymous or named ones")
+                    failed += 1
+                    continue
+                try:
+                    con.execute("EXPLAIN " + sql.rstrip().rstrip(";"), [None] * highest)
+                except sqlite3.Error as e:
+                    print(f"{path}: FAILED to prepare: {e}")
+                    failed += 1
+    finally:
+        con.close()
+
 if failed:
     print(f"\nSQL lint: {failed} issue(s)")
     sys.exit(1)
-print(f"SQL lint: {len(files)} file(s) OK")
+print(f"SQL lint: {len(files)} file(s) OK "
+      f"({len(query_files)} prepared, {len(files) - len(query_files)} executed)")
 PY


### PR DESCRIPTION
`CLAUDE.md` already states the policy: schema DDL lives in `.sql` files, and "reusable query SQL (hot/tuned queries) should likewise move to `.sql` files where it makes sense — lintable, `EXPLAIN`-able, and tunable without recompiling." The query half never happened. This is the first crate moved across, together with the linting change that makes moving the rest possible at all.

**Why it could not have happened before.** `scripts/lint-sql.sh` runs in `make ci` and in pre-commit, globs every `crates/**/*.sql`, and validates by `executescript`. That is correct for DDL and impossible for a query: a file holding `SELECT ... WHERE profile_id = ?1` fails on the missing table, and `executescript` refuses bound parameters outright. So the first extracted statement would have reddened CI for everyone.

**The linter now classifies by content, not by path.** A file whose first keyword is `CREATE`/`ALTER`/`DROP`/`PRAGMA`/`BEGIN` is DDL and keeps exactly the behaviour it had, including the cumulative migration-chain replay and the per-directory fragment groups. Anything else is a statement, and it is **prepared rather than executed**, against a database carrying the migration chain plus every DDL fragment in the tree, with positional binds filled with `NULL` and the statement wrapped in `EXPLAIN` so nothing is evaluated and no row is touched.

Preparation is what resolves names, so this is strictly stronger than what the DDL half gets: a typo'd table or column now fails at lint time rather than in a test run. The query path also rejects more than one statement per file, anonymous (`?`) or named (`:name`) binds, and positional binds that do not run `1..N` without gaps.

Verified in both directions, through the linter itself:

```
SQL lint: 56 file(s) OK (11 prepared, 45 executed)

# typo a column in one file
crates/khive-pack-brain/sql/brain_implicit_mass_read.sql: FAILED to prepare: no such column: last_event_att
# replace ?1 with ?
crates/khive-pack-brain/sql/brain_implicit_mass_read.sql: positional binds must run 1..N with no gaps
# restore
SQL lint: 56 file(s) OK (11 prepared, 45 executed)
```

**The reference crate.** `khive-pack-brain`: eleven statements, eleven files under `crates/khive-pack-brain/sql/`, reached through a crate-local `sql!` macro that resolves via `include_str!` at compile time, so a renamed or missing file is a build error rather than a runtime surprise. One statement per file, `?N` binds only, nothing string-built.

**The burn-down instrument.** A census in `khive-runtime` fails when a crate on its `CONVERTED` list has SQL text back in a Rust literal. A crate joins that list in the pull request that extracts it.

Its limits are written into the test rather than left implied, because they decide what a pass means. It selects by **spelling**, so it cannot see a statement assembled from fragments, returned by a helper, or built at runtime. A leading verb alone was not enough spelling to go on: the first run of this check called four English strings offenders, a verb description beginning `Create a new brain profile` and three copies of the error label `insert serve batch`. It now requires a second structural keyword and matches case-sensitively, since every statement here writes its keywords upper case and prose does not. Matching a keyword after the first means flattening the literal, because a statement in Rust wears its line breaks as real newlines, as `\n` escapes, or as backslash continuations — and the must-fail control caught the first attempt at that, where dropping only the backslash left `nFROM` and six of the eleven statements could have moved back into Rust unnoticed. That control now puts every extracted statement back into Rust in all three shapes and requires each one to be caught. Its population is code that **compiles into the crate**, so `#[cfg(test)]` module bodies are stripped along with `tests/` and `benches/`; a test standing a fixture table up inline is out of scope. And it carries a **must-match control** against a crate known to still hold SQL inline, asserted in the same pass that produces the clean reading, because a detector that finds nothing anywhere reads exactly like a clean tree.

That control is not decorative. Counting this population by filename rather than by compilation context inflates the workspace total from 1,023 statements to 2,541, because a `mod tests` inside `handlers.rs` is not a file named `tests.rs`.


