### PR TITLE
feat(blob): stage large objects across parts, and let the daemon expire them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
         run: cargo build --manifest-path crates/Cargo.toml --locked -p kkernel --bin kkernel
       - name: Install dependencies and run Python tests
         # pytest exits nonzero when no tests are collected; no separate floor is needed.
-        run: uv run --no-project --with 'pydantic>=2.7' --with 'pytest>=8' pytest python/tests
+        run: uv run --no-project --with 'pydantic>=2.7' --with 'pytest>=8' --with 'blake3>=1' pytest python/tests
 
   kg-editor:
     name: KG Studio (Next.js)

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -261,7 +261,7 @@ jobs:
             echo
             echo "> A research knowledge graph runtime for AI agents: typed entities, a closed"
             echo "> 17-relation edge ontology, hybrid FTS+vector search, and GQL/SPARQL queries,"
-            echo "> all dispatched through one MCP tool (\`request\`). 129 verbs across 14 packs."
+            echo "> all dispatched through one MCP tool (\`request\`). 133 verbs across 14 packs."
             echo
             echo "## Docs"
             echo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ into a dedicated map database, ADR-085 Amendment 2); its `finding` note kind is 
 written only through the `kkernel code-ingest` admin CLI path (ADR-085 D1, Amendment 3);
 the `workspace` pack contributes zero verbs, adding only the `workspace` entity kind and
 `contains` endpoint rules to git/gtd/session notes (#873); the `blob` pack contributes
-three verbs, `blob.put` / `blob.get` / `blob.stat`, over content-addressed storage.
+seven verbs, `blob.put` / `blob.get` / `blob.stat` plus `blob.begin` / `blob.put_part` /
+`blob.commit` / `blob.abort`, over content-addressed storage and staged uploads.
 
 If you're working on khive itself (writing code in this repo), see `CLAUDE.md` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Chunked blob uploads: `blob.begin`, `blob.put_part`, `blob.commit` and
+  `blob.abort` stage an object across sequential parts and publish it under the
+  BLAKE3 reference the completed bytes hash to, so an object larger than one
+  request can be stored without holding it in a single message. Staged uploads
+  are bounded, 128 concurrently and 16 per actor by default, overridable with
+  `KHIVE_BLOB_UPLOAD_MAX_ACTIVE` and `KHIVE_BLOB_UPLOAD_MAX_PER_ACTOR`; a caller
+  past either ceiling is refused by name rather than allowed to accumulate
+  staging entries.
+
 ### Changed
 
 - `KHIVE_EMAIL_DEFAULT_ACTOR` now falls back to `local` when unset or blank,
@@ -24,6 +35,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checkpointed, and unlinked the sidecars while the daemon kept writing to the
   unlinked files. Hardening now runs before the open, the post-open check uses
   `lstat` only, and a cross-process test asserts the locks are held.
+
+### Security
+
+- Staged upload filesystem operations are race-free on Unix and are not on other
+  platforms. The Unix paths open relative to a retained root descriptor and
+  refuse to follow symlinks; the non-Unix paths validate and then resolve the
+  same path again, so a local process able to write inside the blob root can
+  substitute a directory, junction or reparse point in that window. The trust
+  boundary is stated accordingly: the blob root, its contents and its ancestors
+  must be writable only by trusted processes, including processes under the same
+  account. A handle-based replacement is follow-up work and needs native coverage
+  on the affected platform before it can be believed.
 
 ## [0.8.0] - 2026-08-27
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ behavior isn't written there, it is an unspecified design decision → escalate,
 │  14 default packs (`RuntimeConfig::built_in_packs()`):        │
 │  kg, gtd, memory, brain, comm, schedule, knowledge, session, │
 │  tool, exec, git, code, workspace, blob — together exposing   │
-│  129 public verbs (see the verb-catalog paragraph below       │
+│  133 public verbs (see the verb-catalog paragraph below       │
 │  for the per-pack breakdown)                                   │
 │  khive-vcs         — KG versioning: snapshots/branches (ADR-010)    │
 │  khive-merge       — KG merge algorithm (ADR-039, forward-deployed,  │
@@ -215,7 +215,8 @@ system git with hardened, allowlisted argv construction and unconditional force-
 (ADR-108); comm.probe (#644) added 2026-07-07; brain.event_counts (ADR-103 Stage 1, #724
 Ask A) added 2026-07-08; kg.resolve added 2026-07-09; workspace (#873) contributes zero verbs,
 adding only the `workspace` entity kind and `contains` endpoint rules to git/gtd/session notes;
-blob contributes three verbs, blob.put/blob.get/blob.stat (ADR-111), over the `BlobStore`
+blob contributes seven verbs: blob.put/blob.get/blob.stat (ADR-111) and
+blob.begin/blob.put_part/blob.commit/blob.abort (ADR-173), over the `BlobStore`
 content-addressed storage trait; a normal file-backed boot installs a default `FsBlobStore`
 beside the database file with no config needed, and the verbs stay unconfigured only
 against an in-memory backend;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ stdio, and `cargo test` finishes in 4 seconds.
 
 | Capability                  | How                                                                                                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **129 verbs, 14 packs**     | KG, GTD, memory, brain, comm, schedule, knowledge, session, tool, exec, git, code, workspace, blob: all load by default                                  |
+| **133 verbs, 14 packs**     | KG, GTD, memory, brain, comm, schedule, knowledge, session, tool, exec, git, code, workspace, blob: all load by default                                  |
 | **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                                                            |
 | **Typed edges**             | 17 closed relations in 9 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation, epistemic)                      |
 | **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                                                      |
@@ -63,8 +63,8 @@ request(ops="[v1(...), v2(...), v3(...)]")             # parallel batch (max 100
 request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]") # equivalent JSON form
 ```
 
-All 14 packs load by default, giving **129 verbs** out of the box (updated from the
-current handler declarations, 2026-09-09; verify again with `request(ops="verbs()")`
+All 14 packs load by default, giving **133 verbs** out of the box (updated from the
+current handler declarations, 2026-09-12; verify again with `request(ops="verbs()")`
 before editing this table):
 
 | Pack          | Prefix       | Verbs | What it does                                                                                                                                                          |
@@ -82,7 +82,7 @@ before editing this table):
 | **git**       | `git.`       | 16    | Provenance ingest, branch/commit/push writes (ADR-108), dev-loop verbs: checkout, diff, gates, receipts, reconcile, status, log, init, PR open/review/merge (ADR-182) |
 | **code**      | _(none)_     | 1     | `code.ingest`: L1 manifest + L1.5 import-scan source ingest (ADR-085 Amendment 2)                                                                                     |
 | **workspace** | _(none)_     | 0     | Adds the `workspace` entity kind + `contains` endpoint rules to git/gtd/session notes (#873)                                                                          |
-| **blob**      | `blob.`      | 3     | Content-addressed object put/get/stat over the `BlobStore` CAS trait (ADR-111)                                                                                        |
+| **blob**      | `blob.`      | 7     | Content-addressed put/get/stat and staged uploads over `BlobStore` (ADR-111, ADR-173)                                                                                 |
 
 `create`, `list`, `search` take `kind=entity|note` (or `kind=edge` for `list`).
 `get`, `update`, `delete`, `merge` are UUID-only: they auto-detect the record type.
@@ -153,7 +153,7 @@ records what's connected, in which direction, and why.
 │  khive-pack-workspace: workspace entity + contains endpoint   │
 │                        rules (0 verbs)                        │
 │  khive-pack-blob:      content-addressed object storage       │
-│                        (3 verbs)                              │
+│                        (7 verbs)                              │
 │  khive-pack-tool:      tool/skill/plugin registry, capability │
 │                        discovery, use policy (13 verbs)       │
 │  khive-pack-exec:      sandboxed run over a materialized tree │
@@ -272,7 +272,7 @@ kkernel --version   # confirms the binary and version you just installed
 ```
 
 All 14 packs load by default, a background daemon auto-spawns to keep the runtime warm, and any
-MCP client discovers the `request` tool with the full 129-verb catalog.
+MCP client discovers the `request` tool with the full 133-verb catalog.
 
 ### Alternative: npm
 
@@ -404,7 +404,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**Main after v0.7.0.** 129 verbs across 14 packs, 9 entity kinds, 17 edge relations, daemon warm startup
+**Main after v0.7.0.** 133 verbs across 14 packs, 9 entity kinds, 17 edge relations, daemon warm startup
 (ADR-049), knowledge search with embedding rerank, Bayesian brain profiles, threaded messaging,
 scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2156,6 +2156,7 @@ dependencies = [
  "blake3",
  "inventory",
  "khive-db",
+ "khive-request",
  "khive-runtime",
  "khive-storage",
  "khive-types",
@@ -2163,6 +2164,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2160,6 +2160,7 @@ dependencies = [
  "khive-runtime",
  "khive-storage",
  "khive-types",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/khive-db/src/stores/blob.rs
+++ b/crates/khive-db/src/stores/blob.rs
@@ -24,7 +24,8 @@ use std::time::{Duration, SystemTime};
 use async_trait::async_trait;
 
 use khive_storage::blob::{
-    BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, MAX_BLOB_WHOLE_BYTES,
+    BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, UploadId,
+    MAX_BLOB_WHOLE_BYTES,
 };
 use khive_storage::error::StorageError;
 use khive_storage::types::{SqlRow, SqlStatement, SqlValue, StorageResult};
@@ -32,6 +33,9 @@ use khive_storage::{AtomicUnitOp, SqlAccess, StorageCapability};
 
 use crate::error::SqliteError;
 use uuid::Uuid;
+
+#[path = "blob_uploads.rs"]
+mod uploads;
 
 const ROOT_WRITE_LOCK_FILE: &str = ".khive-blob-write.lock";
 const DATABASE_GC_LOCK_SUFFIX: &str = ".khive-blob-gc.lock";
@@ -691,17 +695,18 @@ fn unlink_entry_at(parent_fd: std::os::unix::io::RawFd, name: &str) -> std::io::
 
 #[cfg(unix)]
 fn rename_entry_at(
-    parent_fd: std::os::unix::io::RawFd,
+    source_fd: std::os::unix::io::RawFd,
     from: &str,
+    destination_fd: std::os::unix::io::RawFd,
     to: &str,
 ) -> std::io::Result<()> {
     let c_from = std::ffi::CString::new(from)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
     let c_to = std::ffi::CString::new(to)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
-    // SAFETY: both names are NUL-terminated and relative to the same live
-    // shard-directory handle.
-    let rc = unsafe { libc::renameat(parent_fd, c_from.as_ptr(), parent_fd, c_to.as_ptr()) };
+    // SAFETY: both names are NUL-terminated and relative to live directory
+    // handles retained from the same blob root.
+    let rc = unsafe { libc::renameat(source_fd, c_from.as_ptr(), destination_fd, c_to.as_ptr()) };
     if rc != 0 {
         return Err(std::io::Error::last_os_error());
     }
@@ -917,10 +922,15 @@ where
         ));
     }
 
-    tmp.persist(&target)
-        .map_err(|e| map_io_err(e.error, "put_persist"))?;
+    let temporary = tmp.into_temp_path();
+    publish_blob_path(&temporary, &target)?;
 
     Ok(content_ref)
+}
+
+#[cfg(any(test, not(unix)))]
+fn publish_blob_path(source: &Path, target: &Path) -> StorageResult<()> {
+    fs::rename(source, target).map_err(|error| map_io_err(error, "put_persist"))
 }
 
 #[cfg(any(test, not(unix)))]
@@ -1033,6 +1043,7 @@ fn publish_blob_at(
     root: &fs::File,
     shard1: &fs::File,
     shard2: &fs::File,
+    source: &fs::File,
     temp_name: &str,
     content_ref: &ContentRef,
     publication: &BlobPublication,
@@ -1040,9 +1051,14 @@ fn publish_blob_at(
     use std::os::fd::AsRawFd;
 
     if let Err(error) = publication.step("put_persist", || {
-        rename_entry_at(shard2.as_raw_fd(), temp_name, content_ref.as_str())
+        rename_entry_at(
+            source.as_raw_fd(),
+            temp_name,
+            shard2.as_raw_fd(),
+            content_ref.as_str(),
+        )
     }) {
-        let _ = unlink_entry_at(shard2.as_raw_fd(), temp_name);
+        let _ = unlink_entry_at(source.as_raw_fd(), temp_name);
         return Err(error);
     }
     // A barrier failure after rename leaves a complete but unacknowledged
@@ -1137,6 +1153,7 @@ fn put_blocking_from_root_handle(
     publish_blob_at(
         root_handle,
         &shard1_dir,
+        &shard2_dir,
         &shard2_dir,
         &temp_name,
         &content_ref,
@@ -2539,6 +2556,26 @@ impl FsBlobStore {
 
 #[async_trait]
 impl BlobStore for FsBlobStore {
+    async fn begin_upload(&self, declared_size: u64) -> StorageResult<UploadId> {
+        uploads::begin(self, declared_size).await
+    }
+
+    async fn append_part(&self, id: &UploadId, bytes: Vec<u8>) -> StorageResult<u64> {
+        uploads::append(self, id.clone(), bytes).await
+    }
+
+    async fn commit_upload(&self, id: &UploadId, content_ref: &ContentRef) -> StorageResult<()> {
+        uploads::commit(self, id.clone(), content_ref.clone()).await
+    }
+
+    async fn abort_upload(&self, id: &UploadId) -> StorageResult<()> {
+        uploads::abort(self, id.clone()).await
+    }
+
+    async fn sweep_uploads(&self, idle_for: Duration) -> StorageResult<u64> {
+        uploads::sweep(self, idle_for).await
+    }
+
     async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef> {
         // OWNED guard, MOVED into the blocking closure below: a guard merely
         // borrowed here and held in this

--- a/crates/khive-db/src/stores/blob_uploads.rs
+++ b/crates/khive-db/src/stores/blob_uploads.rs
@@ -1,5 +1,26 @@
 //! Staged filesystem uploads, sharing the blob root's write ownership and
 //! publication primitives. Hashing and wire-session state belong to the pack.
+//!
+//! # Path resolution is race-free on Unix and not on other platforms
+//!
+//! The Unix arms here open relative to a retained root descriptor with
+//! `openat`-style calls that refuse to follow symlinks, so a path cannot be
+//! swapped between the check and the use. The `cfg(not(unix))` arms cannot do
+//! that yet: they validate with `symlink_metadata` and then let `OpenOptions`,
+//! `remove_file`, `create_dir_all` and `rename` resolve the same path again. A
+//! local process able to write inside the blob root can substitute a directory,
+//! junction or reparse point in that window and redirect the operation outside
+//! the root.
+//!
+//! This is a known limitation, not an oversight, and the API's trust boundary is
+//! written to match: the blob root, its contents and its ancestors must be
+//! writable only by trusted processes, including processes running under the
+//! same account. A handle-based Windows replacement needs native coverage of
+//! concurrent swaps across begin, append, commit, abort and sweep before it can
+//! be believed, and the hosted matrix does not run Windows, so it is follow-up
+//! work rather than something to write blind. The arms are
+//! `UploadContext::directory`, `open_staging` and `commit_staged`; do not narrow
+//! the trust boundary in the documentation without replacing all three.
 
 use super::*;
 

--- a/crates/khive-db/src/stores/blob_uploads.rs
+++ b/crates/khive-db/src/stores/blob_uploads.rs
@@ -1,0 +1,769 @@
+//! Staged filesystem uploads, sharing the blob root's write ownership and
+//! publication primitives. Hashing and wire-session state belong to the pack.
+
+use super::*;
+
+const UPLOAD_DIRECTORY: &str = ".uploads";
+
+struct UploadContext {
+    root: PathBuf,
+    root_handle: Arc<fs::File>,
+    floor_bytes: u64,
+    #[cfg(unix)]
+    publication: BlobPublication,
+}
+
+async fn run<T: Send + 'static>(
+    store: &FsBlobStore,
+    operation: &'static str,
+    work: impl FnOnce(UploadContext) -> StorageResult<T> + Send + 'static,
+) -> StorageResult<T> {
+    let guard = store.write_lock.clone().lock_owned().await;
+    #[cfg(test)]
+    let hook = sync_hook::take(&store.root);
+    let context = UploadContext {
+        root: store.root.clone(),
+        root_handle: Arc::clone(&store.root_handle),
+        floor_bytes: store.floor_bytes,
+        #[cfg(unix)]
+        publication: BlobPublication {
+            #[cfg(test)]
+            hook: hook.as_ref().and_then(|hook| hook.publication.clone()),
+        },
+    };
+    tokio::task::spawn_blocking(move || {
+        // Cancellation of the async caller cannot release ownership while a
+        // blocking append or rename is still using the filesystem.
+        let result = {
+            let _guard = guard;
+            #[cfg(test)]
+            if let Some(hook) = &hook {
+                let _ = hook.reached.send(());
+                let _ = hook.release.recv();
+            }
+            (|| {
+                #[cfg(unix)]
+                let _file_guard =
+                    acquire_root_write_lock_anchored(&context.root, &context.root_handle)?;
+                #[cfg(not(unix))]
+                let _file_guard = {
+                    verify_blob_root_identity(&context.root, &context.root_handle)
+                        .map_err(|error| map_io_err(error, operation))?;
+                    acquire_root_write_lock(&context.root)?
+                };
+                work(context)
+            })()
+        };
+        #[cfg(test)]
+        if let Some(hook) = &hook {
+            let _ = hook.done.send(());
+        }
+        result
+    })
+    .await
+    .map_err(|error| StorageError::driver(StorageCapability::Blob, operation, error))?
+}
+
+fn invalid(operation: &'static str, message: impl Into<String>) -> StorageError {
+    StorageError::InvalidInput {
+        capability: StorageCapability::Blob,
+        operation: operation.into(),
+        message: message.into(),
+    }
+}
+
+fn upload_error(error: std::io::Error, id: &UploadId, operation: &'static str) -> StorageError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        StorageError::NotFound {
+            capability: StorageCapability::Blob,
+            resource: "upload",
+            key: id.to_string(),
+        }
+    } else {
+        map_io_err(error, operation)
+    }
+}
+
+impl UploadContext {
+    #[cfg(unix)]
+    fn directory(&self, create: bool) -> std::io::Result<fs::File> {
+        use std::os::fd::AsRawFd;
+        if create {
+            open_or_create_dir_at_no_follow(self.root_handle.as_raw_fd(), UPLOAD_DIRECTORY)
+        } else {
+            openat_dir_no_follow(self.root_handle.as_raw_fd(), UPLOAD_DIRECTORY)
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn directory(&self, create: bool) -> std::io::Result<PathBuf> {
+        let path = self.root.join(UPLOAD_DIRECTORY);
+        if create {
+            match fs::create_dir(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        }
+        let metadata = fs::symlink_metadata(&path)?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "upload staging directory must be a real directory",
+            ));
+        }
+        Ok(path)
+    }
+
+    fn check_space(&self, bytes: u64) -> StorageResult<()> {
+        #[cfg(unix)]
+        let available = available_space_at(&self.root_handle);
+        #[cfg(not(unix))]
+        let available = fs4::available_space(&self.root);
+        let available = available.map_err(|error| map_io_err(error, "append_part_check_space"))?;
+        if crosses_floor(available, bytes, self.floor_bytes) {
+            return Err(StorageError::CapacityFloor {
+                capability: StorageCapability::Blob,
+                volume: self.root.display().to_string(),
+                available_bytes: available,
+                floor_bytes: self.floor_bytes,
+            });
+        }
+        Ok(())
+    }
+}
+
+pub(super) async fn begin(store: &FsBlobStore, declared_size: u64) -> StorageResult<UploadId> {
+    if declared_size > MAX_BLOB_WHOLE_BYTES {
+        return Err(invalid(
+            "begin_upload",
+            "declared upload exceeds the 64 MiB ceiling",
+        ));
+    }
+    run(store, "begin_upload", |context| {
+        let directory = context
+            .directory(true)
+            .map_err(|error| map_io_err(error, "begin_upload"))?;
+        loop {
+            let id = UploadId::from_bytes(Uuid::new_v4().as_bytes());
+            #[cfg(unix)]
+            let created = {
+                use std::os::fd::AsRawFd;
+                create_regular_file_at_no_follow(directory.as_raw_fd(), id.as_str(), 0o600)
+            };
+            #[cfg(not(unix))]
+            let created = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(directory.join(id.as_str()));
+            match created {
+                Ok(file) => {
+                    file.sync_all()
+                        .map_err(|error| map_io_err(error, "begin_upload_sync"))?;
+                    return Ok(id);
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(map_io_err(error, "begin_upload")),
+            }
+        }
+    })
+    .await
+}
+
+#[cfg(not(unix))]
+fn open_staging(path: &Path, append: bool) -> std::io::Result<fs::File> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "upload must be a regular file",
+        ));
+    }
+    fs::OpenOptions::new().write(true).append(append).open(path)
+}
+
+pub(super) async fn append(
+    store: &FsBlobStore,
+    id: UploadId,
+    bytes: Vec<u8>,
+) -> StorageResult<u64> {
+    run(store, "append_part", move |context| {
+        let directory = context
+            .directory(false)
+            .map_err(|error| upload_error(error, &id, "append_part"))?;
+        #[cfg(unix)]
+        let opened = {
+            use std::os::fd::AsRawFd;
+            openat_regular_file_no_follow(
+                directory.as_raw_fd(),
+                id.as_str(),
+                libc::O_WRONLY | libc::O_APPEND,
+            )
+        };
+        #[cfg(not(unix))]
+        let opened = open_staging(&directory.join(id.as_str()), true);
+        let mut file = opened.map_err(|error| upload_error(error, &id, "append_part"))?;
+        let before = file
+            .metadata()
+            .map_err(|error| map_io_err(error, "append_part_stat"))?
+            .len();
+        let after = before
+            .checked_add(bytes.len() as u64)
+            .filter(|size| *size <= MAX_BLOB_WHOLE_BYTES)
+            .ok_or_else(|| invalid("append_part", "staged upload exceeds the 64 MiB ceiling"))?;
+        context.check_space(bytes.len() as u64)?;
+        file.write_all(&bytes)
+            .map_err(|error| map_io_err(error, "append_part_write"))?;
+        file.set_modified(SystemTime::now())
+            .map_err(|error| map_io_err(error, "append_part_touch"))?;
+        file.sync_all()
+            .map_err(|error| map_io_err(error, "append_part_sync"))?;
+        if file
+            .metadata()
+            .map_err(|error| map_io_err(error, "append_part_stat"))?
+            .len()
+            != after
+        {
+            return Err(invalid(
+                "append_part",
+                "staged length changed during append",
+            ));
+        }
+        Ok(after)
+    })
+    .await
+}
+
+pub(super) async fn commit(
+    store: &FsBlobStore,
+    id: UploadId,
+    content_ref: ContentRef,
+) -> StorageResult<()> {
+    run(store, "commit_upload", move |context| {
+        commit_staged(&context, &id, &content_ref)
+    })
+    .await
+}
+
+#[cfg(unix)]
+fn commit_staged(
+    context: &UploadContext,
+    id: &UploadId,
+    content_ref: &ContentRef,
+) -> StorageResult<()> {
+    use std::os::fd::AsRawFd;
+    let uploads = context
+        .directory(false)
+        .map_err(|error| upload_error(error, id, "commit_upload"))?;
+    let staged = openat_regular_file_no_follow(uploads.as_raw_fd(), id.as_str(), libc::O_WRONLY)
+        .map_err(|error| upload_error(error, id, "commit_upload"))?;
+    context
+        .publication
+        .step("put_fsync", || staged.sync_all())?;
+    let hex = content_ref.as_str();
+    let shard1 = open_or_create_dir_at_no_follow(context.root_handle.as_raw_fd(), &hex[..2])
+        .map_err(|error| map_io_err(error, "commit_upload_mkdir"))?;
+    let shard2 = open_or_create_dir_at_no_follow(shard1.as_raw_fd(), &hex[2..4])
+        .map_err(|error| map_io_err(error, "commit_upload_mkdir"))?;
+    match openat_regular_file_no_follow(shard2.as_raw_fd(), hex, libc::O_WRONLY) {
+        Ok(existing) => {
+            existing
+                .set_modified(SystemTime::now())
+                .map_err(|error| map_io_err(error, "put_touch_mtime"))?;
+            existing
+                .sync_all()
+                .map_err(|error| map_io_err(error, "put_fsync"))?;
+            context
+                .publication
+                .sync_directories(&context.root_handle, &shard1, &shard2)?;
+            unlink_entry_at(uploads.as_raw_fd(), id.as_str())
+                .map_err(|error| map_io_err(error, "commit_upload_cleanup"))?;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            publish_blob_at(
+                &context.root_handle,
+                &shard1,
+                &shard2,
+                &uploads,
+                id.as_str(),
+                content_ref,
+                &context.publication,
+            )?;
+        }
+        Err(error) => return Err(map_io_err(error, "commit_upload_existing")),
+    }
+    context
+        .publication
+        .sync_directory("upload_sync_staging", &uploads)
+        .map_err(|error| map_io_err(error, "upload_sync_staging"))
+}
+
+#[cfg(not(unix))]
+fn commit_staged(
+    context: &UploadContext,
+    id: &UploadId,
+    content_ref: &ContentRef,
+) -> StorageResult<()> {
+    let uploads = context
+        .directory(false)
+        .map_err(|error| upload_error(error, id, "commit_upload"))?;
+    let source = uploads.join(id.as_str());
+    let staged =
+        open_staging(&source, false).map_err(|error| upload_error(error, id, "commit_upload"))?;
+    staged
+        .sync_all()
+        .map_err(|error| map_io_err(error, "put_fsync"))?;
+    drop(staged);
+    let target = shard_path(&context.root, content_ref);
+    if target.exists() {
+        let existing =
+            open_staging(&target, false).map_err(|error| map_io_err(error, "put_touch_open"))?;
+        existing
+            .set_modified(SystemTime::now())
+            .map_err(|error| map_io_err(error, "put_touch_mtime"))?;
+        existing
+            .sync_all()
+            .map_err(|error| map_io_err(error, "put_fsync"))?;
+        fs::remove_file(source).map_err(|error| map_io_err(error, "commit_upload_cleanup"))
+    } else {
+        fs::create_dir_all(target.parent().expect("blob shard parent"))
+            .map_err(|error| map_io_err(error, "commit_upload_mkdir"))?;
+        publish_blob_path(&source, &target)
+    }
+}
+
+pub(super) async fn abort(store: &FsBlobStore, id: UploadId) -> StorageResult<()> {
+    run(store, "abort_upload", move |context| {
+        let result = (|| -> std::io::Result<()> {
+            let directory = context.directory(false)?;
+            #[cfg(unix)]
+            {
+                use std::os::fd::AsRawFd;
+                unlink_entry_at(directory.as_raw_fd(), id.as_str())
+            }
+            #[cfg(not(unix))]
+            fs::remove_file(directory.join(id.as_str()))
+        })();
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(map_io_err(error, "abort_upload")),
+        }
+    })
+    .await
+}
+
+pub(super) async fn sweep(store: &FsBlobStore, idle_for: Duration) -> StorageResult<u64> {
+    run(store, "sweep_uploads", move |context| {
+        let directory = match context.directory(false) {
+            Ok(directory) => directory,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(error) => return Err(map_io_err(error, "sweep_uploads_open")),
+        };
+        #[cfg(unix)]
+        let names = {
+            use std::os::fd::AsRawFd;
+            read_dir_names_no_follow(directory.as_raw_fd())
+        };
+        #[cfg(not(unix))]
+        let names = fs::read_dir(&directory).and_then(|entries| {
+            entries
+                .map(|entry| entry.map(|entry| entry.file_name().to_string_lossy().into_owned()))
+                .collect::<std::io::Result<Vec<_>>>()
+        });
+        let now = SystemTime::now();
+        let mut removed = 0;
+        for name in names.map_err(|error| map_io_err(error, "sweep_uploads_list"))? {
+            let Ok(id) = UploadId::from_hex(name) else {
+                continue;
+            };
+            #[cfg(unix)]
+            let opened = {
+                use std::os::fd::AsRawFd;
+                openat_regular_file_no_follow(directory.as_raw_fd(), id.as_str(), libc::O_RDONLY)
+            };
+            #[cfg(not(unix))]
+            let opened = open_staging(&directory.join(id.as_str()), false);
+            let file = match opened {
+                Ok(file) => file,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(map_io_err(error, "sweep_uploads_stat")),
+            };
+            let modified = file
+                .metadata()
+                .and_then(|metadata| metadata.modified())
+                .map_err(|error| map_io_err(error, "sweep_uploads_stat"))?;
+            drop(file);
+            if now
+                .duration_since(modified)
+                .is_ok_and(|age| age >= idle_for)
+            {
+                #[cfg(unix)]
+                let deleted = {
+                    use std::os::fd::AsRawFd;
+                    unlink_entry_at(directory.as_raw_fd(), id.as_str())
+                };
+                #[cfg(not(unix))]
+                let deleted = fs::remove_file(directory.join(id.as_str()));
+                match deleted {
+                    Ok(()) => removed += 1,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(map_io_err(error, "sweep_uploads_delete")),
+                }
+            }
+        }
+        Ok(removed)
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> (tempfile::TempDir, FsBlobStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FsBlobStore::new(dir.path().join("blobs"), 0).unwrap();
+        (dir, store)
+    }
+
+    fn staged(store: &FsBlobStore, id: &UploadId) -> PathBuf {
+        store.root().join(UPLOAD_DIRECTORY).join(id.as_str())
+    }
+
+    async fn stage(store: &FsBlobStore, bytes: &[u8]) -> (UploadId, ContentRef) {
+        let id = store.begin_upload(bytes.len() as u64).await.unwrap();
+        let midpoint = bytes.len() / 2;
+        assert_eq!(
+            store
+                .append_part(&id, bytes[..midpoint].to_vec())
+                .await
+                .unwrap(),
+            midpoint as u64
+        );
+        assert_eq!(
+            store
+                .append_part(&id, bytes[midpoint..].to_vec())
+                .await
+                .unwrap(),
+            bytes.len() as u64
+        );
+        let reference = ContentRef::from_digest_bytes(blake3::hash(bytes).as_bytes());
+        (id, reference)
+    }
+
+    #[tokio::test]
+    async fn upload_roundtrip_and_dedup_touch_one_object() {
+        let (_dir, store) = fixture();
+        let bytes = b"parts make one content-addressed object";
+        let (id, reference) = stage(&store, bytes).await;
+        assert!(!store.exists(&reference).await.unwrap());
+        assert_eq!(fs::read(staged(&store, &id)).unwrap(), bytes);
+        store.commit_upload(&id, &reference).await.unwrap();
+        assert!(!staged(&store, &id).exists());
+        assert_eq!(
+            store
+                .get_bounded_verified(&reference, bytes.len() as u64)
+                .await
+                .unwrap(),
+            bytes
+        );
+        assert!(matches!(
+            store.append_part(&id, vec![1]).await,
+            Err(StorageError::NotFound { .. })
+        ));
+        assert!(matches!(
+            store.commit_upload(&id, &reference).await,
+            Err(StorageError::NotFound { .. })
+        ));
+
+        let target = shard_path(store.root(), &reference);
+        let old = SystemTime::UNIX_EPOCH + Duration::from_secs(60);
+        fs::File::options()
+            .write(true)
+            .open(&target)
+            .unwrap()
+            .set_modified(old)
+            .unwrap();
+        let (again, same) = stage(&store, bytes).await;
+        assert_eq!(same, reference);
+        store.commit_upload(&again, &same).await.unwrap();
+        assert!(!staged(&store, &again).exists());
+        assert!(fs::metadata(&target).unwrap().modified().unwrap() > old);
+        assert_eq!(fs::read_dir(target.parent().unwrap()).unwrap().count(), 1);
+        assert_eq!(store.put(bytes.to_vec()).await.unwrap(), reference);
+    }
+
+    #[tokio::test]
+    async fn upload_empty_object_commits() {
+        let (_dir, store) = fixture();
+        let (id, reference) = stage(&store, b"").await;
+        store.commit_upload(&id, &reference).await.unwrap();
+        assert_eq!(store.size(&reference).await.unwrap(), Some(0));
+        assert_eq!(
+            store.get_bounded_verified(&reference, 0).await.unwrap(),
+            b""
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_abort_and_restart_sweep_leave_committed_and_live_files() {
+        let (_dir, store) = fixture();
+        let object = store.put(b"committed".to_vec()).await.unwrap();
+        let live = store.begin_upload(1).await.unwrap();
+        store.append_part(&live, vec![1]).await.unwrap();
+        let aborted = store.begin_upload(0).await.unwrap();
+        store.abort_upload(&aborted).await.unwrap();
+        store.abort_upload(&aborted).await.unwrap();
+        assert!(!staged(&store, &aborted).exists());
+
+        let orphan = store.begin_upload(1).await.unwrap();
+        store.append_part(&orphan, vec![2]).await.unwrap();
+        fs::File::options()
+            .write(true)
+            .open(staged(&store, &orphan))
+            .unwrap()
+            .set_modified(SystemTime::UNIX_EPOCH)
+            .unwrap();
+        let root = store.root().to_path_buf();
+        drop(store);
+        let reopened = FsBlobStore::open_existing(root, 0).unwrap();
+        assert_eq!(
+            reopened
+                .sweep_uploads(Duration::from_secs(3600))
+                .await
+                .unwrap(),
+            1
+        );
+        assert!(!staged(&reopened, &orphan).exists());
+        assert!(staged(&reopened, &live).exists());
+        assert_eq!(
+            reopened.get_bounded_verified(&object, 9).await.unwrap(),
+            b"committed"
+        );
+        assert_eq!(
+            reopened
+                .sweep_uploads(Duration::from_secs(3600))
+                .await
+                .unwrap(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_each_part_checks_floor_before_writing() {
+        let (_dir, mut store) = fixture();
+        let id = store.begin_upload(3).await.unwrap();
+        store.append_part(&id, vec![1]).await.unwrap();
+        store.floor_bytes = u64::MAX;
+        assert!(matches!(
+            store.append_part(&id, vec![2, 3]).await,
+            Err(StorageError::CapacityFloor { .. })
+        ));
+        assert_eq!(fs::read(staged(&store, &id)).unwrap(), [1]);
+        store.floor_bytes = 0;
+        assert_eq!(store.append_part(&id, vec![2, 3]).await.unwrap(), 3);
+        assert_eq!(fs::read(staged(&store, &id)).unwrap(), [1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn upload_ceiling_refuses_before_creation_or_append() {
+        let (_dir, store) = fixture();
+        assert!(matches!(
+            store.begin_upload(MAX_BLOB_WHOLE_BYTES + 1).await,
+            Err(StorageError::InvalidInput { .. })
+        ));
+        assert!(!store.root().join(UPLOAD_DIRECTORY).exists());
+        let id = store.begin_upload(MAX_BLOB_WHOLE_BYTES).await.unwrap();
+        let file = fs::File::options()
+            .write(true)
+            .open(staged(&store, &id))
+            .unwrap();
+        file.set_len(MAX_BLOB_WHOLE_BYTES).unwrap();
+        drop(file);
+        assert!(matches!(
+            store.append_part(&id, vec![1]).await,
+            Err(StorageError::InvalidInput { .. })
+        ));
+        assert_eq!(
+            fs::metadata(staged(&store, &id)).unwrap().len(),
+            MAX_BLOB_WHOLE_BYTES
+        );
+        store.abort_upload(&id).await.unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn upload_commit_uses_publication_barriers_for_fresh_and_dedup() {
+        use std::os::unix::fs::MetadataExt;
+        let (_dir, store) = fixture();
+        for dedup in [false, true] {
+            let (id, reference) = stage(&store, b"publication").await;
+            let hook = sync_hook::install_publication(store.root(), None);
+            store.commit_upload(&id, &reference).await.unwrap();
+            let mut expected = vec!["put_fsync"];
+            if !dedup {
+                expected.push("put_persist");
+            }
+            expected.extend([
+                "put_sync_shard",
+                "put_sync_parent",
+                "put_sync_root",
+                "upload_sync_staging",
+            ]);
+            assert_eq!(*hook.completed.lock().unwrap(), expected);
+            let target = shard_path(store.root(), &reference);
+            let expected_paths = [
+                target.parent().unwrap().to_path_buf(),
+                target.parent().unwrap().parent().unwrap().to_path_buf(),
+                store.root().to_path_buf(),
+                store.root().join(UPLOAD_DIRECTORY),
+            ];
+            let expected_inodes: Vec<_> = expected_paths
+                .iter()
+                .map(|path| {
+                    let meta = fs::metadata(path).unwrap();
+                    (meta.dev(), meta.ino())
+                })
+                .collect();
+            let synced_inodes: Vec<_> = hook
+                .directories
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(_, device, inode)| (*device, *inode))
+                .collect();
+            assert_eq!(synced_inodes, expected_inodes);
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn upload_publication_failures_preserve_only_complete_objects() {
+        for operation in [
+            "put_fsync",
+            "put_persist",
+            "put_sync_shard",
+            "put_sync_parent",
+            "put_sync_root",
+            "upload_sync_staging",
+        ] {
+            let (_dir, store) = fixture();
+            let (id, reference) = stage(&store, b"whole object").await;
+            sync_hook::install_publication(store.root(), Some(operation));
+            let error = store.commit_upload(&id, &reference).await.unwrap_err();
+            assert!(error.to_string().contains(operation), "{error}");
+            let published = !matches!(operation, "put_fsync" | "put_persist");
+            assert_eq!(store.exists(&reference).await.unwrap(), published);
+            if published {
+                assert_eq!(
+                    store.get_bounded_verified(&reference, 12).await.unwrap(),
+                    b"whole object"
+                );
+            }
+            store.abort_upload(&id).await.unwrap();
+            assert!(!staged(&store, &id).exists());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn upload_put_and_commit_share_the_publish_routine() {
+        // This is a construction assertion required alongside the executed
+        // barrier tests: an independently copied rename cannot satisfy it.
+        let blob = include_str!("blob.rs");
+        let put = blob
+            .split_once("fn put_blocking_from_root_handle(")
+            .unwrap()
+            .1
+            .split_once("\n#[cfg(not(unix))]")
+            .unwrap()
+            .0;
+        let upload = include_str!("blob_uploads.rs");
+        let commit = upload
+            .split_once("fn commit_staged(")
+            .unwrap()
+            .1
+            .split_once("\n#[cfg(not(unix))]")
+            .unwrap()
+            .0;
+        assert_eq!(put.matches("publish_blob_at(").count(), 1);
+        assert_eq!(commit.matches("publish_blob_at(").count(), 1);
+        assert_eq!(blob.matches("fn publish_blob_at(").count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn upload_staging_symlinks_never_modify_their_targets() {
+        use std::os::unix::fs::symlink;
+        let (dir, store) = fixture();
+        let outside = dir.path().join("outside");
+        fs::create_dir(&outside).unwrap();
+        let victim = outside.join("victim");
+        fs::write(&victim, b"unchanged").unwrap();
+        let uploads = store.root().join(UPLOAD_DIRECTORY);
+        symlink(&outside, &uploads).unwrap();
+        assert!(store.begin_upload(1).await.is_err());
+        fs::remove_file(&uploads).unwrap();
+        let id = store.begin_upload(1).await.unwrap();
+        fs::remove_file(staged(&store, &id)).unwrap();
+        symlink(&victim, staged(&store, &id)).unwrap();
+        assert!(store.append_part(&id, vec![1]).await.is_err());
+        let reference = ContentRef::from_digest_bytes(blake3::hash(b"x").as_bytes());
+        assert!(store.commit_upload(&id, &reference).await.is_err());
+        assert!(store.sweep_uploads(Duration::ZERO).await.is_err());
+        store.abort_upload(&id).await.unwrap();
+        assert_eq!(fs::read(victim).unwrap(), b"unchanged");
+        assert!(!store.exists(&reference).await.unwrap());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn upload_operations_refuse_a_replaced_root() {
+        let (dir, store) = fixture();
+        let id = store.begin_upload(1).await.unwrap();
+        let moved = dir.path().join("original");
+        fs::rename(store.root(), &moved).unwrap();
+        fs::create_dir(store.root()).unwrap();
+        let sentinel = store.root().join("sentinel");
+        fs::write(&sentinel, b"replacement").unwrap();
+        let reference = ContentRef::from_hex("a".repeat(64)).unwrap();
+        assert!(store.begin_upload(0).await.is_err());
+        assert!(store.append_part(&id, vec![1]).await.is_err());
+        assert!(store.commit_upload(&id, &reference).await.is_err());
+        assert!(store.abort_upload(&id).await.is_err());
+        assert!(store.sweep_uploads(Duration::ZERO).await.is_err());
+        assert_eq!(
+            fs::metadata(moved.join(UPLOAD_DIRECTORY).join(id.as_str()))
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(fs::read(sentinel).unwrap(), b"replacement");
+        assert_eq!(fs::read_dir(store.root()).unwrap().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn upload_cancelled_append_keeps_write_ownership_until_io_finishes() {
+        let (_dir, store) = fixture();
+        let store = Arc::new(store);
+        let id = store.begin_upload(1).await.unwrap();
+        let (reached, release, done) = sync_hook::install(store.root());
+        let writer = store.clone();
+        let upload = id.clone();
+        let task = tokio::spawn(async move { writer.append_part(&upload, vec![1]).await });
+        tokio::task::spawn_blocking(move || reached.recv_timeout(Duration::from_secs(10)).unwrap())
+            .await
+            .unwrap();
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert!(store.write_lock.try_lock().is_err());
+        release.send(()).unwrap();
+        tokio::task::spawn_blocking(move || done.recv_timeout(Duration::from_secs(10)).unwrap())
+            .await
+            .unwrap();
+        assert!(store.write_lock.try_lock().is_ok());
+        assert_eq!(fs::read(staged(&store, &id)).unwrap(), [1]);
+        store.abort_upload(&id).await.unwrap();
+    }
+}

--- a/crates/khive-db/tests/blob_conformance.rs
+++ b/crates/khive-db/tests/blob_conformance.rs
@@ -45,6 +45,36 @@ impl FixtureBlobStore {
     }
 }
 
+#[tokio::test]
+async fn upload_defaults_refuse_for_backends_without_staging() {
+    let store = FixtureBlobStore::default();
+    let id = khive_storage::UploadId::from_bytes(&[1; 16]);
+    let reference = ContentRef::from_hex("a".repeat(64)).unwrap();
+    let failures = [
+        store.begin_upload(1).await.map(|_| ()),
+        store.append_part(&id, vec![1]).await.map(|_| ()),
+        store.commit_upload(&id, &reference).await,
+        store.abort_upload(&id).await,
+        store
+            .sweep_uploads(std::time::Duration::ZERO)
+            .await
+            .map(|_| ()),
+    ];
+    for (result, expected) in failures.into_iter().zip([
+        "begin_upload",
+        "append_part",
+        "commit_upload",
+        "abort_upload",
+        "sweep_uploads",
+    ]) {
+        let StorageError::Unsupported { operation, .. } = result.unwrap_err() else {
+            panic!("expected unsupported staging")
+        };
+        assert_eq!(operation, expected);
+    }
+    assert!(store.objects.lock().unwrap().is_empty());
+}
+
 #[async_trait]
 impl BlobStore for FixtureBlobStore {
     async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef> {

--- a/crates/khive-mcp/src/components.rs
+++ b/crates/khive-mcp/src/components.rs
@@ -772,6 +772,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(config_ledger)]
     fn blob_upload_roster_uses_the_registered_manager_and_requires_an_available_store() {
         let runtime = KhiveRuntime::memory().expect("runtime");
         let unavailable = blob_server(runtime);

--- a/crates/khive-mcp/src/components.rs
+++ b/crates/khive-mcp/src/components.rs
@@ -7,8 +7,8 @@
 //! shutdown. External components register at link time through `inventory`
 //! (ADR-119 Amendment 1), so a distribution binary's components participate
 //! without this crate naming any of them. The host additionally contributes
-//! the dynamic `schedule-tick` registration when its resolved pack set carries
-//! a schedule runtime (ADR-119 Amendment 4); a plain core build still has an
+//! dynamic `schedule-tick` and `blob-upload-sweep` registrations when their
+//! resolved packs supply writable state; a plain core build still has an
 //! empty external inventory.
 //!
 //! Supervision joins the daemon's existing shutdown path: every supervisor
@@ -152,6 +152,44 @@ fn schedule_component_registration(
                 interval,
             ))
         }),
+    }
+}
+
+const BLOB_UPLOAD_COMPONENT_NAME: &str = "blob-upload-sweep";
+
+fn blob_upload_component_registration(
+    manager: Arc<khive_pack_blob::uploads::UploadManager>,
+) -> ComponentRegistration {
+    ComponentRegistration {
+        name: BLOB_UPLOAD_COMPONENT_NAME,
+        restart: RestartClass::OnFailure,
+        max_restarts: 5,
+        backoff_initial_ms: 1_000,
+        backoff_max_ms: 60_000,
+        shutdown_timeout_ms: 5_000,
+        start: Arc::new(move |ctx| Box::pin(blob_upload_sweep_loop(manager.clone(), ctx))),
+    }
+}
+
+async fn blob_upload_sweep_loop(
+    manager: Arc<khive_pack_blob::uploads::UploadManager>,
+    ctx: HostContext,
+) -> Result<(), ComponentError> {
+    let interval = manager.sweep_interval();
+    let mut ticker = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            biased;
+            _ = ctx.cancellation().cancelled() => return Ok(()),
+            _ = ticker.tick() => {}
+        }
+        match manager.sweep().await {
+            Ok(_) => ctx.heartbeat(),
+            Err(error) => {
+                tracing::warn!(%error, "blob upload sweep failed; retrying at the next tick");
+            }
+        }
     }
 }
 
@@ -328,15 +366,14 @@ pub fn start_daemon_components(server: &KhiveMcpServer) -> usize {
     start_daemon_components_with_schedule(server, None)
 }
 
-/// Start the linked daemon components plus the host-owned schedule drain when
-/// the daemon resolved the `schedule` pack. The schedule component is dynamic
-/// because it must capture that exact pack runtime; reconstructing a runtime
-/// here can point the drain at a different backend (ADR-106, PR #782).
+/// Start linked components and the host-owned schedule and upload loops.
+/// Dynamic registrations capture the exact registered pack state; rebuilding
+/// a pack here would lose its in-memory state or use another backend.
 pub(crate) fn start_daemon_components_with_schedule(
     server: &KhiveMcpServer,
     schedule_runtime: Option<khive_runtime::KhiveRuntime>,
 ) -> usize {
-    let regs = component_registrations(schedule_runtime);
+    let regs = component_registrations(schedule_runtime, server.blob_upload_manager());
     start_component_registrations(
         regs,
         server,
@@ -347,6 +384,7 @@ pub(crate) fn start_daemon_components_with_schedule(
 
 fn component_registrations(
     schedule_runtime: Option<khive_runtime::KhiveRuntime>,
+    upload_manager: Option<Arc<khive_pack_blob::uploads::UploadManager>>,
 ) -> Vec<ComponentRegistration> {
     let linked: Vec<&'static DaemonComponentRegistration> =
         inventory::iter::<DaemonComponentRegistration>().collect();
@@ -362,6 +400,9 @@ fn component_registrations(
             runtime,
             crate::pending_events::tick_interval_from_env(),
         ));
+    }
+    if let Some(manager) = upload_manager {
+        regs.push(blob_upload_component_registration(manager));
     }
     regs
 }
@@ -669,6 +710,202 @@ mod tests {
         );
     }
 
+    #[derive(Debug, Default)]
+    struct UploadSweepProbe {
+        calls: AtomicU32,
+    }
+
+    #[async_trait::async_trait]
+    impl khive_storage::BlobStore for UploadSweepProbe {
+        async fn put(
+            &self,
+            _bytes: Vec<u8>,
+        ) -> khive_storage::StorageResult<khive_storage::ContentRef> {
+            panic!("sweeper must not publish objects")
+        }
+
+        async fn get_bounded_verified(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+            _max_bytes: u64,
+        ) -> khive_storage::StorageResult<Vec<u8>> {
+            panic!("sweeper must not read committed objects")
+        }
+
+        async fn exists(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+        ) -> khive_storage::StorageResult<bool> {
+            panic!("sweeper must not inspect committed objects")
+        }
+
+        async fn size(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+        ) -> khive_storage::StorageResult<Option<u64>> {
+            panic!("sweeper must not inspect committed objects")
+        }
+
+        async fn delete(
+            &self,
+            _content_ref: &khive_storage::ContentRef,
+        ) -> khive_storage::StorageResult<bool> {
+            panic!("sweeper must not delete committed objects")
+        }
+
+        async fn sweep_uploads(&self, _idle_for: Duration) -> khive_storage::StorageResult<u64> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if call <= 6 {
+                Err(khive_storage::StorageError::Internal(
+                    "transient upload sweep failure".to_string(),
+                ))
+            } else {
+                Ok(0)
+            }
+        }
+    }
+
+    fn blob_server(runtime: KhiveRuntime) -> KhiveMcpServer {
+        let mut builder = khive_runtime::VerbRegistryBuilder::new();
+        builder.register(khive_pack_blob::BlobPack::new(runtime));
+        KhiveMcpServer::from_registry(builder.build().expect("blob registry"))
+    }
+
+    #[test]
+    fn blob_upload_roster_uses_the_registered_manager_and_requires_an_available_store() {
+        let runtime = KhiveRuntime::memory().expect("runtime");
+        let unavailable = blob_server(runtime);
+        assert!(unavailable.blob_upload_manager().is_none());
+
+        let empty_registry = khive_runtime::VerbRegistryBuilder::new()
+            .build()
+            .expect("empty registry");
+        let absent = KhiveMcpServer::from_registry(empty_registry);
+        assert!(absent.blob_upload_manager().is_none());
+
+        let runtime = KhiveRuntime::memory().expect("runtime");
+        runtime
+            .install_blob_store(Arc::new(UploadSweepProbe::default()))
+            .expect("install blob store");
+        let server = blob_server(runtime);
+        let manager = server.blob_upload_manager().expect("upload manager");
+        assert!(Arc::ptr_eq(
+            &manager,
+            &server
+                .clone()
+                .blob_upload_manager()
+                .expect("cloned manager")
+        ));
+        let roster = component_registrations(None, Some(manager));
+        assert_eq!(
+            roster
+                .iter()
+                .filter(|reg| reg.name == BLOB_UPLOAD_COMPONENT_NAME)
+                .count(),
+            1
+        );
+        assert!(
+            component_registrations(None, unavailable.blob_upload_manager())
+                .iter()
+                .all(|reg| reg.name != BLOB_UPLOAD_COMPONENT_NAME)
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(config_ledger)]
+    fn blob_upload_roster_obeys_its_own_runtime_mode_in_mixed_deployments() {
+        let (_dir, db) = tmp_db();
+        let config = RuntimeConfig {
+            db_path: Some(std::path::PathBuf::from(db)),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["blob".to_string()],
+            ..Default::default()
+        };
+        KhiveRuntime::new(config.clone()).expect("initialize database");
+        #[cfg(unix)]
+        freeze_snapshot_sidecars(config.db_path.as_ref().expect("db path"));
+        let read_only = KhiveRuntime::new_readonly(config).expect("read-only runtime");
+        read_only
+            .install_blob_store(Arc::new(UploadSweepProbe::default()))
+            .expect("install read-only blob store");
+        let before = read_only.backend().pool().writer_acquisition_snapshot();
+        let writable = KhiveRuntime::memory().expect("writable runtime");
+        writable
+            .install_blob_store(Arc::new(UploadSweepProbe::default()))
+            .expect("install writable blob store");
+
+        let read_only_blob = blob_server(read_only.clone()).with_runtime(writable.clone());
+        assert!(read_only_blob.blob_upload_manager().is_none());
+        let writable_blob = blob_server(writable).with_runtime(read_only.clone());
+        assert!(writable_blob.blob_upload_manager().is_some());
+        assert_eq!(
+            read_only.backend().pool().writer_acquisition_snapshot(),
+            before,
+            "upload admission must not probe a read-only backend through a writer"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn blob_upload_sweeper_delays_retries_skips_missed_ticks_and_joins_on_cancel() {
+        let store = Arc::new(UploadSweepProbe::default());
+        let runtime = KhiveRuntime::memory().expect("runtime");
+        runtime
+            .install_blob_store(store.clone())
+            .expect("install blob store");
+        let server = blob_server(runtime);
+        let manager = server.blob_upload_manager().expect("upload manager");
+        let interval = manager.sweep_interval();
+        let health = HealthReporter::default();
+        let parent = CancellationToken::new();
+        let supervisor = tokio::spawn(supervise(
+            blob_upload_component_registration(manager),
+            server,
+            parent.child_token(),
+            health.clone(),
+        ));
+        tokio::task::yield_now().await;
+        assert_eq!(store.calls.load(Ordering::SeqCst), 0);
+        tokio::time::advance(interval - Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(store.calls.load(Ordering::SeqCst), 0);
+        tokio::time::advance(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(store.calls.load(Ordering::SeqCst), 1);
+
+        for expected in 2..=7 {
+            tokio::time::advance(interval).await;
+            tokio::task::yield_now().await;
+            assert_eq!(store.calls.load(Ordering::SeqCst), expected);
+        }
+        let status = health.status(BLOB_UPLOAD_COMPONENT_NAME).expect("status");
+        assert_eq!(status.state, ComponentState::Running);
+        assert_eq!(
+            status.restart_count, 0,
+            "backend errors must not spend restart budget"
+        );
+        assert!(status.last_heartbeat.is_some());
+
+        tokio::time::advance(interval * 4).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            store.calls.load(Ordering::SeqCst),
+            8,
+            "missed ticks must not burst"
+        );
+        parent.cancel();
+        supervisor.await.expect("supervisor joins");
+        let status = health.status(BLOB_UPLOAD_COMPONENT_NAME).expect("status");
+        assert_eq!(status.state, ComponentState::Stopped);
+        tokio::time::advance(interval * 3).await;
+        assert_eq!(
+            store.calls.load(Ordering::SeqCst),
+            8,
+            "no sweep may outlive shutdown"
+        );
+    }
+
     #[test]
     fn shutdown_wait_is_clamped_strictly_inside_the_drain_window() {
         let drain_ms = 10_000;
@@ -752,11 +989,11 @@ mod tests {
         };
         let rt = KhiveRuntime::new(cfg).expect("runtime");
 
-        let absent = component_registrations(None)
+        let absent = component_registrations(None, None)
             .into_iter()
             .filter(|reg| reg.name == SCHEDULE_COMPONENT_NAME)
             .count();
-        let present: Vec<_> = component_registrations(Some(rt))
+        let present: Vec<_> = component_registrations(Some(rt), None)
             .into_iter()
             .filter(|reg| reg.name == SCHEDULE_COMPONENT_NAME)
             .collect();
@@ -793,7 +1030,7 @@ mod tests {
         let read_only = KhiveRuntime::new_readonly(cfg).expect("open schedule snapshot read-only");
         let before = read_only.backend().pool().writer_acquisition_snapshot();
 
-        let schedule_count = component_registrations(Some(read_only.clone()))
+        let schedule_count = component_registrations(Some(read_only.clone()), None)
             .into_iter()
             .filter(|reg| reg.name == SCHEDULE_COMPONENT_NAME)
             .count();

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -10441,6 +10441,33 @@ backend = "schedule-backend"
 
     #[test]
     #[serial_test::serial(config_ledger)]
+    fn client_role_never_starts_the_blob_upload_component() {
+        use clap::Parser;
+        let directory = tempfile::tempdir().expect("blob directory");
+        let runtime = KhiveRuntime::memory().expect("runtime");
+        runtime
+            .install_blob_store(std::sync::Arc::new(
+                khive_db::stores::blob::FsBlobStore::new(directory.path().to_path_buf(), 0)
+                    .expect("blob store"),
+            ))
+            .expect("install blob store");
+        let mut builder = khive_runtime::VerbRegistryBuilder::new();
+        builder.register(khive_pack_blob::BlobPack::new(runtime));
+        let server = KhiveMcpServer::from_registry(builder.build().expect("blob registry"));
+        assert!(server.blob_upload_manager().is_some());
+
+        for argv in [vec!["mcp"], vec!["mcp", "--transport", "http"]] {
+            let args = Args::parse_from(argv);
+            assert_eq!(
+                start_daemon_components_if_daemon(&args, &server, None),
+                0,
+                "only --daemon may start the upload sweeper, even with an admitted manager"
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(config_ledger)]
     fn client_role_never_starts_the_schedule_component() {
         use clap::Parser;
         let args = Args::parse_from(["mcp"]);

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1769,6 +1769,12 @@ impl KhiveMcpServer {
         self
     }
 
+    pub(crate) fn blob_upload_manager(
+        &self,
+    ) -> Option<Arc<khive_pack_blob::uploads::UploadManager>> {
+        self.registry.pack_host_state("blob")
+    }
+
     /// Clone the verb registry for use by background tasks (e.g. channel polling loops).
     ///
     /// `VerbRegistry` is internally `Arc`-wrapped so this clone is cheap. The returned

--- a/crates/khive-pack-blob/Cargo.toml
+++ b/crates/khive-pack-blob/Cargo.toml
@@ -9,23 +9,25 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Blob verb pack — thin MCP verbs (put/get/stat) over the existing BlobStore CAS"
+description = "Blob verb pack — content-addressed reads and staged uploads"
 
 [dependencies]
 khive-types = { version = "0.8.0", path = "../khive-types", features = ["serde"] }
 khive-runtime = { version = "0.8.0", path = "../khive-runtime" }
 khive-storage = { version = "0.8.0", path = "../khive-storage" }
+khive-request = { version = "0.8.0", path = "../khive-request" }
 async-trait = { workspace = true }
+blake3 = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 base64 = { workspace = true }
 inventory = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-blake3 = { workspace = true }
 khive-db = { version = "0.8.0", path = "../khive-db" }
 tempfile = { workspace = true }
-tokio = { workspace = true }
 
 [[test]]
 name = "integration"

--- a/crates/khive-pack-blob/Cargo.toml
+++ b/crates/khive-pack-blob/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 khive-db = { version = "0.8.0", path = "../khive-db" }
+rusqlite = { workspace = true }
 tempfile = { workspace = true }
 
 [[test]]

--- a/crates/khive-pack-blob/docs/design.md
+++ b/crates/khive-pack-blob/docs/design.md
@@ -84,8 +84,21 @@ staging and returns `{aborted: true}`; unknown or consumed ids report unknown up
 The four upload verbs are Declaration verbs; existing `blob.put` remains Commissive,
 and `blob.get` / `blob.stat` remain Assertive.
 All mutations refuse on a read-only runtime. Upload ids are capabilities: the
-originating actor is retained for attribution, not an ownership restriction.
+originating actor is retained for attribution and admission limits, not an ownership restriction.
 There is no upload journal and a restarted daemon answers unknown upload.
+
+Each loaded upload manager admits at most 128 staged uploads in total and 16 per
+originating actor. `KHIVE_BLOB_UPLOAD_MAX_ACTIVE` and
+`KHIVE_BLOB_UPLOAD_MAX_PER_ACTOR` override those ceilings with positive integers;
+invalid values warn and use the defaults. A full ceiling refuses `blob.begin` with
+`InvalidInput` naming the total or per-actor ceiling. The known-reference shortcut
+needs no slot. Reservations count pending backend creation and remain occupied
+until successful commit or cleanup, including when cleanup must be retried. Once
+creation is admitted, it finishes registering its record even if the request is
+cancelled, so the reservation and stage remain tracked for expiry. Admission and
+reservation happen under one short lock; backend I/O holds no admission lock.
+These are process-local concurrency bounds, not disk quotas or request rate limits.
+Staging orphaned by a process restart is still reclaimed by backend sweeping.
 
 Only the daemon starts the upload sweep component. Each tick expires pack records
 and calls backend `sweep_uploads` for orphan staging, using the same idle policy as
@@ -99,6 +112,30 @@ by the interval. The filesystem stages below `.uploads/`, which object GC ignore
 The current staged-upload backend is `FsBlobStore`. `S3BlobStore` retains whole-object
 put/get/stat support but inherits Unsupported for staging methods; its known-reference
 begin shortcut can still return an existing object without staging.
+
+## Filesystem platform limits
+
+On Windows and other non-Unix systems, staged filesystem operations validate paths
+and then resolve them again for creation, append, publication and removal. These
+checks do not prevent a local writer from swapping a directory, junction or reparse
+point between validation and use, redirecting an operation outside the blob root.
+Deploy with the blob root, its contents and its ancestor directories writable only
+by trusted processes. An untrusted process running as the same service account is
+also outside this containment boundary. Upload IDs constrain input names but do
+not close the filesystem race.
+
+The Unix implementation uses anchored directory handles and no-follow operations.
+A Windows handle-based replacement remains follow-up work: it needs native
+Windows coverage of concurrent swaps during begin, append, commit, abort and sweep,
+including both the publication source and destination. A compile-only check does
+not establish those runtime guarantees.
+
+Filesystem writes currently share a per-root mutex across staged operations,
+ordinary publication and object GC. The guard stays held through blocking writes
+and synchronization, including after cancellation of the async caller. Concurrent
+uploads can be admitted, but their filesystem writes to the same root are serialized.
+Changing that lock requires preserving cancellation ownership, capacity checks,
+publication and GC exclusion; it is separate follow-up work.
 
 ## Expiry and ownership controls
 
@@ -122,8 +159,11 @@ Removing only backend `sweep_uploads` leaves live-record expiry effective throug
 `scripts/test-blob-upload-mutations.py` builds baseline, mutated and restored executables in
 an isolated clean checkout with an explicit `CARGO_TARGET_DIR`. Supply `--root`, `--head`,
 `--binary` and a fresh `--out` evidence directory outside the checkout. Its default
-`--case all` runs five controls: the four ADR-173 mutation operators (tail digest, verb
-expiry, backend sweep, copied publisher) and daemon ownership. `--case owner` selects
+`--case all` runs six controls: the four ADR-173 mutation operators (tail digest, verb
+expiry, backend sweep, copied publisher), daemon ownership and the total upload ceiling.
+`--case cap` removes only the total ceiling while the per-actor limit remains above
+the test's total limit; accepting another `blob.begin` must fail the assertion.
+`--case owner` selects
 only the ownership control, suppressing the entire daemon sweep call while preserving its
 timer and heartbeat. It requires one baseline pass, exactly one failure reporting retained
 staging, exact source restoration and one restored pass. Compile errors and unrelated

--- a/crates/khive-pack-blob/docs/design.md
+++ b/crates/khive-pack-blob/docs/design.md
@@ -28,6 +28,13 @@ verbs: `blob.put`, `blob.get`, `blob.stat`, `blob.begin`, `blob.put_part`, `blob
   shared admission controller, then optionally slices it and returns base64 bytes.
 - `blob.stat(content_ref)` reports existence and size through metadata only; it neither hydrates
   bytes nor implies a lease or reservation.
+- `blob.begin(size, content_ref?)` opens staging and returns `{upload_id, part_limit, next_index}`,
+  or returns `{content_ref, size}` for an existing reference without staging.
+- `blob.put_part(upload_id, index, bytes)` appends sequential base64 parts and returns
+  `{next_index, received_bytes}`; an identical last-part retry returns the same counters.
+- `blob.commit(upload_id)` checks the complete length and optional expected reference, publishes
+  the object, and returns `{content_ref, size}` while consuming the upload id.
+- `blob.abort(upload_id)` discards staging, consumes the upload id, and returns `{aborted: true}`.
 
 ## Invariants
 
@@ -40,8 +47,8 @@ verbs: `blob.put`, `blob.get`, `blob.stat`, `blob.begin`, `blob.put_part`, `blob
   happens after full verified hydration.
 - `blob.get` uses digest-verified hydration; `blob.stat` deliberately does not claim digest
   verification because it never reads the content.
-- `blob.put` is unavailable on a read-only runtime. Reads remain available when a store is
-  installed.
+- `blob.put` and the four upload verbs are unavailable on a read-only runtime. Reads remain
+  available when a store is installed.
 - Deleting committed objects and sweeping unreferenced committed objects remain administrator-only
   operations. Upload abort and expiry remove only staging.
 
@@ -49,35 +56,49 @@ verbs: `blob.put`, `blob.get`, `blob.stat`, `blob.begin`, `blob.put_part`, `blob
 
 `blob.begin(size, content_ref?)` returns `{upload_id, part_limit, next_index}`. If the
 optional reference already exists, it returns `{content_ref, size}` without creating
-staging. `blob.put_part(upload_id, index, bytes)` accepts base64 parts in order and
-returns `{next_index, received_bytes}`. The returned `part_limit` derives from the
-live request-parser and frame caps, minus an 8192-byte request reserve, scaled by 3/4.
+staging; that response uses the stored object's size. `size` is a required non-negative
+integer at most 64 MiB, including zero. Content references are 64-character lowercase-hex
+strings and upload ids are 32-character lowercase-hex strings, not UUID spellings or paths.
+`blob.put_part(upload_id, index, bytes)` requires a non-negative integer index and a
+base64 string, accepts parts in order starting at zero, and returns integer
+`{next_index, received_bytes}` counters. Empty parts are valid. The returned integer
+`part_limit` derives from the live request-parser and frame caps, minus an 8192-byte
+request reserve, scaled by 3/4; it currently equals 780,288 decoded bytes.
 
 An identical resend of the last part is acknowledged without changing bytes, hash,
-index or activity time. An altered tail retry aborts the upload. Crossing declared
-size also aborts. A successful append records activity from before backend I/O,
-so a slow sync cannot make the pack clock newer than an already expiring stage.
+index or activity time. An altered tail retry aborts the upload. Other out-of-order
+indices are refused with `InvalidInput` without advancing it. A next part crossing
+declared size also aborts; exceeding only `part_limit` refuses the part while retaining
+the upload. Invalid base64 is refused before appending. A successful append records
+activity from before backend I/O, so a slow sync cannot make the pack clock newer than
+an already expiring stage.
 Cancelled or failed backend writes invalidate the record; cleanup failures retain
 an unusable record for the next sweep to retry.
 
 `blob.commit(upload_id)` requires exactly the declared length, verifies an optional
 expected reference, and calls the backend's shared publication routine. It returns
-`{content_ref, size}` and consumes the id. `blob.abort(upload_id)` removes staging
-and returns `{aborted: true}`; unknown or consumed ids report unknown upload.
+`{content_ref, size}` and consumes the id. An incomplete commit is refused without
+discarding the upload; a reference mismatch aborts it. `blob.abort(upload_id)` removes
+staging and returns `{aborted: true}`; unknown or consumed ids report unknown upload.
 
-The four upload verbs are Declaration verbs; existing `blob.put` remains Commissive.
+The four upload verbs are Declaration verbs; existing `blob.put` remains Commissive,
+and `blob.get` / `blob.stat` remain Assertive.
 All mutations refuse on a read-only runtime. Upload ids are capabilities: the
 originating actor is retained for attribution, not an ownership restriction.
 There is no upload journal and a restarted daemon answers unknown upload.
 
 Only the daemon starts the upload sweep component. Each tick expires pack records
 and calls backend `sweep_uploads` for orphan staging, using the same idle policy as
-the verbs. Failures warn and retry on the next tick. The component joins the existing
+the verbs. `put_part` and `commit` also enforce expiry directly: once begin or the last
+accepted new part is at least the idle bound old, they discard the upload and report
+unknown upload. Failures warn and retry on the next tick. The component joins the existing
 daemon cancellation and drain path. `KHIVE_BLOB_UPLOAD_IDLE_SECS` defaults to 3600;
 `KHIVE_BLOB_UPLOAD_SWEEP_INTERVAL_SECS` defaults to 600. Both accept positive integer
 seconds; invalid values use the default with a warning. The first tick is delayed
 by the interval. The filesystem stages below `.uploads/`, which object GC ignores.
-Backends without staged-upload support return Unsupported from the storage contract.
+The current staged-upload backend is `FsBlobStore`. `S3BlobStore` retains whole-object
+put/get/stat support but inherits Unsupported for staging methods; its known-reference
+begin shortcut can still return an existing object without staging.
 
 ## Expiry and ownership controls
 
@@ -100,9 +121,10 @@ Removing only backend `sweep_uploads` leaves live-record expiry effective throug
 
 `scripts/test-blob-upload-mutations.py` builds baseline, mutated and restored executables in
 an isolated clean checkout with an explicit `CARGO_TARGET_DIR`. Supply `--root`, `--head`,
-`--binary` and a fresh `--out` evidence directory outside the checkout. Its default `--case all` runs the four
-ADR-173 mutation operators (tail digest, verb expiry, backend sweep, copied publisher).
-The additional `--case owner` suppresses the entire daemon sweep call while preserving its
+`--binary` and a fresh `--out` evidence directory outside the checkout. Its default
+`--case all` runs five controls: the four ADR-173 mutation operators (tail digest, verb
+expiry, backend sweep, copied publisher) and daemon ownership. `--case owner` selects
+only the ownership control, suppressing the entire daemon sweep call while preserving its
 timer and heartbeat. It requires one baseline pass, exactly one failure reporting retained
 staging, exact source restoration and one restored pass. Compile errors and unrelated
 test failures do not satisfy a mutation control. All commands, counts and logs are retained.

--- a/crates/khive-pack-blob/docs/design.md
+++ b/crates/khive-pack-blob/docs/design.md
@@ -78,3 +78,31 @@ daemon cancellation and drain path. `KHIVE_BLOB_UPLOAD_IDLE_SECS` defaults to 36
 seconds; invalid values use the default with a warning. The first tick is delayed
 by the interval. The filesystem stages below `.uploads/`, which object GC ignores.
 Backends without staged-upload support return Unsupported from the storage contract.
+
+## Expiry and ownership controls
+
+`python/tests/test_blob_upload_wire_integration.py` contains real daemon controls for
+[ADR-173](../../../docs/adr/ADR-173-blob-chunked-upload.md) acceptance items 5 and 6.
+The tests require an explicit `KKERNEL` executable and the Python client test dependencies.
+
+| Acceptance          | Wire arm                                             | Discriminating failure                                                                            |
+| ------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| 5: verb expiry      | `verb_expiry_without_sweeper[put_part]`              | Removing the verb idle guard acknowledges the stale part instead of refusing it.                  |
+| 5: daemon expiry    | `daemon_expiry_without_verbs_keeps_committed_object` | Removing the whole daemon sweep leaves staging present; the committed object must survive.        |
+| 6: restart          | `restart_orphan_sweep_and_begin_again`               | Removing backend sweeping leaves the old process's staging present despite its unknown upload id. |
+| 6: daemon ownership | `daemon_owns_expiry_after_mcp_client_exit`           | Removing the whole daemon sweep leaves staging present after the client has exited.               |
+
+The owner arm proves the file exists after the client exits, then polls only filesystem
+state and daemon liveness until removal. It sends no further verb, and fixture cleanup runs
+after the assertion. This prevents verb-side expiry or teardown from satisfying the control.
+Removing only backend `sweep_uploads` leaves live-record expiry effective through
+`abort_upload`, so the live-record control correctly remains green under that mutation.
+
+`scripts/test-blob-upload-mutations.py` builds baseline, mutated and restored executables in
+an isolated clean checkout with an explicit `CARGO_TARGET_DIR`. Supply `--root`, `--head`,
+`--binary` and a fresh `--out` evidence directory outside the checkout. Its default `--case all` runs the four
+ADR-173 mutation operators (tail digest, verb expiry, backend sweep, copied publisher).
+The additional `--case owner` suppresses the entire daemon sweep call while preserving its
+timer and heartbeat. It requires one baseline pass, exactly one failure reporting retained
+staging, exact source restoration and one restored pass. Compile errors and unrelated
+test failures do not satisfy a mutation control. All commands, counts and logs are retained.

--- a/crates/khive-pack-blob/docs/design.md
+++ b/crates/khive-pack-blob/docs/design.md
@@ -2,17 +2,20 @@
 
 ## Purpose
 
-`khive-pack-blob` exposes the runtime's installed content-addressed blob service through three MCP
-verbs: `blob.put`, `blob.get`, and `blob.stat`. It is a thin wire adapter over `BlobStore` and
+`khive-pack-blob` exposes the runtime's installed content-addressed blob service through seven MCP
+verbs: `blob.put`, `blob.get`, `blob.stat`, `blob.begin`, `blob.put_part`, `blob.commit` and
+`blob.abort`. It adapts `BlobStore` and
 `BlobHydrator`; it does not implement a storage backend, schema, or graph vocabulary.
 
 ## Key types and modules
 
-- `BlobPack` holds the `KhiveRuntime` used to resolve the installed store and shared hydrator.
-- `pack.rs` declares the three agent-visible verbs, inventory-registers the factory, and dispatches
+- `BlobPack` holds the runtime and one shared upload manager. The daemon obtains that same
+  manager from the registered pack instance; constructing another pack would lose the upload map.
+- `pack.rs` declares the seven agent-visible verbs, inventory-registers the factory, and dispatches
   calls to `handlers.rs`.
 - `handlers.rs` validates base64 payloads, strict content references and optional ranges, enforces
   memory/wire bounds, and shapes verb responses.
+- `uploads.rs` owns sequential part accounting, incremental hashing, tail retries and expiry.
 - `ContentRef` is the canonical lowercase-hex BLAKE3 identity supplied by `khive-storage`.
 - `vocab.rs` contributes no entity or note kinds; typed artifact/reference modeling is a separate
   layer.
@@ -39,5 +42,39 @@ verbs: `blob.put`, `blob.get`, and `blob.stat`. It is a thin wire adapter over `
   verification because it never reads the content.
 - `blob.put` is unavailable on a read-only runtime. Reads remain available when a store is
   installed.
-- Physical deletion and orphan sweeping remain administrator-only operations and are not pack
-  verbs.
+- Deleting committed objects and sweeping unreferenced committed objects remain administrator-only
+  operations. Upload abort and expiry remove only staging.
+
+## Staged uploads
+
+`blob.begin(size, content_ref?)` returns `{upload_id, part_limit, next_index}`. If the
+optional reference already exists, it returns `{content_ref, size}` without creating
+staging. `blob.put_part(upload_id, index, bytes)` accepts base64 parts in order and
+returns `{next_index, received_bytes}`. The returned `part_limit` derives from the
+live request-parser and frame caps, minus an 8192-byte request reserve, scaled by 3/4.
+
+An identical resend of the last part is acknowledged without changing bytes, hash,
+index or activity time. An altered tail retry aborts the upload. Crossing declared
+size also aborts. A successful append records activity from before backend I/O,
+so a slow sync cannot make the pack clock newer than an already expiring stage.
+Cancelled or failed backend writes invalidate the record; cleanup failures retain
+an unusable record for the next sweep to retry.
+
+`blob.commit(upload_id)` requires exactly the declared length, verifies an optional
+expected reference, and calls the backend's shared publication routine. It returns
+`{content_ref, size}` and consumes the id. `blob.abort(upload_id)` removes staging
+and returns `{aborted: true}`; unknown or consumed ids report unknown upload.
+
+The four upload verbs are Declaration verbs; existing `blob.put` remains Commissive.
+All mutations refuse on a read-only runtime. Upload ids are capabilities: the
+originating actor is retained for attribution, not an ownership restriction.
+There is no upload journal and a restarted daemon answers unknown upload.
+
+Only the daemon starts the upload sweep component. Each tick expires pack records
+and calls backend `sweep_uploads` for orphan staging, using the same idle policy as
+the verbs. Failures warn and retry on the next tick. The component joins the existing
+daemon cancellation and drain path. `KHIVE_BLOB_UPLOAD_IDLE_SECS` defaults to 3600;
+`KHIVE_BLOB_UPLOAD_SWEEP_INTERVAL_SECS` defaults to 600. Both accept positive integer
+seconds; invalid values use the default with a warning. The first tick is delayed
+by the interval. The filesystem stages below `.uploads/`, which object GC ignores.
+Backends without staged-upload support return Unsupported from the storage contract.

--- a/crates/khive-pack-blob/src/handlers.rs
+++ b/crates/khive-pack-blob/src/handlers.rs
@@ -9,7 +9,9 @@ use serde_json::{json, Value};
 use khive_runtime::daemon::MAX_FRAME_BYTES;
 use khive_runtime::{BlobHydrator, KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::blob::ContentRef;
-use khive_storage::BlobStore;
+use khive_storage::{BlobStore, UploadId};
+
+use crate::uploads::UploadManager;
 
 /// Ceiling on the size of any object this verb surface will hydrate into
 /// memory, on either the write path (`blob.put`'s decoded size) or the read
@@ -27,7 +29,7 @@ use khive_storage::BlobStore;
 /// bound is what makes put/get behavior backend-independent: an object this
 /// surface accepts against an `FsBlobStore` install must also fit through an
 /// `S3BlobStore` install without a surprise rejection on `put`.
-const MAX_OBJECT_BYTES: u64 = 64 * 1024 * 1024;
+pub(crate) const MAX_OBJECT_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Reserve for the JSON envelope around `bytes` in a `blob.get` response
 /// (`content_ref`, `size`, `range`, field names, and braces/quoting) —
@@ -45,7 +47,16 @@ fn max_returnable_raw_bytes() -> u64 {
     frame_budget * 3 / 4
 }
 
-fn blob_store(runtime: &KhiveRuntime) -> Result<Arc<dyn BlobStore>, RuntimeError> {
+/// Room for upload call fields inside the request parser's ops string.
+pub const REQUEST_RESERVE: u64 = 8192;
+
+/// Maximum decoded part that fits the live parser and daemon frame budgets.
+pub fn max_request_part_raw_bytes() -> u64 {
+    let budget = khive_request::MAX_OPS_INPUT_LEN.min(MAX_FRAME_BYTES) as u64;
+    budget.saturating_sub(REQUEST_RESERVE) * 3 / 4
+}
+
+pub(crate) fn blob_store(runtime: &KhiveRuntime) -> Result<Arc<dyn BlobStore>, RuntimeError> {
     runtime.blob_store().ok_or_else(|| {
         RuntimeError::Unconfigured(
             "no BlobStore installed on this server (configure [storage.blob] in khive.toml, or \
@@ -81,6 +92,94 @@ fn parse_content_ref(params: &Value, verb: &str) -> Result<ContentRef, RuntimeEr
     let raw = required_str(params, "content_ref", verb)?;
     ContentRef::from_hex(raw)
         .map_err(|e| RuntimeError::InvalidInput(format!("{verb}: invalid content_ref: {e}")))
+}
+
+fn parse_upload_id(params: &Value, verb: &str) -> Result<UploadId, RuntimeError> {
+    UploadId::from_hex(required_str(params, "upload_id", verb)?)
+        .map_err(|error| RuntimeError::InvalidInput(format!("{verb}: {error}")))
+}
+
+fn required_u64(params: &Value, field: &str, verb: &str) -> Result<u64, RuntimeError> {
+    params.get(field).and_then(Value::as_u64).ok_or_else(|| {
+        RuntimeError::InvalidInput(format!("{verb}: {field} must be a non-negative integer"))
+    })
+}
+
+pub(crate) async fn handle_begin(
+    uploads: &UploadManager,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let size = required_u64(&params, "size", "blob.begin")?;
+    let reference = match params.get("content_ref") {
+        None | Some(Value::Null) => None,
+        Some(_) => Some(parse_content_ref(&params, "blob.begin")?),
+    };
+    uploads
+        .begin(size, reference, token.actor().to_string())
+        .await
+}
+
+pub(crate) async fn handle_put_part(
+    uploads: &UploadManager,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let id = parse_upload_id(&params, "blob.put_part")?;
+    let index = required_u64(&params, "index", "blob.put_part")?;
+    let b64 = params.get("bytes").and_then(Value::as_str).ok_or_else(|| {
+        RuntimeError::InvalidInput("blob.put_part requires \"bytes\" (base64)".into())
+    })?;
+    let limit = max_request_part_raw_bytes();
+    // Permit one extra decoded byte so the boundary is decided on raw
+    // length; bound larger inputs before allocating a decoded buffer.
+    if b64.len() as u64 > limit.saturating_mul(4) / 3 + 4 {
+        // Validate without allocating the oversized decoded object. Only
+        // the final quartet may contain padding; decode it with the same
+        // engine to check canonical padding bits and obtain the exact size.
+        let encoded = b64.as_bytes();
+        if encoded.len() % 4 != 0 {
+            return Err(RuntimeError::InvalidInput(
+                "blob.put_part: invalid base64 length".into(),
+            ));
+        }
+        let (prefix, suffix) = encoded.split_at(encoded.len() - 4);
+        if !prefix
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(*byte, b'+' | b'/'))
+        {
+            return Err(RuntimeError::InvalidInput(
+                "blob.put_part: invalid base64 alphabet or padding".into(),
+            ));
+        }
+        let mut tail = [0; 3];
+        let tail_len = BASE64.decode_slice(suffix, &mut tail).map_err(|error| {
+            RuntimeError::InvalidInput(format!("blob.put_part: invalid base64: {error}"))
+        })?;
+        let decoded_len = (prefix.len() / 4 * 3 + tail_len) as u64;
+        return uploads.reject_oversized_part(&id, index, decoded_len).await;
+    }
+    let bytes = BASE64.decode(b64).map_err(|error| {
+        RuntimeError::InvalidInput(format!("blob.put_part: invalid base64: {error}"))
+    })?;
+    uploads.put_part(&id, index, bytes).await
+}
+
+pub(crate) async fn handle_commit(
+    uploads: &UploadManager,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    uploads
+        .commit(&parse_upload_id(&params, "blob.commit")?)
+        .await
+}
+
+pub(crate) async fn handle_abort(
+    uploads: &UploadManager,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    uploads
+        .abort(&parse_upload_id(&params, "blob.abort")?)
+        .await
 }
 
 /// Strictly parse an optional `range` field into `(offset, length)`.

--- a/crates/khive-pack-blob/src/handlers.rs
+++ b/crates/khive-pack-blob/src/handlers.rs
@@ -116,7 +116,11 @@ pub(crate) async fn handle_begin(
         Some(_) => Some(parse_content_ref(&params, "blob.begin")?),
     };
     uploads
-        .begin(size, reference, token.actor().to_string())
+        .begin(
+            size,
+            reference,
+            format!("{}:{}", token.actor().kind, token.actor().id),
+        )
         .await
 }
 

--- a/crates/khive-pack-blob/src/lib.rs
+++ b/crates/khive-pack-blob/src/lib.rs
@@ -1,6 +1,6 @@
 //! Blob verb pack — thin MCP verbs over the existing `BlobStore` CAS.
 //!
-//! Three verbs — `blob.put`, `blob.get`, and `blob.stat` — expose the installed
+//! Direct put, staged upload, get and stat verbs expose the installed
 //! content-addressed service. `put` and `stat` use the raw store's mutation and
 //! metadata capabilities; `get` enters the paired runtime `BlobHydrator` for
 //! backend-verified, shared-admission whole-buffer reads. This pack adds no
@@ -10,7 +10,12 @@
 
 pub mod handlers;
 mod pack;
+pub mod uploads;
 pub mod vocab;
+
+pub use uploads::UploadManager;
+
+use std::sync::Arc;
 
 use khive_runtime::KhiveRuntime;
 use khive_types::{HandlerDef, Pack};
@@ -23,6 +28,7 @@ pub(crate) const PACK_NAME: &str = "blob";
 /// Blob pack: thin verb surface over the runtime's installed `BlobStore`.
 pub struct BlobPack {
     runtime: KhiveRuntime,
+    uploads: Arc<UploadManager>,
 }
 
 impl Pack for BlobPack {
@@ -35,7 +41,8 @@ impl Pack for BlobPack {
 
 impl BlobPack {
     pub fn new(runtime: KhiveRuntime) -> Self {
-        Self { runtime }
+        let uploads = Arc::new(UploadManager::new(runtime.clone()));
+        Self { runtime, uploads }
     }
 
     pub(crate) fn runtime(&self) -> &KhiveRuntime {

--- a/crates/khive-pack-blob/src/pack.rs
+++ b/crates/khive-pack-blob/src/pack.rs
@@ -9,7 +9,7 @@ use khive_types::{HandlerDef, IdResolutionMode, ParamDef, Visibility};
 
 use crate::{handlers, BlobPack, PACK_NAME};
 
-pub(crate) static BLOB_HANDLERS: [HandlerDef; 3] = [
+pub(crate) static BLOB_HANDLERS: [HandlerDef; 7] = [
     HandlerDef {
         name: "blob.put",
         description: "Store bytes (base64) in the content-addressed \
@@ -64,6 +64,87 @@ pub(crate) static BLOB_HANDLERS: [HandlerDef; 3] = [
             resolution_mode: IdResolutionMode::NotApplicable,
         }],
     },
+    HandlerDef {
+        name: "blob.begin",
+        description: "Begin a sequential upload, or return an existing known content reference without staging.",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            ParamDef {
+                name: "size",
+                param_type: "integer",
+                required: true,
+                description: "Declared total bytes, at most 64 MiB.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+            ParamDef {
+                name: "content_ref",
+                param_type: "string",
+                required: false,
+                description: "Optional BLAKE3 reference; checked at commit, with an existence shortcut at begin.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+        ],
+    },
+    HandlerDef {
+        name: "blob.put_part",
+        description: "Append a base64 part at next_index; an identical tail retry is acknowledged without appending.",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            ParamDef {
+                name: "upload_id",
+                param_type: "string",
+                required: true,
+                description: "32-character lowercase hex upload capability returned by blob.begin.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+            ParamDef {
+                name: "index",
+                param_type: "integer",
+                required: true,
+                description: "Zero-based next part index, or the last accepted index for an identical retry.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+            ParamDef {
+                name: "bytes",
+                param_type: "string",
+                required: true,
+                description: "Base64 part, decoded length no greater than the returned part_limit.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+        ],
+    },
+    HandlerDef {
+        name: "blob.commit",
+        description: "Verify declared size and optional reference, then publish the staged object; consumes the upload id.",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            ParamDef {
+                name: "upload_id",
+                param_type: "string",
+                required: true,
+                description: "32-character lowercase hex upload capability returned by blob.begin.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+        ],
+    },
+    HandlerDef {
+        name: "blob.abort",
+        description: "Discard a staged upload and invalidate its process-local capability.",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            ParamDef {
+                name: "upload_id",
+                param_type: "string",
+                required: true,
+                description: "32-character lowercase hex upload capability returned by blob.begin.",
+                resolution_mode: IdResolutionMode::NotApplicable,
+            },
+        ],
+    },
 ];
 
 struct BlobPackFactory;
@@ -100,6 +181,14 @@ impl PackRuntime for BlobPack {
         <BlobPack as khive_types::Pack>::REQUIRES
     }
 
+    fn host_state(&self) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
+        if self.runtime().is_read_only() || self.runtime().blob_store().is_none() {
+            None
+        } else {
+            Some(self.uploads.clone())
+        }
+    }
+
     async fn dispatch(
         &self,
         verb: &str,
@@ -111,6 +200,10 @@ impl PackRuntime for BlobPack {
             "blob.put" => handlers::handle_put(self.runtime(), token, params).await,
             "blob.get" => handlers::handle_get(self.runtime(), token, params).await,
             "blob.stat" => handlers::handle_stat(self.runtime(), token, params).await,
+            "blob.begin" => handlers::handle_begin(&self.uploads, token, params).await,
+            "blob.put_part" => handlers::handle_put_part(&self.uploads, params).await,
+            "blob.commit" => handlers::handle_commit(&self.uploads, params).await,
+            "blob.abort" => handlers::handle_abort(&self.uploads, params).await,
             _ => Err(RuntimeError::InvalidInput(format!(
                 "{PACK_NAME} pack does not handle verb {verb:?}"
             ))),

--- a/crates/khive-pack-blob/src/uploads.rs
+++ b/crates/khive-pack-blob/src/uploads.rs
@@ -14,10 +14,25 @@ use crate::handlers::{blob_store, max_request_part_raw_bytes, MAX_OBJECT_BYTES};
 struct UploadPolicy {
     idle_for: Duration,
     sweep_interval: Duration,
+    max_active: usize,
+    max_per_actor: usize,
 }
 
 impl UploadPolicy {
+    fn positive_limit(raw: &str) -> Option<usize> {
+        raw.parse::<usize>().ok().filter(|value| *value > 0)
+    }
+
     fn from_env() -> Self {
+        fn limit(name: &str, default: usize) -> usize {
+            match std::env::var(name) {
+                Ok(raw) => UploadPolicy::positive_limit(&raw).unwrap_or_else(|| {
+                    tracing::warn!(name, "invalid upload ceiling; using default");
+                    default
+                }),
+                Err(_) => default,
+            }
+        }
         fn duration(name: &str, default: u64) -> Duration {
             match std::env::var(name) {
                 Ok(raw) => match raw.parse::<u64>() {
@@ -40,6 +55,64 @@ impl UploadPolicy {
         Self {
             idle_for: duration("KHIVE_BLOB_UPLOAD_IDLE_SECS", 3600),
             sweep_interval: duration("KHIVE_BLOB_UPLOAD_SWEEP_INTERVAL_SECS", 600),
+            max_active: limit("KHIVE_BLOB_UPLOAD_MAX_ACTIVE", 128),
+            max_per_actor: limit("KHIVE_BLOB_UPLOAD_MAX_PER_ACTOR", 16),
+        }
+    }
+}
+
+/// Reservations include backend creation and records awaiting successful cleanup.
+/// Actor counts live outside the async record locks so admission never holds the
+/// registry mutex across I/O or inverts the record -> registry cleanup lock order.
+#[derive(Default)]
+struct UploadSlots {
+    by_actor: Mutex<HashMap<String, usize>>,
+}
+
+impl UploadSlots {
+    fn reserve(
+        self: &Arc<Self>,
+        actor: &str,
+        policy: UploadPolicy,
+    ) -> Result<UploadSlot, RuntimeError> {
+        let mut counts = self.by_actor.lock().expect("upload slots mutex poisoned");
+        let total: usize = counts.values().sum();
+        if total >= policy.max_active {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob.begin: total active-upload ceiling of {} reached",
+                policy.max_active
+            )));
+        }
+        if counts.get(actor).copied().unwrap_or(0) >= policy.max_per_actor {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob.begin: per-actor active-upload ceiling of {} reached",
+                policy.max_per_actor
+            )));
+        }
+        *counts.entry(actor.to_owned()).or_default() += 1;
+        Ok(UploadSlot {
+            slots: Arc::clone(self),
+            actor: actor.to_owned(),
+        })
+    }
+}
+
+struct UploadSlot {
+    slots: Arc<UploadSlots>,
+    actor: String,
+}
+
+impl Drop for UploadSlot {
+    fn drop(&mut self) {
+        let mut counts = self
+            .slots
+            .by_actor
+            .lock()
+            .expect("upload slots mutex poisoned");
+        let count = counts.get_mut(&self.actor).expect("reserved upload actor");
+        *count -= 1;
+        if *count == 0 {
+            counts.remove(&self.actor);
         }
     }
 }
@@ -63,13 +136,15 @@ struct UploadRecord {
     actor: String,
     last_part: Instant,
     phase: UploadPhase,
+    slot: Option<UploadSlot>,
 }
 
 /// Shared state owned by one loaded blob pack; upload ids do not survive restart.
 pub struct UploadManager {
     runtime: KhiveRuntime,
     policy: UploadPolicy,
-    records: Mutex<HashMap<UploadId, Arc<tokio::sync::Mutex<UploadRecord>>>>,
+    records: Arc<Mutex<HashMap<UploadId, Arc<tokio::sync::Mutex<UploadRecord>>>>>,
+    slots: Arc<UploadSlots>,
 }
 
 impl UploadManager {
@@ -77,7 +152,8 @@ impl UploadManager {
         Self {
             runtime,
             policy: UploadPolicy::from_env(),
-            records: Mutex::new(HashMap::new()),
+            records: Arc::new(Mutex::new(HashMap::new())),
+            slots: Arc::new(UploadSlots::default()),
         }
     }
 
@@ -121,6 +197,7 @@ impl UploadManager {
         record.phase = UploadPhase::Aborted;
         record.store.abort_upload(id).await?;
         record.phase = UploadPhase::Finished;
+        drop(record.slot.take());
         self.forget(id);
         Ok(())
     }
@@ -166,24 +243,37 @@ impl UploadManager {
                 return Ok(json!({"content_ref": reference.to_string(), "size": stored_size}));
             }
         }
-        let last_part = Instant::now();
-        let id = store.begin_upload(size).await?;
-        let record = UploadRecord {
-            store,
-            size,
-            expected_ref,
-            hasher: blake3::Hasher::new(),
-            received_bytes: 0,
-            next_index: 0,
-            tail: None,
-            actor,
-            last_part,
-            phase: UploadPhase::Active,
-        };
-        self.records
-            .lock()
-            .expect("upload map mutex poisoned")
-            .insert(id.clone(), Arc::new(tokio::sync::Mutex::new(record)));
+        let slot = self.slots.reserve(&actor, self.policy)?;
+        let records = Arc::clone(&self.records);
+        // Once admitted, finish registration even if the calling request is
+        // cancelled. Otherwise a backend creation could outlive its reservation
+        // and leave staging that no longer counts toward either ceiling.
+        let id = tokio::spawn(async move {
+            let last_part = Instant::now();
+            let id = store.begin_upload(size).await?;
+            let record = UploadRecord {
+                store,
+                size,
+                expected_ref,
+                hasher: blake3::Hasher::new(),
+                received_bytes: 0,
+                next_index: 0,
+                tail: None,
+                actor,
+                last_part,
+                phase: UploadPhase::Active,
+                slot: Some(slot),
+            };
+            records
+                .lock()
+                .expect("upload map mutex poisoned")
+                .insert(id.clone(), Arc::new(tokio::sync::Mutex::new(record)));
+            Ok::<_, RuntimeError>(id)
+        })
+        .await
+        .map_err(|error| {
+            RuntimeError::Internal(format!("blob.begin: creation task failed: {error}"))
+        })??;
         Ok(
             json!({"upload_id": id.to_string(), "part_limit": max_request_part_raw_bytes(), "next_index": 0}),
         )
@@ -326,6 +416,7 @@ impl UploadManager {
             return Err(error.into());
         }
         record.phase = UploadPhase::Finished;
+        drop(record.slot.take());
         self.forget(id);
         Ok(json!({"content_ref": reference.to_string(), "size": record.size}))
     }

--- a/crates/khive-pack-blob/src/uploads.rs
+++ b/crates/khive-pack-blob/src/uploads.rs
@@ -1,0 +1,387 @@
+//! Process-local upload capabilities shared by the verbs and daemon sweeper.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use khive_runtime::{KhiveRuntime, RuntimeError};
+use khive_storage::{BlobStore, ContentRef, UploadId};
+use serde_json::{json, Value};
+
+use crate::handlers::{blob_store, max_request_part_raw_bytes, MAX_OBJECT_BYTES};
+
+#[derive(Clone, Copy)]
+struct UploadPolicy {
+    idle_for: Duration,
+    sweep_interval: Duration,
+}
+
+impl UploadPolicy {
+    fn from_env() -> Self {
+        fn duration(name: &str, default: u64) -> Duration {
+            match std::env::var(name) {
+                Ok(raw) => match raw.parse::<u64>() {
+                    Ok(seconds)
+                        if seconds > 0
+                            && Instant::now()
+                                .checked_add(Duration::from_secs(seconds))
+                                .is_some() =>
+                    {
+                        Duration::from_secs(seconds)
+                    }
+                    _ => {
+                        tracing::warn!(name, "invalid upload duration; using default");
+                        Duration::from_secs(default)
+                    }
+                },
+                Err(_) => Duration::from_secs(default),
+            }
+        }
+        Self {
+            idle_for: duration("KHIVE_BLOB_UPLOAD_IDLE_SECS", 3600),
+            sweep_interval: duration("KHIVE_BLOB_UPLOAD_SWEEP_INTERVAL_SECS", 600),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UploadPhase {
+    Active,
+    InFlight,
+    Aborted,
+    Finished,
+}
+
+struct UploadRecord {
+    store: Arc<dyn BlobStore>,
+    size: u64,
+    expected_ref: Option<ContentRef>,
+    hasher: blake3::Hasher,
+    received_bytes: u64,
+    next_index: u64,
+    tail: Option<(usize, blake3::Hash)>,
+    actor: String,
+    last_part: Instant,
+    phase: UploadPhase,
+}
+
+/// Shared state owned by one loaded blob pack; upload ids do not survive restart.
+pub struct UploadManager {
+    runtime: KhiveRuntime,
+    policy: UploadPolicy,
+    records: Mutex<HashMap<UploadId, Arc<tokio::sync::Mutex<UploadRecord>>>>,
+}
+
+impl UploadManager {
+    pub(crate) fn new(runtime: KhiveRuntime) -> Self {
+        Self {
+            runtime,
+            policy: UploadPolicy::from_env(),
+            records: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Delay between daemon-owned cleanup passes.
+    pub fn sweep_interval(&self) -> Duration {
+        self.policy.sweep_interval
+    }
+
+    fn write_store(&self) -> Result<Arc<dyn BlobStore>, RuntimeError> {
+        if self.runtime.is_read_only() {
+            return Err(RuntimeError::InvalidInput(
+                "blob uploads are unavailable because the blob pack runtime is read-only".into(),
+            ));
+        }
+        blob_store(&self.runtime)
+    }
+
+    fn unknown(id: &UploadId) -> RuntimeError {
+        RuntimeError::NotFound(format!("unknown upload {id}"))
+    }
+
+    fn record(&self, id: &UploadId) -> Result<Arc<tokio::sync::Mutex<UploadRecord>>, RuntimeError> {
+        self.records
+            .lock()
+            .expect("upload map mutex poisoned")
+            .get(id)
+            .cloned()
+            .ok_or_else(|| Self::unknown(id))
+    }
+
+    fn forget(&self, id: &UploadId) {
+        self.records
+            .lock()
+            .expect("upload map mutex poisoned")
+            .remove(id);
+    }
+
+    async fn discard(&self, id: &UploadId, record: &mut UploadRecord) -> Result<(), RuntimeError> {
+        // Keep a terminal record when cleanup fails or is cancelled. In
+        // particular, a live S3 multipart handle cannot be found by listing.
+        record.phase = UploadPhase::Aborted;
+        record.store.abort_upload(id).await?;
+        record.phase = UploadPhase::Finished;
+        self.forget(id);
+        Ok(())
+    }
+
+    async fn discard_after_error(&self, id: &UploadId, record: &mut UploadRecord) {
+        if let Err(error) = self.discard(id, record).await {
+            tracing::warn!(upload_id = %id, actor = %record.actor, %error, "upload cleanup failed; sweep will retry");
+        }
+    }
+
+    async fn require_live(
+        &self,
+        id: &UploadId,
+        record: &mut UploadRecord,
+    ) -> Result<(), RuntimeError> {
+        if record.phase != UploadPhase::Active {
+            if record.phase != UploadPhase::Finished {
+                self.discard_after_error(id, record).await;
+            }
+            return Err(Self::unknown(id));
+        }
+        if record.last_part.elapsed() >= self.policy.idle_for {
+            self.discard_after_error(id, record).await;
+            return Err(Self::unknown(id));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn begin(
+        &self,
+        size: u64,
+        expected_ref: Option<ContentRef>,
+        actor: String,
+    ) -> Result<Value, RuntimeError> {
+        let store = self.write_store()?;
+        if size > MAX_OBJECT_BYTES {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob.begin: size exceeds the {MAX_OBJECT_BYTES}-byte maximum"
+            )));
+        }
+        if let Some(reference) = &expected_ref {
+            if let Some(stored_size) = store.size(reference).await? {
+                return Ok(json!({"content_ref": reference.to_string(), "size": stored_size}));
+            }
+        }
+        let last_part = Instant::now();
+        let id = store.begin_upload(size).await?;
+        let record = UploadRecord {
+            store,
+            size,
+            expected_ref,
+            hasher: blake3::Hasher::new(),
+            received_bytes: 0,
+            next_index: 0,
+            tail: None,
+            actor,
+            last_part,
+            phase: UploadPhase::Active,
+        };
+        self.records
+            .lock()
+            .expect("upload map mutex poisoned")
+            .insert(id.clone(), Arc::new(tokio::sync::Mutex::new(record)));
+        Ok(
+            json!({"upload_id": id.to_string(), "part_limit": max_request_part_raw_bytes(), "next_index": 0}),
+        )
+    }
+
+    pub(crate) async fn put_part(
+        &self,
+        id: &UploadId,
+        index: u64,
+        bytes: Vec<u8>,
+    ) -> Result<Value, RuntimeError> {
+        self.write_store()?;
+        let entry = self.record(id)?;
+        let mut record = entry.lock().await;
+        self.require_live(id, &mut record).await?;
+        let part_hash = blake3::hash(&bytes);
+        if record.next_index.checked_sub(1) == Some(index) {
+            let (tail_len, tail_hash) = record.tail.expect("accepted part has a tail digest");
+            if bytes.len() != tail_len || part_hash != tail_hash {
+                self.discard_after_error(id, &mut record).await;
+                return Err(RuntimeError::InvalidInput(
+                    "blob.put_part: tail retry differs from the accepted part; upload aborted"
+                        .into(),
+                ));
+            }
+            // A retry did not write a new part or refresh the backend mtime;
+            // keep its idle clock unchanged as well.
+            return Ok(
+                json!({"next_index": record.next_index, "received_bytes": record.received_bytes}),
+            );
+        }
+        if index != record.next_index {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob.put_part: expected index {}, got {index}",
+                record.next_index
+            )));
+        }
+        let received = record.received_bytes.checked_add(bytes.len() as u64);
+        let Some(received) =
+            received.filter(|total| *total <= record.size && *total <= MAX_OBJECT_BYTES)
+        else {
+            self.discard_after_error(id, &mut record).await;
+            return Err(RuntimeError::InvalidInput(
+                "blob.put_part: part exceeds declared size; upload aborted".into(),
+            ));
+        };
+        if bytes.len() as u64 > max_request_part_raw_bytes() {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob.put_part: decoded length {} exceeds part_limit {}",
+                bytes.len(),
+                max_request_part_raw_bytes()
+            )));
+        }
+        let Some(next_index) = record.next_index.checked_add(1) else {
+            self.discard_after_error(id, &mut record).await;
+            return Err(RuntimeError::InvalidInput(
+                "blob.put_part: index overflow; upload aborted".into(),
+            ));
+        };
+        let mut hasher = record.hasher.clone();
+        hasher.update(&bytes);
+        let part_len = bytes.len();
+        // If this await is cancelled, the backend may still finish its write.
+        // Leave InFlight until success is accounted for: later verbs abort it.
+        let accepted_at = Instant::now();
+        record.phase = UploadPhase::InFlight;
+        match record.store.append_part(id, bytes).await {
+            Ok(observed) if observed == received => {}
+            Ok(_) => {
+                self.discard_after_error(id, &mut record).await;
+                return Err(RuntimeError::Internal(
+                    "staged upload length differs from accepted parts".into(),
+                ));
+            }
+            Err(error) => {
+                self.discard_after_error(id, &mut record).await;
+                return Err(error.into());
+            }
+        }
+        record.hasher = hasher;
+        record.received_bytes = received;
+        record.next_index = next_index;
+        record.tail = Some((part_len, part_hash));
+        // Start before backend I/O so a slow sync cannot leave the staging
+        // mtime expired while the pack clock claims the part is still fresh.
+        record.last_part = accepted_at;
+        record.phase = UploadPhase::Active;
+        Ok(json!({"next_index": next_index, "received_bytes": received}))
+    }
+
+    pub(crate) async fn reject_oversized_part(
+        &self,
+        id: &UploadId,
+        index: u64,
+        decoded_bytes: u64,
+    ) -> Result<Value, RuntimeError> {
+        self.write_store()?;
+        let entry = self.record(id)?;
+        let mut record = entry.lock().await;
+        self.require_live(id, &mut record).await?;
+        // Every accepted tail fits the part limit. A validated encoded
+        // input whose decoded size exceeds it cannot be an identical retry.
+        let changed_tail = record.next_index.checked_sub(1) == Some(index);
+        let crosses_size = index == record.next_index
+            && record.received_bytes.saturating_add(decoded_bytes) > record.size;
+        if changed_tail || crosses_size {
+            self.discard_after_error(id, &mut record).await;
+        }
+        Err(RuntimeError::InvalidInput(format!(
+            "blob.put_part: base64 input exceeds the {}-byte part_limit",
+            max_request_part_raw_bytes()
+        )))
+    }
+
+    pub(crate) async fn commit(&self, id: &UploadId) -> Result<Value, RuntimeError> {
+        self.write_store()?;
+        let entry = self.record(id)?;
+        let mut record = entry.lock().await;
+        self.require_live(id, &mut record).await?;
+        if record.received_bytes != record.size {
+            return Err(RuntimeError::InvalidInput(format!(
+                "blob.commit: received {} bytes, expected {}",
+                record.received_bytes, record.size
+            )));
+        }
+        let reference = ContentRef::from_digest_bytes(record.hasher.finalize().as_bytes());
+        if record
+            .expected_ref
+            .as_ref()
+            .is_some_and(|expected| expected != &reference)
+        {
+            self.discard_after_error(id, &mut record).await;
+            return Err(RuntimeError::InvalidInput(
+                "blob.commit: content_ref mismatch; upload aborted".into(),
+            ));
+        }
+        record.phase = UploadPhase::InFlight;
+        if let Err(error) = record.store.commit_upload(id, &reference).await {
+            self.discard_after_error(id, &mut record).await;
+            return Err(error.into());
+        }
+        record.phase = UploadPhase::Finished;
+        self.forget(id);
+        Ok(json!({"content_ref": reference.to_string(), "size": record.size}))
+    }
+
+    pub(crate) async fn abort(&self, id: &UploadId) -> Result<Value, RuntimeError> {
+        self.write_store()?;
+        let entry = self.record(id)?;
+        let mut record = entry.lock().await;
+        if record.phase == UploadPhase::Finished {
+            return Err(Self::unknown(id));
+        }
+        self.discard(id, &mut record).await?;
+        Ok(json!({"aborted": true}))
+    }
+
+    /// Expire records and sweep backend staging that has lost its process state.
+    pub async fn sweep(&self) -> Result<u64, RuntimeError> {
+        let store = self.write_store()?;
+        let entries: Vec<_> = self
+            .records
+            .lock()
+            .expect("upload map mutex poisoned")
+            .iter()
+            .map(|(id, record)| (id.clone(), Arc::clone(record)))
+            .collect();
+        let mut removed = 0;
+        let mut failure = None;
+        for (id, entry) in entries {
+            let mut record = entry.lock().await;
+            if record.phase == UploadPhase::Finished {
+                continue;
+            }
+            if record.phase != UploadPhase::Active
+                || record.last_part.elapsed() >= self.policy.idle_for
+            {
+                match self.discard(&id, &mut record).await {
+                    Ok(()) => removed += 1,
+                    Err(error) => {
+                        tracing::warn!(upload_id = %id, actor = %record.actor, %error, "upload expiry failed; next tick will retry");
+                        failure.get_or_insert(error);
+                    }
+                }
+            }
+        }
+        match store.sweep_uploads(self.policy.idle_for).await {
+            Ok(count) => removed += count,
+            Err(error) => {
+                failure.get_or_insert(error.into());
+            }
+        }
+        match failure {
+            Some(error) => Err(error),
+            None => Ok(removed),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/khive-pack-blob/src/uploads/tests.rs
+++ b/crates/khive-pack-blob/src/uploads/tests.rs
@@ -715,7 +715,27 @@ async fn read_only_runtime_refuses_every_upload_operation_without_mutation() {
         packs: vec!["kg".into()],
         ..RuntimeConfig::no_embeddings()
     };
-    drop(KhiveRuntime::new(config.clone()).unwrap());
+    let writable = KhiveRuntime::new(config.clone()).unwrap();
+    let pool = writable.backend().pool_arc();
+    // This constructor only prepares the schema synchronously and has no
+    // embedding models to register. Prove that no standalone writer task
+    // was spawned and no pool owner survives, rather than assuming drop
+    // settles arbitrary runtime clones or detached writer tasks.
+    assert!(!pool.writer_task_join_was_stored());
+    let pool_lifetime = Arc::downgrade(&pool);
+    drop(pool);
+    drop(writable);
+    assert!(pool_lifetime.upgrade().is_none());
+
+    // The pool drops its writer before its readers, so closed connections
+    // can still leave WAL sidecars. Let SQLite checkpoint and settle them
+    // on one explicitly closed connection; never unlink uncheckpointed WAL.
+    let settled = rusqlite::Connection::open(config.db_path.as_ref().unwrap()).unwrap();
+    let mode: String = settled
+        .pragma_update_and_check(None, "journal_mode", "DELETE", |row| row.get(0))
+        .unwrap();
+    assert_eq!(mode.to_ascii_lowercase(), "delete");
+    settled.close().unwrap();
     let runtime = KhiveRuntime::new_readonly(config).unwrap();
     assert!(runtime.is_read_only());
     let mut readonly = manager_with_store(runtime, f.store.clone());

--- a/crates/khive-pack-blob/src/uploads/tests.rs
+++ b/crates/khive-pack-blob/src/uploads/tests.rs
@@ -1,0 +1,1099 @@
+use super::*;
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use khive_db::stores::blob::FsBlobStore;
+use khive_runtime::{RequestIdentity, RuntimeConfig, VerbRegistryBuilder};
+use khive_storage::{StorageError, StorageResult};
+
+use crate::handlers::{handle_put_part, REQUEST_RESERVE};
+use crate::BlobPack;
+
+const IDLE: Duration = Duration::from_secs(3600);
+
+#[test]
+fn upload_handler_metadata_preserves_declaration_and_commissive_categories() {
+    for (name, expected) in [
+        ("blob.begin", khive_types::VerbCategory::Declaration),
+        ("blob.put_part", khive_types::VerbCategory::Declaration),
+        ("blob.commit", khive_types::VerbCategory::Declaration),
+        ("blob.abort", khive_types::VerbCategory::Declaration),
+        ("blob.put", khive_types::VerbCategory::Commissive),
+    ] {
+        let handler = crate::BLOB_HANDLERS
+            .iter()
+            .find(|handler| handler.name == name)
+            .unwrap_or_else(|| panic!("missing handler metadata for {name}"));
+        assert_eq!(handler.category, expected, "{name}");
+    }
+}
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+    store: Arc<FsBlobStore>,
+    manager: UploadManager,
+}
+
+fn manager_with_store(runtime: KhiveRuntime, store: Arc<dyn BlobStore>) -> UploadManager {
+    runtime.install_blob_store(store).unwrap();
+    UploadManager {
+        runtime,
+        policy: UploadPolicy {
+            idle_for: IDLE,
+            sweep_interval: Duration::from_secs(600),
+        },
+        records: Mutex::new(HashMap::new()),
+    }
+}
+
+fn fixture() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("blobs");
+    let store = Arc::new(FsBlobStore::new(root.clone(), 0).unwrap());
+    let manager = manager_with_store(KhiveRuntime::memory().unwrap(), store.clone());
+    Fixture {
+        _dir: dir,
+        root,
+        store,
+        manager,
+    }
+}
+
+fn upload_id(response: &Value) -> UploadId {
+    UploadId::from_hex(response["upload_id"].as_str().unwrap()).unwrap()
+}
+
+async fn begin(manager: &UploadManager, size: u64) -> UploadId {
+    upload_id(
+        &manager
+            .begin(size, None, "uploader:a".into())
+            .await
+            .unwrap(),
+    )
+}
+
+fn staged(root: &Path, id: &UploadId) -> PathBuf {
+    root.join(".uploads").join(id.as_str())
+}
+
+fn content_ref(bytes: &[u8]) -> ContentRef {
+    ContentRef::from_digest_bytes(blake3::hash(bytes).as_bytes())
+}
+
+fn assert_unknown(error: RuntimeError) {
+    assert!(matches!(error, RuntimeError::NotFound(_)), "{error}");
+    assert!(error.to_string().contains("unknown upload"), "{error}");
+}
+
+async fn expire_record(manager: &UploadManager, id: &UploadId) {
+    manager.record(id).unwrap().lock().await.last_part =
+        Instant::now().checked_sub(IDLE * 2).unwrap();
+}
+
+fn age_file(path: &Path) {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .unwrap()
+        .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1))
+        .unwrap();
+}
+
+#[tokio::test]
+async fn wrong_index_refuses_without_changing_upload() {
+    let f = fixture();
+    let id = begin(&f.manager, 3).await;
+    let error = f.manager.put_part(&id, 1, b"a".to_vec()).await.unwrap_err();
+    assert!(error.to_string().contains("expected index 0"));
+    assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"");
+    f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
+    f.manager.put_part(&id, 1, b"b".to_vec()).await.unwrap();
+    let error = f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap_err();
+    assert!(error.to_string().contains("expected index 2"));
+    assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"ab");
+    f.manager.put_part(&id, 2, b"c".to_vec()).await.unwrap();
+    let result = f.manager.commit(&id).await.unwrap();
+    assert_eq!(result["content_ref"], content_ref(b"abc").to_string());
+}
+
+#[tokio::test]
+async fn identical_tail_retry_preserves_hash_counts_and_idle_clocks() {
+    let f = fixture();
+    let id = begin(&f.manager, 6).await;
+    let accepted = f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    let entry = f.manager.record(&id).unwrap();
+    let (last_part, hash, tail) = {
+        let mut record = entry.lock().await;
+        record.last_part = Instant::now().checked_sub(Duration::from_secs(10)).unwrap();
+        (record.last_part, record.hasher.finalize(), record.tail)
+    };
+    let path = staged(&f.root, &id);
+    age_file(&path);
+    let modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+    let retried = f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    assert_eq!(retried, accepted);
+    {
+        let record = entry.lock().await;
+        assert_eq!(record.received_bytes, 3);
+        assert_eq!(record.next_index, 1);
+        assert_eq!(record.hasher.finalize(), hash);
+        assert_eq!(record.tail, tail);
+        assert_eq!(record.last_part, last_part);
+    }
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().modified().unwrap(),
+        modified
+    );
+    assert_eq!(std::fs::read(&path).unwrap(), b"abc");
+    f.manager.put_part(&id, 1, b"def".to_vec()).await.unwrap();
+    let result = f.manager.commit(&id).await.unwrap();
+    assert_eq!(result["content_ref"], content_ref(b"abcdef").to_string());
+}
+
+#[tokio::test]
+async fn different_length_tail_retry_aborts_and_commit_is_unknown() {
+    let f = fixture();
+    let id = begin(&f.manager, 6).await;
+    f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    let error = f
+        .manager
+        .put_part(&id, 0, b"ab".to_vec())
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("tail retry differs"));
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(f.manager.commit(&id).await.unwrap_err());
+    assert!(!f.store.exists(&content_ref(b"abc")).await.unwrap());
+}
+
+#[tokio::test]
+async fn same_length_different_bytes_tail_retry_aborts_and_commit_is_unknown() {
+    let f = fixture();
+    let id = begin(&f.manager, 6).await;
+    f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    let error = f
+        .manager
+        .put_part(&id, 0, b"abd".to_vec())
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("tail retry differs"));
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(f.manager.commit(&id).await.unwrap_err());
+    assert!(!f.store.exists(&content_ref(b"abc")).await.unwrap());
+}
+
+#[tokio::test]
+async fn zero_byte_part_advances_index_and_is_retryable() {
+    let f = fixture();
+    let id = begin(&f.manager, 1).await;
+    let params = json!({"upload_id": id.to_string(), "index": 0, "bytes": ""});
+    let accepted = handle_put_part(&f.manager, params.clone()).await.unwrap();
+    assert_eq!(accepted, json!({"next_index": 1, "received_bytes": 0}));
+    assert_eq!(handle_put_part(&f.manager, params).await.unwrap(), accepted);
+    f.manager.put_part(&id, 1, b"a".to_vec()).await.unwrap();
+    assert_eq!(
+        f.manager.commit(&id).await.unwrap()["content_ref"],
+        content_ref(b"a").to_string()
+    );
+}
+
+#[tokio::test]
+async fn zero_byte_object_commits_without_a_part() {
+    let f = fixture();
+    let id = begin(&f.manager, 0).await;
+    let result = f.manager.commit(&id).await.unwrap();
+    let reference = content_ref(b"");
+    assert_eq!(
+        result,
+        json!({"content_ref": reference.to_string(), "size": 0})
+    );
+    assert_eq!(
+        f.store.get_bounded_verified(&reference, 0).await.unwrap(),
+        b""
+    );
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(f.manager.commit(&id).await.unwrap_err());
+}
+
+#[tokio::test]
+async fn expected_hash_mismatch_aborts_and_cleans_staging() {
+    let f = fixture();
+    let id = upload_id(
+        &f.manager
+            .begin(3, Some(content_ref(b"abd")), "uploader:a".into())
+            .await
+            .unwrap(),
+    );
+    f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    let error = f.manager.commit(&id).await.unwrap_err();
+    assert!(error.to_string().contains("content_ref mismatch"));
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(f.manager.commit(&id).await.unwrap_err());
+    assert!(!f.store.exists(&content_ref(b"abc")).await.unwrap());
+    assert!(!f.store.exists(&content_ref(b"abd")).await.unwrap());
+}
+
+#[tokio::test]
+async fn partial_commit_refuses_then_remaining_parts_can_complete() {
+    let f = fixture();
+    let id = begin(&f.manager, 6).await;
+    f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    let error = f.manager.commit(&id).await.unwrap_err();
+    assert!(error.to_string().contains("received 3 bytes, expected 6"));
+    assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"abc");
+    f.manager.put_part(&id, 1, b"def".to_vec()).await.unwrap();
+    let reference = content_ref(b"abcdef");
+    assert_eq!(
+        f.manager.commit(&id).await.unwrap(),
+        json!({"content_ref": reference.to_string(), "size": 6})
+    );
+    assert_eq!(
+        f.store.get_bounded_verified(&reference, 6).await.unwrap(),
+        b"abcdef"
+    );
+    assert!(!staged(&f.root, &id).exists());
+}
+
+#[tokio::test]
+async fn part_crossing_declared_size_aborts_without_publishing() {
+    let f = fixture();
+    let id = begin(&f.manager, 3).await;
+    f.manager.put_part(&id, 0, b"ab".to_vec()).await.unwrap();
+    let error = f
+        .manager
+        .put_part(&id, 1, b"cd".to_vec())
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("exceeds declared size"));
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(f.manager.commit(&id).await.unwrap_err());
+    assert!(!f.store.exists(&content_ref(b"abcd")).await.unwrap());
+}
+
+#[tokio::test]
+async fn begin_rejects_above_64_mib_before_creating_staging() {
+    let f = fixture();
+    assert_eq!(MAX_OBJECT_BYTES, 64 * 1024 * 1024);
+    let error = f
+        .manager
+        .begin(MAX_OBJECT_BYTES + 1, None, "uploader:a".into())
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("size exceeds"));
+    assert!(f.manager.records.lock().unwrap().is_empty());
+    assert!(!f.root.join(".uploads").exists());
+    let id = begin(&f.manager, MAX_OBJECT_BYTES).await;
+    assert_eq!(std::fs::metadata(staged(&f.root, &id)).unwrap().len(), 0);
+    f.manager.abort(&id).await.unwrap();
+}
+
+#[tokio::test]
+async fn advertised_part_limit_matches_live_formula_and_parser_accepts_maximum_part() {
+    let f = fixture();
+    let budget =
+        khive_request::MAX_OPS_INPUT_LEN.min(khive_runtime::daemon::MAX_FRAME_BYTES) as u64;
+    assert_eq!(REQUEST_RESERVE, 8192);
+    assert!(budget > REQUEST_RESERVE);
+    let limit = (budget - REQUEST_RESERVE) * 3 / 4;
+    let response = f
+        .manager
+        .begin(limit, None, "uploader:a".into())
+        .await
+        .unwrap();
+    assert_eq!(response["part_limit"], limit);
+    assert_eq!(max_request_part_raw_bytes(), limit);
+    let id = upload_id(&response);
+    let bytes = vec![b'x'; limit as usize];
+    let params = json!({"upload_id": id.to_string(), "index": 0, "bytes": BASE64.encode(&bytes)});
+    let ops = serde_json::to_string(&json!({"tool": "blob.put_part", "args": params})).unwrap();
+    assert!(ops.len() <= khive_request::MAX_OPS_INPUT_LEN);
+    let parsed = khive_request::parse_request(&ops).unwrap();
+    assert_eq!(parsed.ops.len(), 1);
+    assert_eq!(parsed.ops[0].tool, "blob.put_part");
+    assert!(
+        serde_json::to_vec(&json!({"ops": ops, "actor_id": "uploader:a", "namespace": "local"}))
+            .unwrap()
+            .len()
+            <= khive_runtime::daemon::MAX_FRAME_BYTES
+    );
+    let decoded = Value::Object(
+        parsed.ops[0]
+            .args
+            .iter()
+            .map(|(name, argument)| (name.clone(), argument.as_value().unwrap().clone()))
+            .collect(),
+    );
+    assert_eq!(
+        handle_put_part(&f.manager, decoded).await.unwrap(),
+        json!({"next_index": 1, "received_bytes": limit})
+    );
+    assert_eq!(
+        f.manager.commit(&id).await.unwrap()["content_ref"],
+        content_ref(&bytes).to_string()
+    );
+}
+
+#[tokio::test]
+async fn part_limit_plus_one_is_rejected_on_decoded_length_without_aborting() {
+    let f = fixture();
+    let limit = max_request_part_raw_bytes();
+    let id = begin(&f.manager, limit + 1).await;
+    let params = json!({"upload_id": id.to_string(), "index": 0, "bytes": BASE64.encode(vec![b'x'; limit as usize + 1])});
+    let error = handle_put_part(&f.manager, params).await.unwrap_err();
+    assert!(
+        error.to_string().contains(&format!(
+            "decoded length {} exceeds part_limit {limit}",
+            limit + 1
+        )),
+        "{error}"
+    );
+    assert_eq!(std::fs::metadata(staged(&f.root, &id)).unwrap().len(), 0);
+    let entry = f.manager.record(&id).unwrap();
+    let record = entry.lock().await;
+    assert_eq!(record.received_bytes, 0);
+    assert_eq!(record.next_index, 0);
+    assert!(record.phase == UploadPhase::Active);
+    drop(record);
+    f.manager.abort(&id).await.unwrap();
+}
+
+fn parsed_part_params(id: &UploadId, index: u64, bytes: &[u8]) -> Value {
+    let params =
+        json!({"upload_id": id.to_string(), "index": index, "bytes": BASE64.encode(bytes)});
+    let ops = serde_json::to_string(&json!({"tool": "blob.put_part", "args": params})).unwrap();
+    assert!(ops.len() < khive_request::MAX_OPS_INPUT_LEN);
+    let parsed = khive_request::parse_request(&ops).unwrap();
+    assert_eq!(parsed.ops.len(), 1);
+    assert_eq!(parsed.ops[0].tool, "blob.put_part");
+    Value::Object(
+        parsed.ops[0]
+            .args
+            .iter()
+            .map(|(name, argument)| (name.clone(), argument.as_value().unwrap().clone()))
+            .collect(),
+    )
+}
+
+#[tokio::test]
+async fn oversized_tail_retry_aborts_for_decoded_and_predecode_limits() {
+    let limit = max_request_part_raw_bytes();
+    for excess in [1, 6] {
+        let f = fixture();
+        let id = begin(&f.manager, limit * 2).await;
+        f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+        let params = parsed_part_params(&id, 0, &vec![b'x'; (limit + excess) as usize]);
+        assert_eq!(
+            params["bytes"].as_str().unwrap().len() as u64 > limit * 4 / 3 + 4,
+            excess == 6
+        );
+        let error = handle_put_part(&f.manager, params).await.unwrap_err();
+        assert!(matches!(error, RuntimeError::InvalidInput(_)), "{error}");
+        assert!(
+            error.to_string().contains(if excess == 1 {
+                "tail retry differs"
+            } else {
+                "base64 input exceeds"
+            }),
+            "{error}"
+        );
+        assert!(!staged(&f.root, &id).exists(), "excess {excess}");
+        assert_unknown(f.manager.commit(&id).await.unwrap_err());
+        assert!(!f.store.exists(&content_ref(b"abc")).await.unwrap());
+    }
+}
+
+#[tokio::test]
+async fn oversized_next_part_crossing_declared_size_aborts_for_both_limits() {
+    let limit = max_request_part_raw_bytes();
+    for excess in [1, 6] {
+        let f = fixture();
+        let id = begin(&f.manager, limit + 6).await;
+        f.manager
+            .put_part(&id, 0, b"prefix".to_vec())
+            .await
+            .unwrap();
+        let params = parsed_part_params(&id, 1, &vec![b'x'; (limit + excess) as usize]);
+        assert_eq!(
+            params["bytes"].as_str().unwrap().len() as u64 > limit * 4 / 3 + 4,
+            excess == 6
+        );
+        let error = handle_put_part(&f.manager, params).await.unwrap_err();
+        assert!(matches!(error, RuntimeError::InvalidInput(_)), "{error}");
+        assert!(
+            error.to_string().contains(if excess == 1 {
+                "exceeds declared size"
+            } else {
+                "base64 input exceeds"
+            }),
+            "{error}"
+        );
+        assert!(!staged(&f.root, &id).exists(), "excess {excess}");
+        assert_unknown(f.manager.commit(&id).await.unwrap_err());
+        assert!(!f.store.exists(&content_ref(b"prefix")).await.unwrap());
+    }
+    for (excess, padding) in [(6, 0), (7, 2), (8, 1)] {
+        let f = fixture();
+        let raw_length = limit + excess;
+        let id = begin(&f.manager, raw_length - 1).await;
+        let params = parsed_part_params(&id, 0, &vec![b'x'; raw_length as usize]);
+        let encoded = params["bytes"].as_str().unwrap();
+        assert!(encoded.len() as u64 > limit * 4 / 3 + 4);
+        assert_eq!(
+            encoded
+                .bytes()
+                .rev()
+                .take_while(|byte| *byte == b'=')
+                .count(),
+            padding
+        );
+        let error = handle_put_part(&f.manager, params).await.unwrap_err();
+        assert!(matches!(error, RuntimeError::InvalidInput(_)), "{error}");
+        assert!(
+            error.to_string().contains("base64 input exceeds"),
+            "{error}"
+        );
+        assert!(
+            !staged(&f.root, &id).exists(),
+            "raw excess {excess}, padding {padding}"
+        );
+        assert_unknown(f.manager.commit(&id).await.unwrap_err());
+    }
+}
+
+#[tokio::test]
+async fn oversized_first_part_within_declared_size_keeps_upload_usable_for_both_limits() {
+    let limit = max_request_part_raw_bytes();
+    for excess in [1, 6] {
+        let f = fixture();
+        let id = begin(&f.manager, limit + 6).await;
+        let params = parsed_part_params(&id, 0, &vec![b'x'; (limit + excess) as usize]);
+        assert_eq!(
+            params["bytes"].as_str().unwrap().len() as u64 > limit * 4 / 3 + 4,
+            excess == 6
+        );
+        let error = handle_put_part(&f.manager, params).await.unwrap_err();
+        assert!(matches!(error, RuntimeError::InvalidInput(_)), "{error}");
+        assert!(
+            error.to_string().contains(if excess == 1 {
+                "decoded length"
+            } else {
+                "base64 input exceeds"
+            }),
+            "{error}"
+        );
+        assert_eq!(std::fs::metadata(staged(&f.root, &id)).unwrap().len(), 0);
+        {
+            let entry = f.manager.record(&id).unwrap();
+            let record = entry.lock().await;
+            assert_eq!(record.received_bytes, 0);
+            assert_eq!(record.next_index, 0);
+            assert_eq!(record.hasher.finalize(), blake3::hash(b""));
+            assert!(record.phase == UploadPhase::Active);
+        }
+        assert_eq!(
+            handle_put_part(&f.manager, parsed_part_params(&id, 0, b"a"))
+                .await
+                .unwrap(),
+            json!({"next_index": 1, "received_bytes": 1})
+        );
+        assert_eq!(
+            handle_put_part(&f.manager, parsed_part_params(&id, 1, b"bc"))
+                .await
+                .unwrap(),
+            json!({"next_index": 2, "received_bytes": 3})
+        );
+        assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"abc");
+        assert_eq!(
+            f.manager.abort(&id).await.unwrap(),
+            json!({"aborted": true})
+        );
+        assert!(!staged(&f.root, &id).exists());
+    }
+    for malformed in ["inner padding", "noncanonical terminal padding bits"] {
+        let f = fixture();
+        let id = begin(&f.manager, 3).await;
+        let mut encoded = BASE64.encode(vec![b'x'; (limit + 7) as usize]);
+        assert!(encoded.len() as u64 > limit * 4 / 3 + 4);
+        if malformed == "inner padding" {
+            encoded.replace_range(4..5, "=");
+        } else {
+            assert!(encoded.ends_with("eA=="));
+            let offset = encoded.len() - 3;
+            encoded.replace_range(offset..offset + 1, "B");
+        }
+        let ops = serde_json::to_string(&json!({
+            "tool": "blob.put_part",
+            "args": {"upload_id": id.to_string(), "index": 0, "bytes": encoded}
+        }))
+        .unwrap();
+        assert!(ops.len() < khive_request::MAX_OPS_INPUT_LEN);
+        let parsed = khive_request::parse_request(&ops).unwrap();
+        let params = Value::Object(
+            parsed.ops[0]
+                .args
+                .iter()
+                .map(|(name, argument)| (name.clone(), argument.as_value().unwrap().clone()))
+                .collect(),
+        );
+        let error = handle_put_part(&f.manager, params).await.unwrap_err();
+        assert!(matches!(error, RuntimeError::InvalidInput(_)), "{error}");
+        assert!(
+            error.to_string().contains("invalid base64"),
+            "{malformed}: {error}"
+        );
+        assert_eq!(std::fs::metadata(staged(&f.root, &id)).unwrap().len(), 0);
+        {
+            let entry = f.manager.record(&id).unwrap();
+            let record = entry.lock().await;
+            assert_eq!(record.received_bytes, 0);
+            assert_eq!(record.next_index, 0);
+            assert_eq!(record.hasher.finalize(), blake3::hash(b""));
+            assert!(record.phase == UploadPhase::Active);
+        }
+        handle_put_part(&f.manager, parsed_part_params(&id, 0, b"a"))
+            .await
+            .unwrap();
+        handle_put_part(&f.manager, parsed_part_params(&id, 1, b"bc"))
+            .await
+            .unwrap();
+        assert_eq!(
+            f.manager.commit(&id).await.unwrap(),
+            json!({"content_ref": content_ref(b"abc").to_string(), "size": 3})
+        );
+        assert!(!staged(&f.root, &id).exists());
+        assert_eq!(
+            f.store
+                .get_bounded_verified(&content_ref(b"abc"), 3)
+                .await
+                .unwrap(),
+            b"abc"
+        );
+    }
+}
+
+#[tokio::test]
+async fn existing_expected_reference_returns_stored_size_without_staging() {
+    let f = fixture();
+    let reference = f.store.put(b"existing".to_vec()).await.unwrap();
+    let result = f
+        .manager
+        .begin(1, Some(reference.clone()), "uploader:a".into())
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        json!({"content_ref": reference.to_string(), "size": 8})
+    );
+    assert!(result.get("upload_id").is_none());
+    assert!(f.manager.records.lock().unwrap().is_empty());
+    assert!(!f.root.join(".uploads").exists());
+}
+
+#[tokio::test]
+async fn abort_removes_staging_and_consumes_capability() {
+    let f = fixture();
+    let id = begin(&f.manager, 3).await;
+    f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    assert_eq!(
+        f.manager.abort(&id).await.unwrap(),
+        json!({"aborted": true})
+    );
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(f.manager.abort(&id).await.unwrap_err());
+    assert_unknown(f.manager.commit(&id).await.unwrap_err());
+}
+
+#[tokio::test]
+async fn verb_expiry_rejects_stale_part_without_a_sweeper() {
+    let f = fixture();
+    let id = begin(&f.manager, 2).await;
+    f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
+    expire_record(&f.manager, &id).await;
+    assert!(staged(&f.root, &id).exists());
+    assert_unknown(f.manager.put_part(&id, 1, b"b".to_vec()).await.unwrap_err());
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(f.manager.commit(&id).await.unwrap_err());
+}
+
+#[tokio::test]
+async fn verb_expiry_rejects_stale_complete_commit_without_a_sweeper() {
+    let f = fixture();
+    let id = begin(&f.manager, 1).await;
+    f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
+    expire_record(&f.manager, &id).await;
+    assert_unknown(f.manager.commit(&id).await.unwrap_err());
+    assert!(!staged(&f.root, &id).exists());
+    assert!(!f.store.exists(&content_ref(b"a")).await.unwrap());
+}
+
+#[tokio::test]
+async fn live_expiry_sweep_removes_staging_without_a_verb_call() {
+    let f = fixture();
+    let id = begin(&f.manager, 2).await;
+    f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
+    expire_record(&f.manager, &id).await;
+    assert_eq!(f.manager.sweep().await.unwrap(), 1);
+    assert!(!staged(&f.root, &id).exists());
+    assert!(!f.manager.records.lock().unwrap().contains_key(&id));
+    assert_eq!(f.manager.sweep().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn restart_orphan_sweep_removes_staging_without_a_live_record() {
+    let f = fixture();
+    let id = begin(&f.manager, 2).await;
+    f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
+    let runtime = f.manager.runtime.clone();
+    drop(f.manager);
+    let restarted = UploadManager {
+        runtime,
+        policy: UploadPolicy {
+            idle_for: IDLE,
+            sweep_interval: Duration::from_secs(600),
+        },
+        records: Mutex::new(HashMap::new()),
+    };
+    assert_unknown(restarted.commit(&id).await.unwrap_err());
+    assert!(staged(&f.root, &id).exists());
+    age_file(&staged(&f.root, &id));
+    assert_eq!(restarted.sweep().await.unwrap(), 1);
+    assert!(!staged(&f.root, &id).exists());
+    let new_id = begin(&restarted, 2).await;
+    assert_ne!(new_id, id);
+    restarted
+        .put_part(&new_id, 0, b"ab".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        restarted.commit(&new_id).await.unwrap()["content_ref"],
+        content_ref(b"ab").to_string()
+    );
+}
+
+#[tokio::test]
+async fn sweep_preserves_fresh_upload_and_committed_object() {
+    let f = fixture();
+    let committed = f.store.put(b"committed".to_vec()).await.unwrap();
+    let id = begin(&f.manager, 2).await;
+    f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
+    assert_eq!(f.manager.sweep().await.unwrap(), 0);
+    assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"a");
+    assert!(f.store.exists(&committed).await.unwrap());
+    f.manager.abort(&id).await.unwrap();
+}
+
+#[tokio::test]
+async fn unconfigured_runtime_refuses_every_upload_operation() {
+    let manager = UploadManager::new(KhiveRuntime::memory().unwrap());
+    let id = UploadId::from_bytes(&[0; 16]);
+    for result in [
+        manager.begin(0, None, "uploader:a".into()).await,
+        manager.put_part(&id, 0, Vec::new()).await,
+        manager.commit(&id).await,
+        manager.abort(&id).await,
+        manager.sweep().await.map(Value::from),
+    ] {
+        let error = result.unwrap_err();
+        assert!(matches!(error, RuntimeError::Unconfigured(_)), "{error}");
+    }
+    assert!(manager.records.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn read_only_runtime_refuses_every_upload_operation_without_mutation() {
+    let f = fixture();
+    let id = begin(&f.manager, 1).await;
+    f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
+    let config = RuntimeConfig {
+        db_path: Some(f._dir.path().join("readonly.db")),
+        packs: vec!["kg".into()],
+        ..RuntimeConfig::no_embeddings()
+    };
+    drop(KhiveRuntime::new(config.clone()).unwrap());
+    let runtime = KhiveRuntime::new_readonly(config).unwrap();
+    assert!(runtime.is_read_only());
+    let mut readonly = manager_with_store(runtime, f.store.clone());
+    readonly
+        .records
+        .get_mut()
+        .unwrap()
+        .insert(id.clone(), f.manager.record(&id).unwrap());
+    for result in [
+        readonly.begin(0, None, "uploader:a".into()).await,
+        readonly.put_part(&id, 0, b"a".to_vec()).await,
+        readonly.commit(&id).await,
+        readonly.abort(&id).await,
+        readonly.sweep().await.map(Value::from),
+    ] {
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("read-only"), "{error}");
+    }
+    assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"a");
+    assert!(readonly.records.lock().unwrap().contains_key(&id));
+    assert!(!f.store.exists(&content_ref(b"a")).await.unwrap());
+    f.manager.abort(&id).await.unwrap();
+}
+
+#[derive(Debug)]
+struct ControlledStore {
+    inner: Arc<FsBlobStore>,
+    abort_failures: AtomicUsize,
+    abort_calls: AtomicUsize,
+    pause_after_append: AtomicBool,
+    fail_after_append: AtomicBool,
+    wrong_append_length: AtomicBool,
+    appended: tokio::sync::Notify,
+}
+
+impl ControlledStore {
+    fn new(inner: Arc<FsBlobStore>) -> Self {
+        Self {
+            inner,
+            abort_failures: AtomicUsize::new(0),
+            abort_calls: AtomicUsize::new(0),
+            pause_after_append: AtomicBool::new(false),
+            fail_after_append: AtomicBool::new(false),
+            wrong_append_length: AtomicBool::new(false),
+            appended: tokio::sync::Notify::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl BlobStore for ControlledStore {
+    async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef> {
+        self.inner.put(bytes).await
+    }
+
+    async fn begin_upload(&self, size: u64) -> StorageResult<UploadId> {
+        self.inner.begin_upload(size).await
+    }
+
+    async fn append_part(&self, id: &UploadId, bytes: Vec<u8>) -> StorageResult<u64> {
+        let length = self.inner.append_part(id, bytes).await?;
+        if self.pause_after_append.load(Ordering::SeqCst) {
+            self.appended.notify_one();
+            std::future::pending::<()>().await;
+        }
+        if self.fail_after_append.load(Ordering::SeqCst) {
+            return Err(StorageError::Internal(
+                "injected append failure after write".into(),
+            ));
+        }
+        Ok(length + u64::from(self.wrong_append_length.load(Ordering::SeqCst)))
+    }
+
+    async fn commit_upload(&self, id: &UploadId, reference: &ContentRef) -> StorageResult<()> {
+        self.inner.commit_upload(id, reference).await
+    }
+
+    async fn abort_upload(&self, id: &UploadId) -> StorageResult<()> {
+        self.abort_calls.fetch_add(1, Ordering::SeqCst);
+        if self
+            .abort_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+            .is_ok()
+        {
+            return Err(StorageError::Internal("injected abort failure".into()));
+        }
+        self.inner.abort_upload(id).await
+    }
+
+    async fn sweep_uploads(&self, idle_for: Duration) -> StorageResult<u64> {
+        self.inner.sweep_uploads(idle_for).await
+    }
+
+    async fn get_bounded_verified(
+        &self,
+        reference: &ContentRef,
+        max_bytes: u64,
+    ) -> StorageResult<Vec<u8>> {
+        self.inner.get_bounded_verified(reference, max_bytes).await
+    }
+
+    async fn exists(&self, reference: &ContentRef) -> StorageResult<bool> {
+        self.inner.exists(reference).await
+    }
+
+    async fn size(&self, reference: &ContentRef) -> StorageResult<Option<u64>> {
+        self.inner.size(reference).await
+    }
+
+    async fn delete(&self, reference: &ContentRef) -> StorageResult<bool> {
+        self.inner.delete(reference).await
+    }
+}
+
+#[tokio::test]
+async fn failed_abort_is_retained_and_retried_by_successive_sweeps() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.abort_failures.store(2, Ordering::SeqCst);
+    let manager = manager_with_store(KhiveRuntime::memory().unwrap(), store.clone());
+    let id = begin(&manager, 1).await;
+    assert!(manager
+        .abort(&id)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("injected abort failure"));
+    assert!(manager.record(&id).unwrap().lock().await.phase == UploadPhase::Aborted);
+    assert!(staged(&f.root, &id).exists());
+    assert!(manager
+        .sweep()
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("injected abort failure"));
+    assert!(manager.records.lock().unwrap().contains_key(&id));
+    assert!(staged(&f.root, &id).exists());
+    assert_eq!(manager.sweep().await.unwrap(), 1);
+    assert_eq!(store.abort_calls.load(Ordering::SeqCst), 3);
+    assert!(!manager.records.lock().unwrap().contains_key(&id));
+    assert!(!staged(&f.root, &id).exists());
+}
+
+#[tokio::test]
+async fn failed_error_cleanup_retains_aborted_upload_until_sweep_retries() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.abort_failures.store(1, Ordering::SeqCst);
+    let manager = manager_with_store(KhiveRuntime::memory().unwrap(), store.clone());
+    let id = begin(&manager, 3).await;
+    manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    let error = manager.put_part(&id, 0, b"abd".to_vec()).await.unwrap_err();
+    assert!(error.to_string().contains("tail retry differs"));
+    assert!(manager.record(&id).unwrap().lock().await.phase == UploadPhase::Aborted);
+    assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"abc");
+    assert_eq!(manager.sweep().await.unwrap(), 1);
+    assert_eq!(store.abort_calls.load(Ordering::SeqCst), 2);
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(manager.commit(&id).await.unwrap_err());
+}
+
+#[tokio::test]
+async fn append_failure_after_real_write_aborts_and_never_acknowledges() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.fail_after_append.store(true, Ordering::SeqCst);
+    let manager = manager_with_store(KhiveRuntime::memory().unwrap(), store);
+    let id = begin(&manager, 3).await;
+    let error = manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("injected append failure after write"));
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(manager.commit(&id).await.unwrap_err());
+    assert!(!f.store.exists(&content_ref(b"abc")).await.unwrap());
+}
+
+#[tokio::test]
+async fn inconsistent_backend_length_aborts_and_never_acknowledges() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.wrong_append_length.store(true, Ordering::SeqCst);
+    let manager = manager_with_store(KhiveRuntime::memory().unwrap(), store);
+    let id = begin(&manager, 3).await;
+    let error = manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap_err();
+    assert!(error.to_string().contains("staged upload length differs"));
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(manager.commit(&id).await.unwrap_err());
+}
+
+#[tokio::test]
+async fn cancelled_append_never_acknowledges_inconsistent_staged_bytes() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.pause_after_append.store(true, Ordering::SeqCst);
+    let manager = Arc::new(manager_with_store(
+        KhiveRuntime::memory().unwrap(),
+        store.clone(),
+    ));
+    let id = begin(&manager, 6).await;
+    let task = tokio::spawn({
+        let manager = manager.clone();
+        let id = id.clone();
+        async move { manager.put_part(&id, 0, b"abc".to_vec()).await }
+    });
+    tokio::time::timeout(Duration::from_secs(10), store.appended.notified())
+        .await
+        .unwrap();
+    assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"abc");
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    {
+        let entry = manager.record(&id).unwrap();
+        let record = entry.lock().await;
+        assert!(record.phase == UploadPhase::InFlight);
+        assert_eq!(record.received_bytes, 0);
+        assert_eq!(record.next_index, 0);
+        assert_eq!(record.hasher.finalize(), blake3::hash(b""));
+    }
+    store.pause_after_append.store(false, Ordering::SeqCst);
+    assert_unknown(manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap_err());
+    assert!(!staged(&f.root, &id).exists());
+    assert_unknown(manager.commit(&id).await.unwrap_err());
+    assert!(!f.store.exists(&content_ref(b"abcabc")).await.unwrap());
+}
+
+#[tokio::test]
+async fn independent_capabilities_allow_cross_actor_append_commit_and_abort() {
+    let f = fixture();
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(BlobPack::new(f.manager.runtime.clone()));
+    let registry = builder.build().unwrap();
+    let actor_a = RequestIdentity {
+        namespace: "local".into(),
+        actor_id: Some("uploader:a".into()),
+        ..Default::default()
+    };
+    let actor_b = RequestIdentity {
+        namespace: "other".into(),
+        actor_id: Some("uploader:b".into()),
+        ..Default::default()
+    };
+    let first = registry
+        .dispatch_with_identity("blob.begin", json!({"size": 3}), Some(actor_a.clone()))
+        .await
+        .unwrap();
+    let second = registry
+        .dispatch_with_identity("blob.begin", json!({"size": 3}), Some(actor_b.clone()))
+        .await
+        .unwrap();
+    let first_id = upload_id(&first);
+    let second_id = upload_id(&second);
+    assert_ne!(first_id, second_id);
+    registry
+        .dispatch_with_identity(
+            "blob.put_part",
+            json!({"upload_id": first_id.to_string(), "index": 0, "bytes": BASE64.encode(b"abc")}),
+            Some(actor_b.clone()),
+        )
+        .await
+        .unwrap();
+    registry
+        .dispatch_with_identity(
+            "blob.put_part",
+            json!({"upload_id": second_id.to_string(), "index": 0, "bytes": BASE64.encode(b"def")}),
+            Some(actor_a.clone()),
+        )
+        .await
+        .unwrap();
+    registry
+        .dispatch_with_identity(
+            "blob.abort",
+            json!({"upload_id": second_id.to_string()}),
+            Some(actor_a),
+        )
+        .await
+        .unwrap();
+    assert!(!staged(&f.root, &second_id).exists());
+    assert_eq!(std::fs::read(staged(&f.root, &first_id)).unwrap(), b"abc");
+    let result = registry
+        .dispatch_with_identity(
+            "blob.commit",
+            json!({"upload_id": first_id.to_string()}),
+            Some(actor_b),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result["content_ref"], content_ref(b"abc").to_string());
+    assert!(!f.store.exists(&content_ref(b"def")).await.unwrap());
+}
+
+#[tokio::test]
+async fn transactional_gc_preserves_committed_and_staging_then_upload_sweep_only_reaps_staging() {
+    let f = fixture();
+    let backend = khive_db::StorageBackend::sqlite(f._dir.path().join("gc.db")).unwrap();
+    {
+        let mut writer = backend.pool().writer().unwrap();
+        let conn = writer.conn_mut();
+        conn.execute_batch(include_str!(
+            "../../../khive-db/sql/schema-migrations-table.sql"
+        ))
+        .unwrap();
+        for migration in khive_db::MIGRATIONS
+            .iter()
+            .filter(|migration| migration.version <= 20)
+        {
+            let tx = conn.transaction().unwrap();
+            tx.execute_batch(migration.up).unwrap();
+            tx.execute(
+                "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, 0)",
+                (migration.version, migration.name),
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        khive_db::migrations::stage_attachment_cutover(conn).unwrap();
+        khive_db::migrations::finalize_attachment_cutover(conn).unwrap();
+        assert_eq!(
+            khive_db::migrations::read_schema_version(conn).unwrap(),
+            khive_db::migrations::ATTACHMENT_CUTOVER_VERSION
+        );
+    }
+    let reference = f.store.put(b"committed control".to_vec()).await.unwrap();
+    {
+        let writer = backend.pool().writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(
+                "INSERT INTO entities \
+                 (id, namespace, kind, name, tags, created_at, updated_at, deleted_at) \
+                 VALUES ('11111111-1111-4111-8111-111111111111', 'local', 'document', \
+                         'live blob control', '[]', 1, 1, NULL);",
+            )
+            .unwrap();
+        writer
+            .conn()
+            .execute(
+                "INSERT INTO attachments \
+                 (record_uuid, substrate, role, content_ref, created_at) \
+                 VALUES ('11111111-1111-4111-8111-111111111111', \
+                         'entity', 'content', ?1, 1)",
+                [reference.as_str()],
+            )
+            .unwrap();
+    }
+    let committed_path = f
+        .root
+        .join(&reference.as_str()[..2])
+        .join(&reference.as_str()[2..4])
+        .join(reference.as_str());
+    age_file(&committed_path);
+    assert!(
+        std::fs::metadata(&committed_path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .elapsed()
+            .unwrap()
+            > FsBlobStore::DEFAULT_ORPHAN_SWEEP_GRACE
+    );
+    let id = begin(&f.manager, 3).await;
+    f.manager.put_part(&id, 0, b"abc".to_vec()).await.unwrap();
+    let result = f
+        .store
+        .transactional_orphan_sweep(backend.sql().as_ref(), false)
+        .await
+        .unwrap();
+    assert_eq!(result.scanned, 1);
+    assert_eq!(result.deleted, 0);
+    assert_eq!(result.would_delete, 0);
+    assert_eq!(result.grace_period_skipped, 0);
+    assert_eq!(std::fs::read(staged(&f.root, &id)).unwrap(), b"abc");
+    assert!(f.store.exists(&reference).await.unwrap());
+    expire_record(&f.manager, &id).await;
+    assert_eq!(f.manager.sweep().await.unwrap(), 1);
+    assert!(!staged(&f.root, &id).exists());
+    assert_eq!(
+        f.store.get_bounded_verified(&reference, 32).await.unwrap(),
+        b"committed control"
+    );
+}

--- a/crates/khive-pack-blob/src/uploads/tests.rs
+++ b/crates/khive-pack-blob/src/uploads/tests.rs
@@ -42,14 +42,14 @@ struct Fixture {
 
 fn manager_with_store(runtime: KhiveRuntime, store: Arc<dyn BlobStore>) -> UploadManager {
     runtime.install_blob_store(store).unwrap();
-    UploadManager {
-        runtime,
-        policy: UploadPolicy {
-            idle_for: IDLE,
-            sweep_interval: Duration::from_secs(600),
-        },
-        records: Mutex::new(HashMap::new()),
-    }
+    let mut manager = UploadManager::new(runtime);
+    manager.policy = UploadPolicy {
+        idle_for: IDLE,
+        sweep_interval: Duration::from_secs(600),
+        max_active: 128,
+        max_per_actor: 16,
+    };
+    manager
 }
 
 fn fixture() -> Fixture {
@@ -103,6 +103,352 @@ fn age_file(path: &Path) {
         .unwrap()
         .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1))
         .unwrap();
+}
+
+fn assert_upload_ceiling(error: RuntimeError, ceiling: &str, limit: usize) {
+    match error {
+        RuntimeError::InvalidInput(message) => assert_eq!(
+            message,
+            format!("blob.begin: {ceiling} active-upload ceiling of {limit} reached")
+        ),
+        other => panic!("expected named InvalidInput upload ceiling, got {other}"),
+    }
+}
+
+#[test]
+fn upload_ceiling_parser_accepts_positive_usize_and_rejects_invalid_values() {
+    assert_eq!(UploadPolicy::positive_limit("1"), Some(1));
+    assert_eq!(UploadPolicy::positive_limit("128"), Some(128));
+    assert_eq!(
+        UploadPolicy::positive_limit(&usize::MAX.to_string()),
+        Some(usize::MAX)
+    );
+    for invalid in ["", "0", "-1", "1.5", " 16", "sixteen"] {
+        assert_eq!(UploadPolicy::positive_limit(invalid), None, "{invalid:?}");
+    }
+    assert_eq!(
+        UploadPolicy::positive_limit(&format!("{}0", usize::MAX)),
+        None
+    );
+}
+
+#[tokio::test]
+async fn total_active_upload_ceiling_refuses_before_staging_and_abort_restores_slot() {
+    let mut f = fixture();
+    f.manager.policy.max_active = 2;
+    f.manager.policy.max_per_actor = 3;
+    let first = begin(&f.manager, 0).await;
+    let second = begin(&f.manager, 0).await;
+    assert_upload_ceiling(
+        f.manager
+            .begin(0, None, "uploader:b".into())
+            .await
+            .unwrap_err(),
+        "total",
+        2,
+    );
+    assert_eq!(
+        std::fs::read_dir(f.root.join(".uploads")).unwrap().count(),
+        2
+    );
+    let retained_record = f.manager.record(&first).unwrap();
+    f.manager.abort(&first).await.unwrap();
+    assert!(!staged(&f.root, &first).exists());
+    let replacement = upload_id(&f.manager.begin(0, None, "uploader:b".into()).await.unwrap());
+    assert!(retained_record.lock().await.slot.is_none());
+    assert_ne!(replacement, first);
+    assert!(staged(&f.root, &second).exists());
+    f.manager.abort(&second).await.unwrap();
+    f.manager.abort(&replacement).await.unwrap();
+}
+
+#[tokio::test]
+async fn per_actor_upload_ceiling_isolated_and_abort_releases_originating_actor_slot() {
+    let mut f = fixture();
+    f.manager.policy.max_active = 4;
+    f.manager.policy.max_per_actor = 1;
+    let first = begin(&f.manager, 0).await;
+    assert_upload_ceiling(
+        f.manager
+            .begin(0, None, "uploader:a".into())
+            .await
+            .unwrap_err(),
+        "per-actor",
+        1,
+    );
+    let other = upload_id(&f.manager.begin(0, None, "uploader:b".into()).await.unwrap());
+    crate::handlers::handle_abort(&f.manager, json!({"upload_id": first.to_string()}))
+        .await
+        .unwrap();
+    let replacement = begin(&f.manager, 0).await;
+    assert_upload_ceiling(
+        f.manager
+            .begin(0, None, "uploader:b".into())
+            .await
+            .unwrap_err(),
+        "per-actor",
+        1,
+    );
+    assert!(staged(&f.root, &other).exists());
+    f.manager.abort(&other).await.unwrap();
+    f.manager.abort(&replacement).await.unwrap();
+}
+
+#[tokio::test]
+async fn committed_upload_releases_total_and_actor_slots() {
+    let mut f = fixture();
+    f.manager.policy.max_active = 1;
+    f.manager.policy.max_per_actor = 1;
+    let id = begin(&f.manager, 1).await;
+    f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
+    let retained_record = f.manager.record(&id).unwrap();
+    f.manager.commit(&id).await.unwrap();
+    assert!(!staged(&f.root, &id).exists());
+    assert!(f.store.exists(&content_ref(b"a")).await.unwrap());
+    let replacement = begin(&f.manager, 0).await;
+    assert!(retained_record.lock().await.slot.is_none());
+    f.manager.abort(&replacement).await.unwrap();
+}
+
+#[tokio::test]
+async fn known_reference_bypasses_full_upload_ceilings_without_reserving_slot() {
+    let mut f = fixture();
+    f.manager.policy.max_active = 1;
+    f.manager.policy.max_per_actor = 1;
+    let id = begin(&f.manager, 0).await;
+    let reference = f.store.put(b"known".to_vec()).await.unwrap();
+    for actor in ["uploader:a", "uploader:b"] {
+        let result = f
+            .manager
+            .begin(0, Some(reference.clone()), actor.into())
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            json!({"content_ref": reference.to_string(), "size": 5})
+        );
+        assert!(result.get("upload_id").is_none());
+    }
+    assert_eq!(f.manager.records.lock().unwrap().len(), 1);
+    assert_eq!(
+        std::fs::read_dir(f.root.join(".uploads")).unwrap().count(),
+        1
+    );
+    assert_upload_ceiling(
+        f.manager
+            .begin(0, None, "uploader:b".into())
+            .await
+            .unwrap_err(),
+        "total",
+        1,
+    );
+    f.manager.abort(&id).await.unwrap();
+    let replacement = begin(&f.manager, 0).await;
+    f.manager.abort(&replacement).await.unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_begins_reserve_total_and_actor_slots_before_backend_returns() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.pause_after_begin.store(true, Ordering::SeqCst);
+    let mut manager = manager_with_store(KhiveRuntime::memory().unwrap(), store.clone());
+    manager.policy.max_active = 2;
+    manager.policy.max_per_actor = 1;
+    let manager = Arc::new(manager);
+    let first = tokio::spawn({
+        let manager = manager.clone();
+        async move { manager.begin(0, None, "uploader:a".into()).await }
+    });
+    tokio::time::timeout(Duration::from_secs(10), store.begun.notified())
+        .await
+        .unwrap();
+    assert!(manager.records.lock().unwrap().is_empty());
+    assert_upload_ceiling(
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            manager.begin(0, None, "uploader:a".into()),
+        )
+        .await
+        .unwrap()
+        .unwrap_err(),
+        "per-actor",
+        1,
+    );
+    let second = tokio::spawn({
+        let manager = manager.clone();
+        async move { manager.begin(0, None, "uploader:b".into()).await }
+    });
+    tokio::time::timeout(Duration::from_secs(10), store.begun.notified())
+        .await
+        .unwrap();
+    assert!(manager.records.lock().unwrap().is_empty());
+    assert_eq!(store.begin_calls.load(Ordering::SeqCst), 2);
+    assert_upload_ceiling(
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            manager.begin(0, None, "uploader:c".into()),
+        )
+        .await
+        .unwrap()
+        .unwrap_err(),
+        "total",
+        2,
+    );
+    assert_eq!(store.begin_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        std::fs::read_dir(f.root.join(".uploads")).unwrap().count(),
+        2
+    );
+    store.pause_after_begin.store(false, Ordering::SeqCst);
+    store.release_begin.notify_waiters();
+    let first_id = upload_id(
+        &tokio::time::timeout(Duration::from_secs(10), first)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap(),
+    );
+    let second_id = upload_id(
+        &tokio::time::timeout(Duration::from_secs(10), second)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap(),
+    );
+    assert_ne!(first_id, second_id);
+    assert_eq!(manager.records.lock().unwrap().len(), 2);
+    manager.abort(&first_id).await.unwrap();
+    manager.abort(&second_id).await.unwrap();
+}
+
+#[tokio::test]
+async fn failed_backend_begin_releases_total_and_actor_reservation() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.begin_failures.store(1, Ordering::SeqCst);
+    let mut manager = manager_with_store(KhiveRuntime::memory().unwrap(), store.clone());
+    manager.policy.max_active = 1;
+    manager.policy.max_per_actor = 1;
+    let error = manager
+        .begin(0, None, "uploader:a".into())
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("injected begin failure"));
+    assert!(manager.records.lock().unwrap().is_empty());
+    assert!(!f.root.join(".uploads").exists());
+    let id = begin(&manager, 0).await;
+    assert_eq!(store.begin_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        store.begun_ids.lock().unwrap().as_slice(),
+        std::slice::from_ref(&id)
+    );
+    manager.abort(&id).await.unwrap();
+}
+
+#[tokio::test]
+async fn failed_cleanup_retains_upload_slots_until_sweep_succeeds() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.abort_failures.store(2, Ordering::SeqCst);
+    let mut manager = manager_with_store(KhiveRuntime::memory().unwrap(), store.clone());
+    manager.policy.max_active = 2;
+    manager.policy.max_per_actor = 1;
+    let id = begin(&manager, 0).await;
+    assert!(manager.abort(&id).await.is_err());
+    assert_upload_ceiling(
+        manager
+            .begin(0, None, "uploader:a".into())
+            .await
+            .unwrap_err(),
+        "per-actor",
+        1,
+    );
+    let other = upload_id(&manager.begin(0, None, "uploader:b".into()).await.unwrap());
+    assert_upload_ceiling(
+        manager
+            .begin(0, None, "uploader:c".into())
+            .await
+            .unwrap_err(),
+        "total",
+        2,
+    );
+    assert!(manager.sweep().await.is_err());
+    assert!(staged(&f.root, &id).exists());
+    assert_upload_ceiling(
+        manager
+            .begin(0, None, "uploader:a".into())
+            .await
+            .unwrap_err(),
+        "total",
+        2,
+    );
+    assert_eq!(manager.sweep().await.unwrap(), 1);
+    assert_eq!(store.abort_calls.load(Ordering::SeqCst), 3);
+    assert!(!staged(&f.root, &id).exists());
+    assert!(staged(&f.root, &other).exists());
+    let replacement = begin(&manager, 0).await;
+    manager.abort(&other).await.unwrap();
+    manager.abort(&replacement).await.unwrap();
+}
+
+#[tokio::test]
+async fn cancelled_begin_keeps_reservation_and_staging_until_expiry_cleanup() {
+    let f = fixture();
+    let store = Arc::new(ControlledStore::new(f.store.clone()));
+    store.pause_after_begin.store(true, Ordering::SeqCst);
+    let mut manager = manager_with_store(KhiveRuntime::memory().unwrap(), store.clone());
+    manager.policy.max_active = 1;
+    manager.policy.max_per_actor = 1;
+    let manager = Arc::new(manager);
+    let request = tokio::spawn({
+        let manager = manager.clone();
+        async move { manager.begin(0, None, "uploader:a".into()).await }
+    });
+    tokio::time::timeout(Duration::from_secs(10), store.begun.notified())
+        .await
+        .unwrap();
+    let id = store.begun_ids.lock().unwrap()[0].clone();
+    assert!(staged(&f.root, &id).exists());
+    assert!(manager.records.lock().unwrap().is_empty());
+    request.abort();
+    assert!(request.await.unwrap_err().is_cancelled());
+    assert_upload_ceiling(
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            manager.begin(0, None, "uploader:b".into()),
+        )
+        .await
+        .unwrap()
+        .unwrap_err(),
+        "total",
+        1,
+    );
+    store.pause_after_begin.store(false, Ordering::SeqCst);
+    store.release_begin.notify_one();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if manager.records.lock().unwrap().contains_key(&id) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_upload_ceiling(
+        manager
+            .begin(0, None, "uploader:a".into())
+            .await
+            .unwrap_err(),
+        "total",
+        1,
+    );
+    expire_record(&manager, &id).await;
+    assert_eq!(manager.sweep().await.unwrap(), 1);
+    assert!(!staged(&f.root, &id).exists());
+    let replacement = begin(&manager, 0).await;
+    manager.abort(&replacement).await.unwrap();
 }
 
 #[tokio::test]
@@ -651,13 +997,12 @@ async fn restart_orphan_sweep_removes_staging_without_a_live_record() {
     f.manager.put_part(&id, 0, b"a".to_vec()).await.unwrap();
     let runtime = f.manager.runtime.clone();
     drop(f.manager);
-    let restarted = UploadManager {
-        runtime,
-        policy: UploadPolicy {
-            idle_for: IDLE,
-            sweep_interval: Duration::from_secs(600),
-        },
-        records: Mutex::new(HashMap::new()),
+    let mut restarted = UploadManager::new(runtime);
+    restarted.policy = UploadPolicy {
+        idle_for: IDLE,
+        sweep_interval: Duration::from_secs(600),
+        max_active: 128,
+        max_per_actor: 16,
     };
     assert_unknown(restarted.commit(&id).await.unwrap_err());
     assert!(staged(&f.root, &id).exists());
@@ -738,10 +1083,10 @@ async fn read_only_runtime_refuses_every_upload_operation_without_mutation() {
     settled.close().unwrap();
     let runtime = KhiveRuntime::new_readonly(config).unwrap();
     assert!(runtime.is_read_only());
-    let mut readonly = manager_with_store(runtime, f.store.clone());
+    let readonly = manager_with_store(runtime, f.store.clone());
     readonly
         .records
-        .get_mut()
+        .lock()
         .unwrap()
         .insert(id.clone(), f.manager.record(&id).unwrap());
     for result in [
@@ -763,6 +1108,12 @@ async fn read_only_runtime_refuses_every_upload_operation_without_mutation() {
 #[derive(Debug)]
 struct ControlledStore {
     inner: Arc<FsBlobStore>,
+    begin_calls: AtomicUsize,
+    begin_failures: AtomicUsize,
+    pause_after_begin: AtomicBool,
+    begun_ids: Mutex<Vec<UploadId>>,
+    begun: tokio::sync::Notify,
+    release_begin: tokio::sync::Notify,
     abort_failures: AtomicUsize,
     abort_calls: AtomicUsize,
     pause_after_append: AtomicBool,
@@ -775,6 +1126,12 @@ impl ControlledStore {
     fn new(inner: Arc<FsBlobStore>) -> Self {
         Self {
             inner,
+            begin_calls: AtomicUsize::new(0),
+            begin_failures: AtomicUsize::new(0),
+            pause_after_begin: AtomicBool::new(false),
+            begun_ids: Mutex::new(Vec::new()),
+            begun: tokio::sync::Notify::new(),
+            release_begin: tokio::sync::Notify::new(),
             abort_failures: AtomicUsize::new(0),
             abort_calls: AtomicUsize::new(0),
             pause_after_append: AtomicBool::new(false),
@@ -792,7 +1149,21 @@ impl BlobStore for ControlledStore {
     }
 
     async fn begin_upload(&self, size: u64) -> StorageResult<UploadId> {
-        self.inner.begin_upload(size).await
+        self.begin_calls.fetch_add(1, Ordering::SeqCst);
+        if self
+            .begin_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+            .is_ok()
+        {
+            return Err(StorageError::Internal("injected begin failure".into()));
+        }
+        let id = self.inner.begin_upload(size).await?;
+        self.begun_ids.lock().unwrap().push(id.clone());
+        if self.pause_after_begin.load(Ordering::SeqCst) {
+            self.begun.notify_one();
+            self.release_begin.notified().await;
+        }
+        Ok(id)
     }
 
     async fn append_part(&self, id: &UploadId, bytes: Vec<u8>) -> StorageResult<u64> {

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -13,7 +13,7 @@ use khive_db::stores::blob_s3::{S3BlobStore, S3BlobStoreConfig};
 use khive_db::{SqliteError, StorageBackend};
 use khive_storage::{
     BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, SqlAccess,
-    StorageCapability, StorageError, StorageResult,
+    StorageCapability, StorageError, StorageResult, UploadId,
 };
 
 use crate::engine_config::BlobConfig;
@@ -427,6 +427,26 @@ impl BlobStore for ReadOnlyBlobStore {
         Err(Self::mutation_error("put"))
     }
 
+    async fn begin_upload(&self, _declared_size: u64) -> StorageResult<UploadId> {
+        Err(Self::mutation_error("begin_upload"))
+    }
+
+    async fn append_part(&self, _id: &UploadId, _bytes: Vec<u8>) -> StorageResult<u64> {
+        Err(Self::mutation_error("append_part"))
+    }
+
+    async fn commit_upload(&self, _id: &UploadId, _content_ref: &ContentRef) -> StorageResult<()> {
+        Err(Self::mutation_error("commit_upload"))
+    }
+
+    async fn abort_upload(&self, _id: &UploadId) -> StorageResult<()> {
+        Err(Self::mutation_error("abort_upload"))
+    }
+
+    async fn sweep_uploads(&self, _idle_for: std::time::Duration) -> StorageResult<u64> {
+        Err(Self::mutation_error("sweep_uploads"))
+    }
+
     async fn get_bounded_verified(
         &self,
         content_ref: &ContentRef,
@@ -470,6 +490,53 @@ mod tests {
     use super::*;
     use crate::engine_config::StorageSectionConfig;
     use serial_test::serial;
+
+    #[tokio::test]
+    async fn read_only_upload_methods_refuse_without_mutating_staging() {
+        let dir = tempfile::tempdir().unwrap();
+        let inner = Arc::new(
+            khive_db::stores::blob::FsBlobStore::new(dir.path().join("blobs"), 0).unwrap(),
+        );
+        let id = inner.begin_upload(1).await.unwrap();
+        let reference = ContentRef::from_hex("a".repeat(64)).unwrap();
+        let guarded = ReadOnlyBlobStore {
+            inner: inner.clone(),
+        };
+        let failures = [
+            guarded.begin_upload(1).await.map(|_| ()),
+            guarded.append_part(&id, vec![1]).await.map(|_| ()),
+            guarded.commit_upload(&id, &reference).await,
+            guarded.abort_upload(&id).await,
+            guarded
+                .sweep_uploads(std::time::Duration::ZERO)
+                .await
+                .map(|_| ()),
+        ];
+        for (result, expected) in failures.into_iter().zip([
+            "begin_upload",
+            "append_part",
+            "commit_upload",
+            "abort_upload",
+            "sweep_uploads",
+        ]) {
+            let StorageError::Unsupported {
+                operation, message, ..
+            } = result.unwrap_err()
+            else {
+                panic!("expected read-only refusal")
+            };
+            assert_eq!(operation, expected);
+            assert!(message.contains("read-only"));
+        }
+        let uploads = inner.root().join(".uploads");
+        assert_eq!(std::fs::read_dir(&uploads).unwrap().count(), 1);
+        assert_eq!(
+            std::fs::metadata(uploads.join(id.as_str())).unwrap().len(),
+            0
+        );
+        assert!(!inner.exists(&reference).await.unwrap());
+        inner.abort_upload(&id).await.unwrap();
+    }
 
     #[derive(Debug, Default)]
     struct RecordingReadStore {

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -10,6 +10,7 @@
 //! `PackRuntime` mirrors `Pack`'s const associated items as methods for object safety.
 //! Build a [`VerbRegistry`] via `VerbRegistryBuilder::build()`; registration is builder-only.
 
+use std::any::Any;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
@@ -226,6 +227,13 @@ use crate::KhiveRuntime;
 pub trait PackRuntime: Send + Sync {
     /// Pack name — must equal `<Self as Pack>::NAME`.
     fn name(&self) -> &str;
+
+    /// Optional instance-owned state for host work outside verb dispatch.
+    /// Return the same shared state used by this pack's handlers. The host
+    /// owns task startup and shutdown; this accessor must not start work.
+    fn host_state(&self) -> Option<Arc<dyn Any + Send + Sync>> {
+        None
+    }
 
     /// Validate this pack instance's configuration before it can execute.
     /// Metadata-only construction does not activate packs.
@@ -3426,6 +3434,17 @@ impl VerbRegistry {
         self.packs.iter().map(|p| p.name()).collect()
     }
 
+    /// Borrow a registered pack's shared host state without reconstructing
+    /// that pack. Missing packs, absent state, and type mismatches return None.
+    pub fn pack_host_state<T: Any + Send + Sync>(&self, name: &str) -> Option<Arc<T>> {
+        self.packs
+            .iter()
+            .find(|pack| pack.name() == name)?
+            .host_state()?
+            .downcast::<T>()
+            .ok()
+    }
+
     /// Declared dependencies for a registered pack.
     pub fn pack_requires(&self, name: &str) -> Option<&'static [&'static str]> {
         self.packs
@@ -4808,6 +4827,69 @@ pub(crate) mod tests {
 
     mod disposition {
         include!("pack_disposition_tests.rs");
+    }
+
+    #[tokio::test]
+    async fn pack_host_state_shares_the_registered_dispatch_instance_across_clones() {
+        struct HostStatePack(Arc<AtomicUsize>);
+
+        #[async_trait]
+        impl PackRuntime for HostStatePack {
+            fn name(&self) -> &str {
+                "host_state"
+            }
+            fn host_state(&self) -> Option<Arc<dyn Any + Send + Sync>> {
+                Some(self.0.clone())
+            }
+            fn note_kinds(&self) -> &'static [&'static str] {
+                &[]
+            }
+            fn entity_kinds(&self) -> &'static [&'static str] {
+                &[]
+            }
+            fn handlers(&self) -> &'static [HandlerDef] {
+                &[HandlerDef {
+                    name: "host_state.touch",
+                    description: "shared state fixture",
+                    visibility: Visibility::Verb,
+                    category: VerbCategory::Commissive,
+                    params: &[],
+                }]
+            }
+            async fn dispatch(
+                &self,
+                _verb: &str,
+                _params: Value,
+                _registry: &VerbRegistry,
+                _token: &NamespaceToken,
+            ) -> Result<Value, RuntimeError> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(Value::Null)
+            }
+        }
+
+        let state = Arc::new(AtomicUsize::new(0));
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register_boxed(Box::new(HostStatePack(state.clone())));
+        builder.register(AlphaPack);
+        let registry = builder.build().expect("registry");
+        let host = registry
+            .pack_host_state::<AtomicUsize>("host_state")
+            .expect("registered state");
+        let cloned_host = registry
+            .clone()
+            .pack_host_state::<AtomicUsize>("host_state")
+            .expect("cloned registry state");
+        assert!(Arc::ptr_eq(&state, &host));
+        assert!(Arc::ptr_eq(&host, &cloned_host));
+        registry
+            .dispatch("host_state.touch", serde_json::json!({}))
+            .await
+            .expect("dispatch");
+        assert_eq!(host.load(Ordering::SeqCst), 1);
+        assert!(registry.pack_host_state::<String>("host_state").is_none());
+        assert!(registry.pack_host_state::<AtomicUsize>("missing").is_none());
+        assert!(registry.pack_host_state::<AtomicUsize>("alpha").is_none());
     }
 
     /// Verbs known, by cross-pack source review (#2147/#2217), to have

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -83,7 +83,7 @@ impl std::fmt::Display for UploadId {
 }
 
 impl<'de> Deserialize<'de> for UploadId {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Self::from_hex(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
     }
 }

--- a/crates/khive-storage/src/blob.rs
+++ b/crates/khive-storage/src/blob.rs
@@ -43,6 +43,51 @@ pub const MAX_BLOB_WHOLE_BYTES: u64 = 64 * 1024 * 1024;
 #[serde(transparent)]
 pub struct ContentRef(String);
 
+/// Opaque capability for a backend's staged upload, encoded as 128-bit hex.
+///
+/// This is not a content reference. The caller owns hashing and upload-session
+/// state; retaining this identifier does not make a session restartable.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct UploadId(String);
+
+impl UploadId {
+    /// Construct an identifier from freshly generated random bytes.
+    pub fn from_bytes(bytes: &[u8; 16]) -> Self {
+        Self(hex_encode(bytes))
+    }
+
+    /// Parse exactly 32 lowercase hex characters, never a backend pathname.
+    pub fn from_hex(value: impl Into<String>) -> Result<Self, String> {
+        let value = value.into();
+        if value.len() != 32
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err("upload_id must be 32 lowercase hex characters".into());
+        }
+        Ok(Self(value))
+    }
+
+    /// Canonical wire spelling.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for UploadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for UploadId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Self::from_hex(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
 impl<'de> Deserialize<'de> for ContentRef {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -164,6 +209,43 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     /// they are now retrievable. Storing byte-identical content more than
     /// once returns the same `ContentRef` and does not re-write the object.
     async fn put(&self, bytes: Vec<u8>) -> StorageResult<ContentRef>;
+
+    /// Create an empty staging object. The pack keeps the declared size,
+    /// incremental hash, sequence and idle clock. Backends enforce their
+    /// capacity policy on each append. Unsupported backends refuse explicitly.
+    async fn begin_upload(&self, declared_size: u64) -> StorageResult<UploadId> {
+        let _ = declared_size;
+        Err(unsupported_upload("begin_upload"))
+    }
+
+    /// Append and synchronize bytes, returning the total staged length.
+    /// The caller serializes parts and aborts after any uncertain append.
+    async fn append_part(&self, id: &UploadId, bytes: Vec<u8>) -> StorageResult<u64> {
+        let _ = (id, bytes);
+        Err(unsupported_upload("append_part"))
+    }
+
+    /// Publish through the same routine as put, without hashing a second time.
+    /// The caller proves the supplied digest and declared size before invoking
+    /// this method. Success consumes the staging object, including on dedup.
+    async fn commit_upload(&self, id: &UploadId, content_ref: &ContentRef) -> StorageResult<()> {
+        let _ = (id, content_ref);
+        Err(unsupported_upload("commit_upload"))
+    }
+
+    /// Discard staging; an already absent staging object is a successful no-op.
+    async fn abort_upload(&self, id: &UploadId) -> StorageResult<()> {
+        let _ = id;
+        Err(unsupported_upload("abort_upload"))
+    }
+
+    /// Remove visible staging objects idle for at least the given duration.
+    /// This never visits committed objects. Open S3 multipart uploads require
+    /// the deployment's incomplete-multipart lifecycle rule instead.
+    async fn sweep_uploads(&self, idle_for: std::time::Duration) -> StorageResult<u64> {
+        let _ = idle_for;
+        Err(unsupported_upload("sweep_uploads"))
+    }
 
     /// Fetch at most `max_bytes` from `content_ref` and verify its BLAKE3
     /// digest before returning any bytes.
@@ -306,9 +388,39 @@ pub trait BlobStore: Send + Sync + std::fmt::Debug + 'static {
     }
 }
 
+fn unsupported_upload(operation: &'static str) -> StorageError {
+    StorageError::Unsupported {
+        capability: StorageCapability::Blob,
+        operation: operation.into(),
+        message: "this backend does not support staged uploads".into(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn upload_id_roundtrips_and_rejects_path_or_noncanonical_input() {
+        let id = UploadId::from_bytes(&[0xab; 16]);
+        assert_eq!(id.as_str(), "ab".repeat(16));
+        assert_eq!(
+            serde_json::from_str::<UploadId>(&serde_json::to_string(&id).unwrap()).unwrap(),
+            id
+        );
+        for invalid in [
+            String::new(),
+            "a".repeat(31),
+            "a".repeat(33),
+            "A".repeat(32),
+            "g".repeat(32),
+            "../outside".into(),
+            "a/b".repeat(11),
+        ] {
+            assert!(UploadId::from_hex(&invalid).is_err());
+            assert!(serde_json::from_value::<UploadId>(serde_json::json!(invalid)).is_err());
+        }
+    }
 
     #[test]
     fn from_hex_accepts_valid_lowercase_digest() {

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -26,7 +26,8 @@ pub mod vectors;
 pub use agent::AgentStore;
 pub use attachment::{Attachment, AttachmentStore, AttachmentSubstrate, NewAttachment};
 pub use blob::{
-    BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, MAX_BLOB_WHOLE_BYTES,
+    BlobOrphanSweepConfig, BlobOrphanSweepResult, BlobStore, ContentRef, UploadId,
+    MAX_BLOB_WHOLE_BYTES,
 };
 pub use capability::StorageCapability;
 pub use entity::{Entity, EntityFilter, EntityStore};

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -2629,6 +2629,22 @@ smaller of the request-parser and daemon-frame caps with an 8192-byte reserve fo
 request fields. Upload IDs are capabilities held in process memory, with no actor
 ownership restriction or restart recovery. After a daemon restart, begin again.
 
+Each loaded upload manager allows 128 staged uploads in total and 16 per originating
+actor by default. `KHIVE_BLOB_UPLOAD_MAX_ACTIVE` and
+`KHIVE_BLOB_UPLOAD_MAX_PER_ACTOR` accept positive integer overrides; invalid values
+warn and use their defaults. Reaching either ceiling refuses `blob.begin` with
+`InvalidInput` naming that ceiling. Pending creation and uploads awaiting successful
+cleanup occupy slots; successful commit or cleanup releases them. Cancelling the
+begin request does not cancel admitted creation: its upload remains tracked until
+expiry. The existing-reference shortcut uses no slot and remains available when
+the ceiling is full. These limits apply per process, not as a shared disk quota.
+
+On Windows and other non-Unix systems, filesystem staging requires trusted local
+write access to the blob root, its contents and its ancestor directories. The
+path checks do not prevent a local writer from swapping a junction or reparse
+point between validation and use. See the
+[filesystem platform limits](../../crates/khive-pack-blob/docs/design.md#filesystem-platform-limits).
+
 ### `blob.put_part` — Declaration
 
 Append one part and return `{next_index, received_bytes}`, both non-negative integers.

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -30,7 +30,7 @@ An always-machine-readable copy of this page is at
 | `git`       | 16    | `KHIVE_PACKS=kg,git`                       | Yes                 |
 | `code`      | 1     | `KHIVE_PACKS=kg,code`                      | Yes                 |
 | `workspace` | 0     | `KHIVE_PACKS=kg,git,gtd,session,workspace` | Yes                 |
-| `blob`      | 3     | `KHIVE_PACKS=kg,blob`                      | Yes                 |
+| `blob`      | 7     | `KHIVE_PACKS=kg,blob`                      | Yes                 |
 | `tool`      | 13    | `KHIVE_PACKS=kg,tool`                      | Yes                 |
 | `exec`      | 9     | `KHIVE_PACKS=kg,exec`                      | Yes                 |
 
@@ -69,12 +69,15 @@ or annotation-edge ID is skipped even when its row is soft-deleted, so neither
 real re-ingest nor `--dry-run` treats a tombstone as a new record or resurrects
 it.
 
-`blob` registers no note or entity kinds; its three verbs (`blob.put` / `blob.get` /
-`blob.stat`) dispatch over the `BlobStore` content-addressed storage trait (ADR-111). A
+`blob` registers no note or entity kinds; its seven verbs (`blob.put` / `blob.get` /
+`blob.stat` / `blob.begin` / `blob.put_part` / `blob.commit` / `blob.abort`) expose
+content-addressed storage and sequential uploads (ADR-111, ADR-173). A
 normal file-backed boot installs a default `FsBlobStore` rooted beside the database file
 even with no `[storage.blob]` section and no `KHIVE_BLOB_ROOT` set; the verbs only stay
 unconfigured (erroring until a backend is installed) when the server boots against an
-in-memory backend, which has no directory to default a root beside.
+in-memory backend, which has no directory to default a root beside. Staged uploads currently
+use the filesystem backend; the S3 backend retains `blob.put` / `blob.get` / `blob.stat`
+and refuses creation of new staging with `Unsupported`.
 
 `tool` (`tool.register`, `tool.ingest`, `tool.suggest`, `tool.describe`, `tool.list`, `tool.check`,
 `tool.request`, `tool.grant`, `tool.deny`, `tool.revoke`, `tool.requests`, `tool.policy`, `tool.policies`)
@@ -2561,14 +2564,19 @@ reporting surface over a code-map database.
 
 ---
 
-## `blob` pack — 3 verbs
+## `blob` pack — 7 verbs
 
-Content-addressed binary object storage (ADR-111). Optional; load with
+Content-addressed binary object storage and sequential uploads (ADR-111, ADR-173). Optional; load with
 `KHIVE_PACKS=kg,blob`. Registers no note or entity kinds. A normal file-backed boot
 installs a default `FsBlobStore` rooted beside the database file even with no
 `[storage.blob]` section in `khive.toml` and no `KHIVE_BLOB_ROOT` set; the verbs stay
 unconfigured (erroring until a backend is installed) only when the server boots against
 an in-memory backend, which has no directory to default a root beside.
+
+Staged uploads currently use `FsBlobStore`; S3 supports the existing whole-object
+operations but returns `Unsupported` when new staging is required. The known-reference
+shortcut in `blob.begin` can return an existing object without staging. `blob.put` and
+all four upload verbs refuse on a read-only runtime.
 
 ### `blob.put` — Commissive
 
@@ -2591,7 +2599,7 @@ before slicing.
 
 | Param         | Type   | Required | Notes                                                                                                                             |
 | ------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `content_ref` | string | yes      | 64-char lowercase-hex BLAKE3 content reference returned by `blob.put`.                                                            |
+| `content_ref` | string | yes      | 64-char lowercase-hex BLAKE3 content reference returned by `blob.put` or `blob.commit`.                                           |
 | `range`       | object | no       | `{offset, length}`, both non-negative integers when present. Applied to the fetched object as a slice, not a streamed range read. |
 
 ### `blob.stat` — Assertive
@@ -2599,13 +2607,84 @@ before slicing.
 Report whether an object exists and its size, answered by a single metadata read with
 no bytes hydrated.
 
-| Param         | Type   | Required | Notes                                                                  |
-| ------------- | ------ | -------- | ---------------------------------------------------------------------- |
-| `content_ref` | string | yes      | 64-char lowercase-hex BLAKE3 content reference returned by `blob.put`. |
+| Param         | Type   | Required | Notes                                                                                   |
+| ------------- | ------ | -------- | --------------------------------------------------------------------------------------- |
+| `content_ref` | string | yes      | 64-char lowercase-hex BLAKE3 content reference returned by `blob.put` or `blob.commit`. |
+
+### `blob.begin` — Declaration
+
+Begin an upload with a declared total size. A new upload returns
+`{upload_id, part_limit, next_index}`: `upload_id` is a 32-character lowercase-hex
+string, `part_limit` is the integer maximum decoded bytes per part, and `next_index`
+starts at integer `0`. If the supplied reference already exists, return
+`{content_ref, size}` with its stored integer byte length and no `upload_id` or staging object.
+
+| Param         | Type    | Required | Notes                                                                                                           |
+| ------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `size`        | integer | yes      | Non-negative declared byte length, at most 64 MiB (67,108,864 bytes). Zero is allowed.                          |
+| `content_ref` | string  | no       | Optional 64-character lowercase-hex BLAKE3 reference. Checked for existence now and against the hash at commit. |
+
+Use the returned `part_limit`; it currently equals 780,288 bytes, derived from the
+smaller of the request-parser and daemon-frame caps with an 8192-byte reserve for
+request fields. Upload IDs are capabilities held in process memory, with no actor
+ownership restriction or restart recovery. After a daemon restart, begin again.
+
+### `blob.put_part` — Declaration
+
+Append one part and return `{next_index, received_bytes}`, both non-negative integers.
+Parts start at index `0` and proceed sequentially.
+
+| Param       | Type    | Required | Notes                                                                                   |
+| ----------- | ------- | -------- | --------------------------------------------------------------------------------------- |
+| `upload_id` | string  | yes      | 32-character lowercase-hex capability returned by `blob.begin`.                         |
+| `index`     | integer | yes      | Non-negative next part index, or the last accepted index for an identical tail retry.   |
+| `bytes`     | string  | yes      | Base64-encoded part with decoded length at most `part_limit`. An empty part is allowed. |
+
+An identical resend of the last accepted part returns the same counters without
+appending or refreshing the idle clock. A tail resend with different decoded length
+or bytes is refused and aborts the upload. Other out-of-order indices are refused
+with `InvalidInput` without advancing the upload. A next part crossing the declared
+total aborts it; a part exceeding only `part_limit` is refused while preserving the
+upload. Invalid base64 is refused before appending.
+
+Unknown or consumed IDs return `unknown upload`. With no new part for 3600 seconds
+after begin or the last accepted new part, `blob.put_part` and `blob.commit` discard
+the expired upload and return `unknown upload`. The daemon also sweeps idle staging
+every 600 seconds. `KHIVE_BLOB_UPLOAD_IDLE_SECS` and
+`KHIVE_BLOB_UPLOAD_SWEEP_INTERVAL_SECS` accept positive integer seconds; invalid
+values warn and use their defaults. Tail retries do not extend the idle bound.
+
+### `blob.commit` — Declaration
+
+Publish a complete upload and return `{content_ref, size}`: a 64-character lowercase-hex
+BLAKE3 string and the integer byte length. Success consumes the upload ID, including
+when the content already exists; the result has no deduplication flag.
+
+| Param       | Type   | Required | Notes                                                           |
+| ----------- | ------ | -------- | --------------------------------------------------------------- |
+| `upload_id` | string | yes      | 32-character lowercase-hex capability returned by `blob.begin`. |
+
+The received length must equal the declared `size`. An incomplete commit is refused
+with `InvalidInput` and leaves the upload available for further parts. A mismatch
+with the optional expected `content_ref` aborts the upload. Unknown, consumed, or
+expired IDs return `unknown upload`.
+
+### `blob.abort` — Declaration
+
+Discard staged bytes and invalidate the upload ID. Success returns `{aborted: true}`.
+Unknown or already consumed IDs return `unknown upload`; abort does not delete a
+committed object.
+
+| Param       | Type   | Required | Notes                                                           |
+| ----------- | ------ | -------- | --------------------------------------------------------------- |
+| `upload_id` | string | yes      | 32-character lowercase-hex capability returned by `blob.begin`. |
 
 ```
 request(ops="blob.put(bytes=\"aGVsbG8=\")")
 request(ops="blob.stat(content_ref=\"<64-char-hex>\")")
+request(ops="blob.begin(size=5)")
+request(ops="blob.put_part(upload_id=\"<32-char-hex>\", index=0, bytes=\"aGVsbG8=\")")
+request(ops="blob.commit(upload_id=\"<32-char-hex>\")")
 ```
 
 ---

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ graph, and link concepts together.
 khive is a research knowledge graph runtime. When you read papers, form
 concepts, link ideas, record decisions, or track tasks, khive gives that work a
 typed, queryable graph that persists across sessions. Everything is accessible
-through 129 verbs across 14 packs, dispatched through a single MCP tool.
+through 133 verbs across 14 packs, dispatched through a single MCP tool.
 
 ## Install
 

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 129 verbs across 14 packs.
+exposing one tool — `request` — that dispatches 133 verbs across 14 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 129 verbs, 14 packs, one MCP tool.
+A research knowledge graph runtime — 133 verbs, 14 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
@@ -37,7 +37,7 @@ runtime warm.
 | **git**       | 16    | Git-lifecycle note kinds (commit/issue/pull_request) + batch ingester + `git.digest`; write verbs `git.commit`/`git.branch`/`git.push` (ADR-108) |
 | **code**      | 1     | `code.ingest` L1/L1.5 source ingest; `findings.json` stays admin-CLI (`kkernel code-ingest`)                                                     |
 | **workspace** | 0     | Adds the `workspace` entity kind + `contains` endpoint rules to git/gtd/session notes (#873)                                                     |
-| **blob**      | 3     | Content-addressed blob storage (`blob.put` / `blob.get` / `blob.stat`)                                                                           |
+| **blob**      | 7     | Content-addressed storage: `put`, `get`, `stat`, plus chunked `begin`, `put_part`, `commit`, `abort`                                             |
 
 ## Usage
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "Apache-2.0" }
 dependencies = ["pydantic>=2.7"]
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "uvicorn>=0.30", "starlette>=0.37"]
+dev = ["pytest>=8", "blake3>=1", "uvicorn>=0.30", "starlette>=0.37"]
 cloud = ["httpx>=0.27", "mcp>=1.2,<2"]
 
 [build-system]

--- a/python/tests/test_blob_upload_wire_integration.py
+++ b/python/tests/test_blob_upload_wire_integration.py
@@ -212,10 +212,14 @@ def upload_daemon_factory():
     assert binary.is_file() and os.access(binary, os.X_OK), binary
     daemons = []
 
-    def create(*, idle=3600, sweep=NO_SWEEP_SECS):
+    def create(*, idle=3600, sweep=NO_SWEEP_SECS, max_active=None, max_per_actor=None):
         # /tmp keeps both the main and derived events AF_UNIX paths below macOS's cap.
         root = Path(tempfile.mkdtemp(prefix="blob-wire-", dir="/tmp"))
         daemon = _Daemon(str(binary), root, idle, sweep)
+        if max_active is not None:
+            daemon.env["KHIVE_BLOB_UPLOAD_MAX_ACTIVE"] = str(max_active)
+        if max_per_actor is not None:
+            daemon.env["KHIVE_BLOB_UPLOAD_MAX_PER_ACTOR"] = str(max_per_actor)
         daemons.append(daemon)
         return daemon.start()
 
@@ -338,6 +342,29 @@ def test_blob_upload_wire_begin_above_object_ceiling_creates_no_stage(upload_dae
     daemon = upload_daemon_factory()
     assert _rust_constant("crates/khive-pack-blob/src/handlers.rs", "MAX_OBJECT_BYTES") == OBJECT_BYTES
     _refused(daemon.client(), "blob.begin", size=OBJECT_BYTES + 1, contains="invalid input")
+    assert not daemon.staging() and not daemon.objects()
+
+
+def test_blob_upload_wire_total_active_cap_refuses_and_abort_releases_slot(upload_daemon_factory):
+    # Keep the per-actor ceiling above the attempted third upload so it cannot
+    # mask removal of the total-cap guard in the mutation control.
+    daemon = upload_daemon_factory(max_active=2, max_per_actor=3)
+    client = daemon.client()
+    active = [_begin(client, 0) for _ in range(2)]
+    stages = {daemon.stage(begin) for begin in active}
+    assert len(stages) == 2 and daemon.staging() == stages
+    assert all(stage.stat().st_size == 0 for stage in stages)
+    _refused(client, "blob.begin", size=0, contains="total active-upload ceiling of 2 reached")
+    assert daemon.staging() == stages and not daemon.objects()
+
+    _one(client, "blob.abort", upload_id=active[0]["upload_id"])
+    remaining = daemon.stage(active[1])
+    assert daemon.staging() == {remaining}
+    replacement = _begin(client, 0)
+    assert replacement["upload_id"] not in {begin["upload_id"] for begin in active}
+    assert daemon.staging() == {remaining, daemon.stage(replacement)}
+    for begin in (active[1], replacement):
+        _one(client, "blob.abort", upload_id=begin["upload_id"])
     assert not daemon.staging() and not daemon.objects()
 
 

--- a/python/tests/test_blob_upload_wire_integration.py
+++ b/python/tests/test_blob_upload_wire_integration.py
@@ -73,7 +73,7 @@ def _one(client: Session, verb: str, **args) -> dict:
 
 def _refused(client: Session, verb: str, *, contains: str, **args) -> dict:
     entry = _entry(client, verb, **args)
-    assert not entry["ok"], entry
+    assert not entry["ok"], f"unexpectedly accepted {verb}: {entry}"
     assert contains in entry["error"]["message"].lower(), entry
     return entry["error"]
 
@@ -555,6 +555,9 @@ def test_blob_upload_wire_daemon_owns_expiry_after_mcp_client_exit(upload_daemon
         child.stdin.close()
         assert child.wait(timeout=15) == 0, stderr_path.read_text(errors="replace")
         assert child.pid != daemon.process.pid and stage.read_bytes() == b"a"
+        # No RPC or upload verb may run from here to the removal assertion:
+        # verb-side expiry would otherwise hide an inert daemon sweeper.
+        # Fixture deletion runs only after this test returns (or fails).
         daemon.wait_removed(stage)
         assert child.poll() == 0 and not daemon.staging()
     finally:

--- a/python/tests/test_blob_upload_wire_integration.py
+++ b/python/tests/test_blob_upload_wire_integration.py
@@ -1,0 +1,585 @@
+"""ADR-173 filesystem acceptance against an explicitly selected real candidate.
+
+Run with KKERNEL pointing to this checkout's gate-built executable and with
+the Python blake3 package installed. No binary fallback and no skip path.
+Each test owns a scratch daemon; none uses the user's daemon or blob root.
+"""
+
+from __future__ import annotations
+
+import ast
+import base64
+import json
+import os
+from pathlib import Path
+import re
+import select
+import shutil
+import signal
+import socket
+import struct
+import subprocess
+import tempfile
+import time
+
+from blake3 import blake3
+import pytest
+
+from khive.dsl import MAX_OPS_INPUT_LEN
+from khive.errors import RequestRejected
+from khive.ops import encode, op
+from khive.transport import MAX_FRAME_BYTES, Session, SocketTransport
+
+
+REPO = Path(__file__).resolve().parents[2]
+OBJECT_BYTES = 64 * 1024 * 1024
+NO_SWEEP_SECS = 86_400
+
+
+def _rust_constant(relative_path: str, name: str) -> int:
+    source = (REPO / relative_path).read_text()
+    found = re.search(rf"\bconst {name}\s*:\s*(?:u64|usize)\s*=\s*([^;]+);", source)
+    assert found, f"missing live Rust constant {name} in {relative_path}"
+
+    def integer(node):
+        if isinstance(node, ast.Constant) and type(node.value) is int:
+            return node.value
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mult):
+            return integer(node.left) * integer(node.right)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            return integer(node.left) + integer(node.right)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Sub):
+            return integer(node.left) - integer(node.right)
+        raise AssertionError(f"inspect changed Rust constant expression: {found.group(1)}")
+
+    return integer(ast.parse(found.group(1).strip(), mode="eval").body)
+
+
+def _b64(payload: bytes) -> str:
+    return base64.b64encode(payload).decode("ascii")
+
+
+def _entry(client: Session, verb: str, **args) -> dict:
+    results = client.request(encode([op(verb, **args)]))
+    assert len(results) == 1 and results[0]["tool"] == verb, results
+    return results[0]
+
+
+def _one(client: Session, verb: str, **args) -> dict:
+    entry = _entry(client, verb, **args)
+    assert entry["ok"], entry
+    return entry["result"]
+
+
+def _refused(client: Session, verb: str, *, contains: str, **args) -> dict:
+    entry = _entry(client, verb, **args)
+    assert not entry["ok"], entry
+    assert contains in entry["error"]["message"].lower(), entry
+    return entry["error"]
+
+
+def _begin(client: Session, size: int, **args) -> dict:
+    result = _one(client, "blob.begin", size=size, **args)
+    assert set(result) == {"upload_id", "part_limit", "next_index"}, result
+    assert re.fullmatch(r"[0-9a-f]{32}", result["upload_id"]), result
+    assert result["next_index"] == 0 and result["part_limit"] > 0, result
+    return result
+
+
+def _part(client: Session, upload_id: str, index: int, payload: bytes) -> dict:
+    return _one(client, "blob.put_part", upload_id=upload_id, index=index, bytes=_b64(payload))
+
+
+def _upload(client: Session, payload: bytes) -> dict:
+    begin = _begin(client, len(payload))
+    for index, offset in enumerate(range(0, len(payload), begin["part_limit"])):
+        chunk = payload[offset : offset + begin["part_limit"]]
+        assert _part(client, begin["upload_id"], index, chunk) == {
+            "next_index": index + 1,
+            "received_bytes": offset + len(chunk),
+        }
+    committed = _one(client, "blob.commit", upload_id=begin["upload_id"])
+    assert committed == {"content_ref": blake3(payload).hexdigest(), "size": len(payload)}
+    return committed
+
+
+class _Daemon:
+    def __init__(self, binary: str, root: Path, idle: int, sweep: int):
+        self.binary, self.root, self.idle, self.sweep = binary, root, idle, sweep
+        self.socket = root / "khived.sock"
+        self.blobs = root / "blobs"
+        self.config = root / "khive.toml"
+        self.config.write_text(
+            '[storage.blob]\nbackend = "fs"\n'
+            f"root = {json.dumps(str(self.blobs))}\nfloor_bytes = 0\n"
+        )
+        self.env = {key: value for key, value in os.environ.items() if not key.startswith("KHIVE_")}
+        self.env.update(
+            KHIVE_SOCKET=str(self.socket),
+            KHIVE_PID=str(root / "khived.pid"),
+            KHIVE_LOCK=str(root / "khived.recovery.lock"),
+            KHIVE_RECOVERER_LOCK=str(root / "khived.recoverer.lock"),
+            KHIVE_PACKS="kg,blob",
+            KHIVE_BLOB_UPLOAD_IDLE_SECS=str(idle),
+            KHIVE_BLOB_UPLOAD_SWEEP_INTERVAL_SECS=str(sweep),
+        )
+        self.process = None
+        self.starts = 0
+
+    def client(self) -> Session:
+        return Session(SocketTransport(self.socket), actor_id="test:blob:owner", timeout=60)
+
+    def args(self) -> list[str]:
+        return ["--config", str(self.config), "--db", str(self.root / "scratch.db"), "--no-embed"]
+
+    def start(self):
+        assert self.process is None
+        self.starts += 1
+        self.stderr = self.root / f"daemon-{self.starts}.stderr"
+        with self.stderr.open("wb") as stderr:
+            self.process = subprocess.Popen(
+                [self.binary, "mcp", "--daemon", *self.args()],
+                env=self.env,
+                cwd=self.root,
+                stdout=subprocess.DEVNULL,
+                stderr=stderr,
+            )
+        self.started_at = time.monotonic()
+        deadline = self.started_at + 45
+        last_error = None
+        while time.monotonic() < deadline:
+            self.assert_alive()
+            if self.socket.exists():
+                try:
+                    ready = Session(SocketTransport(self.socket), timeout=2)
+                    _one(ready, "stats")
+                    return self
+                except Exception as exc:  # readiness includes the audit daemon
+                    last_error = exc
+            time.sleep(0.1)
+        raise AssertionError(f"scratch daemon never became ready: {last_error}; {self.logs()}")
+
+    def logs(self) -> str:
+        return self.stderr.read_text(errors="replace")[-4000:]
+
+    def assert_alive(self):
+        assert self.process is not None and self.process.poll() is None, self.logs()
+
+    def stop(self):
+        if self.process is None:
+            return
+        if self.process.poll() is None:
+            self.process.send_signal(signal.SIGTERM)
+            try:
+                self.process.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=10)
+        self.process = None
+
+    def staging(self) -> set[Path]:
+        path = self.blobs / ".uploads"
+        return set(path.iterdir()) if path.exists() else set()
+
+    def stage(self, begin: dict) -> Path:
+        path = self.blobs / ".uploads" / begin["upload_id"]
+        assert path.is_file(), (path, self.staging())
+        return path
+
+    def object(self, content_ref: str) -> Path:
+        return self.blobs / content_ref[:2] / content_ref[2:4] / content_ref
+
+    def objects(self) -> set[Path]:
+        return {
+            path for path in self.blobs.glob("*/*/*")
+            if re.fullmatch(r"[0-9a-f]{64}", path.name) and path.is_file()
+        }
+
+    def wait_removed(self, stage: Path):
+        deadline = time.monotonic() + self.idle + 3 * self.sweep + 5
+        while stage.exists() and time.monotonic() < deadline:
+            self.assert_alive()
+            time.sleep(0.05)
+        assert not stage.exists(), f"daemon did not expire {stage}: {self.logs()}"
+        self.assert_alive()
+
+
+@pytest.fixture
+def upload_daemon_factory():
+    selected = os.environ.get("KKERNEL")
+    assert selected, "set KKERNEL to this checkout's gate-built candidate; no installed fallback"
+    binary = Path(selected).resolve()
+    assert binary.is_file() and os.access(binary, os.X_OK), binary
+    daemons = []
+
+    def create(*, idle=3600, sweep=NO_SWEEP_SECS):
+        # /tmp keeps both the main and derived events AF_UNIX paths below macOS's cap.
+        root = Path(tempfile.mkdtemp(prefix="blob-wire-", dir="/tmp"))
+        daemon = _Daemon(str(binary), root, idle, sweep)
+        daemons.append(daemon)
+        return daemon.start()
+
+    yield create
+    for daemon in reversed(daemons):
+        daemon.stop()
+        shutil.rmtree(daemon.root, ignore_errors=True)
+
+
+def test_blob_upload_wire_64mib_external_blake3_ranged_roundtrip(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    block = bytes(range(256)) * 4096
+    payload = block * 64
+    assert len(payload) == OBJECT_BYTES
+    expected = blake3(payload).hexdigest()
+    begin = _begin(client, len(payload))
+    part_count = 0
+    for index, offset in enumerate(range(0, len(payload), begin["part_limit"])):
+        chunk = payload[offset : offset + begin["part_limit"]]
+        assert _part(client, begin["upload_id"], index, chunk) == {
+            "next_index": index + 1,
+            "received_bytes": offset + len(chunk),
+        }
+        part_count += 1
+    assert part_count == (OBJECT_BYTES + begin["part_limit"] - 1) // begin["part_limit"]
+    result = _one(client, "blob.commit", upload_id=begin["upload_id"])
+    assert result == {"content_ref": expected, "size": OBJECT_BYTES}
+    assert not daemon.staging()
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="unknown upload")
+
+    response_reserve = _rust_constant(
+        "crates/khive-pack-blob/src/handlers.rs", "RESPONSE_ENVELOPE_RESERVE_BYTES"
+    )
+    read_limit = (MAX_FRAME_BYTES - response_reserve) * 3 // 4
+    returned = blake3()
+    ranges = 0
+    for offset in range(0, OBJECT_BYTES, read_limit):
+        length = min(read_limit, OBJECT_BYTES - offset)
+        result = _one(client, "blob.get", content_ref=expected, range={"offset": offset, "length": length})
+        raw = base64.b64decode(result["bytes"], validate=True)
+        assert result["size"] == OBJECT_BYTES
+        assert result["range"] == {"offset": offset, "length": length}
+        assert raw == payload[offset : offset + length]
+        returned.update(raw)
+        ranges += 1
+    assert returned.hexdigest() == expected
+    print(f"external BLAKE3 {expected}; {part_count} upload parts; {ranges} ranged reads")
+
+
+def test_blob_upload_wire_known_and_full_dedup_touch_one_object(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client, payload = daemon.client(), b"ADR-173 dedup baseline" * 1024
+    first = _upload(client, payload)
+    path = daemon.object(first["content_ref"])
+    assert daemon.objects() == {path}
+    assert _one(client, "blob.begin", size=len(payload), content_ref=first["content_ref"]) == first
+    assert not daemon.staging()
+    before = path.stat().st_mtime_ns
+    time.sleep(1.05)
+    assert _upload(client, payload) == first
+    assert path.stat().st_mtime_ns > before
+    assert daemon.objects() == {path} and not daemon.staging()
+    before = path.stat().st_mtime_ns
+    time.sleep(1.05)
+    assert _one(client, "blob.put", bytes=_b64(payload)) == first
+    assert path.stat().st_mtime_ns > before
+    assert daemon.objects() == {path}
+
+
+def test_blob_upload_wire_wrong_index_preserves_sequential_progress(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, 2)
+    stage = daemon.stage(begin)
+    for index in (1, 9):
+        error = _refused(client, "blob.put_part", upload_id=begin["upload_id"], index=index,
+                         bytes=_b64(b"x"), contains="invalid input")
+        assert "index" in error["message"].lower()
+        assert stage.stat().st_size == 0
+    assert _part(client, begin["upload_id"], 0, b"a") == {"next_index": 1, "received_bytes": 1}
+    _refused(client, "blob.put_part", upload_id=begin["upload_id"], index=2,
+             bytes=_b64(b"x"), contains="invalid input")
+    assert stage.read_bytes() == b"a"
+    assert _part(client, begin["upload_id"], 1, b"b") == {"next_index": 2, "received_bytes": 2}
+    assert _one(client, "blob.commit", upload_id=begin["upload_id"]) == {
+        "content_ref": blake3(b"ab").hexdigest(), "size": 2,
+    }
+
+
+def test_blob_upload_wire_identical_tail_retry_does_not_append_or_touch(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, 2)
+    first = _part(client, begin["upload_id"], 0, b"a")
+    stage = daemon.stage(begin)
+    before = stage.stat()
+    assert _part(client, begin["upload_id"], 0, b"a") == first
+    assert stage.read_bytes() == b"a" and stage.stat().st_mtime_ns == before.st_mtime_ns
+    assert _part(client, begin["upload_id"], 1, b"b") == {"next_index": 2, "received_bytes": 2}
+    assert _one(client, "blob.commit", upload_id=begin["upload_id"]) == {
+        "content_ref": blake3(b"ab").hexdigest(), "size": 2,
+    }
+
+
+@pytest.mark.parametrize("retry", [b"aa", b"b"], ids=["different_length", "same_length_different_bytes"])
+def test_blob_upload_wire_tail_mismatch_aborts(upload_daemon_factory, retry):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, 3)
+    _part(client, begin["upload_id"], 0, b"a")
+    stage = daemon.stage(begin)
+    _refused(client, "blob.put_part", upload_id=begin["upload_id"], index=0,
+             bytes=_b64(retry), contains="invalid input")
+    assert not stage.exists() and not daemon.staging()
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="unknown upload")
+
+
+def test_blob_upload_wire_begin_above_object_ceiling_creates_no_stage(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    assert _rust_constant("crates/khive-pack-blob/src/handlers.rs", "MAX_OBJECT_BYTES") == OBJECT_BYTES
+    _refused(daemon.client(), "blob.begin", size=OBJECT_BYTES + 1, contains="invalid input")
+    assert not daemon.staging() and not daemon.objects()
+
+
+def test_blob_upload_wire_crossing_declared_size_aborts(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, 1)
+    stage = daemon.stage(begin)
+    _refused(client, "blob.put_part", upload_id=begin["upload_id"], index=0,
+             bytes=_b64(b"ab"), contains="invalid input")
+    assert not stage.exists() and not daemon.objects()
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="unknown upload")
+
+
+def test_blob_upload_wire_part_limit_formula_exact_and_plus_one(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    ops_cap = _rust_constant("crates/khive-request/src/types.rs", "MAX_OPS_INPUT_LEN")
+    frame_cap = _rust_constant("crates/khive-runtime/src/daemon.rs", "MAX_FRAME_BYTES")
+    reserve = _rust_constant("crates/khive-pack-blob/src/handlers.rs", "REQUEST_RESERVE")
+    assert (ops_cap, frame_cap, reserve) == (MAX_OPS_INPUT_LEN, MAX_FRAME_BYTES, 8192)
+    limit = (min(ops_cap, frame_cap) - reserve) * 3 // 4
+    begin = _begin(client, limit)
+    assert begin["part_limit"] == limit
+    payload = b"x" * limit
+    ops = encode([op("blob.put_part", upload_id=begin["upload_id"], index=0, bytes=_b64(payload))])
+    client.handshake()
+    serialized = json.dumps(client._request_frame(ops)).encode()
+    assert len(ops.encode()) < ops_cap
+    assert len(serialized) - len(ops.encode()) < frame_cap - ops_cap
+    assert len(serialized) < frame_cap
+    assert client.request(ops)[0]["result"] == {"next_index": 1, "received_bytes": limit}
+    assert _one(client, "blob.commit", upload_id=begin["upload_id"]) == {
+        "content_ref": blake3(payload).hexdigest(), "size": limit,
+    }
+
+    over = _begin(client, limit + 1)
+    ops = encode([op("blob.put_part", upload_id=over["upload_id"], index=0, bytes=_b64(payload + b"x"))])
+    assert len(ops.encode()) < ops_cap
+    entry = client.request(ops)[0]
+    assert not entry["ok"] and "invalid input" in entry["error"]["message"].lower(), entry
+    assert "decoded length" in entry["error"]["message"].lower(), entry
+    assert str(limit + 1) in entry["error"]["message"], entry
+    assert str(limit) in entry["error"]["message"], entry
+    stage = daemon.stage(over)
+    assert stage.stat().st_size == 0
+    assert _part(client, over["upload_id"], 0, b"x") == {"next_index": 1, "received_bytes": 1}
+    assert stage.read_bytes() == b"x"
+    _one(client, "blob.abort", upload_id=over["upload_id"])
+
+
+def test_blob_upload_wire_oversized_ops_is_parser_refusal(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, 1)
+    stage = daemon.stage(begin)
+    ops = encode([op("blob.put_part", upload_id=begin["upload_id"], index=0,
+                     bytes=_b64(b"x" * MAX_OPS_INPUT_LEN))])
+    assert MAX_OPS_INPUT_LEN < len(ops.encode()) < MAX_FRAME_BYTES
+    with pytest.raises(RequestRejected) as rejected:
+        client.request(ops)
+    assert str(MAX_OPS_INPUT_LEN) in str(rejected.value)
+    assert stage.stat().st_size == 0
+    assert _part(client, begin["upload_id"], 0, b"a") == {"next_index": 1, "received_bytes": 1}
+
+
+def test_blob_upload_wire_actual_oversized_frame_is_rejected_before_dispatch(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, OBJECT_BYTES)
+    stage = daemon.stage(begin)
+    payload = b"f" * begin["part_limit"]
+    ops = encode([op("blob.put_part", upload_id=begin["upload_id"], index=0, bytes=_b64(payload))])
+    assert len(ops.encode()) < MAX_OPS_INPUT_LEN
+    client.handshake()
+    frame = client._request_frame(ops)
+    base_size = len(json.dumps(frame).encode())
+    # Every entry is a valid namespace. With the frame guard removed, identity
+    # validation cannot hide a dispatch behind an invalid padding string.
+    frame["visible_namespaces"] = ["local"] * ((MAX_FRAME_BYTES - base_size) // 9 + 3)
+    serialized = json.dumps(frame).encode()
+    assert len(serialized) - len(ops.encode()) > MAX_FRAME_BYTES - MAX_OPS_INPUT_LEN
+    assert len(serialized) > MAX_FRAME_BYTES
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as wire:
+        wire.settimeout(10)
+        wire.connect(str(daemon.socket))
+        try:
+            wire.sendall(struct.pack(">I", len(serialized)) + serialized)
+        except (BrokenPipeError, ConnectionResetError):
+            pass  # the daemon can close as soon as it reads the actual frame's prefix
+        try:
+            assert wire.recv(4) == b"", "oversized frame unexpectedly received a response"
+        except ConnectionResetError:
+            pass
+    daemon.assert_alive()
+    assert stage.stat().st_size == 0
+    assert _part(client, begin["upload_id"], 0, payload) == {
+        "next_index": 1, "received_bytes": len(payload),
+    }
+    print(f"offered serialized frame of {len(serialized)} bytes; cap {MAX_FRAME_BYTES}; no dispatch")
+
+
+def test_blob_upload_wire_abort_removes_stage_and_record(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, 2)
+    _part(client, begin["upload_id"], 0, b"a")
+    stage = daemon.stage(begin)
+    _one(client, "blob.abort", upload_id=begin["upload_id"])
+    assert not stage.exists() and not daemon.staging() and not daemon.objects()
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="unknown upload")
+
+
+@pytest.mark.parametrize("verb", ["blob.put_part", "blob.commit"], ids=["put_part", "commit"])
+def test_blob_upload_wire_verb_expiry_without_sweeper(upload_daemon_factory, verb):
+    daemon = upload_daemon_factory(idle=1, sweep=NO_SWEEP_SECS)
+    client = daemon.client()
+    begin = _begin(client, 2 if verb == "blob.put_part" else 1)
+    _part(client, begin["upload_id"], 0, b"a")
+    stage = daemon.stage(begin)
+    time.sleep(daemon.idle + 0.2)
+    assert time.monotonic() - daemon.started_at < daemon.sweep
+    assert stage.read_bytes() == b"a", "sweep ran before the verb-only expiry assertion"
+    args = {"index": 1, "bytes": _b64(b"b")} if verb == "blob.put_part" else {}
+    _refused(client, verb, upload_id=begin["upload_id"], contains="unknown upload", **args)
+    assert not stage.exists() and not daemon.staging()
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="unknown upload")
+
+
+def test_blob_upload_wire_daemon_expiry_without_verbs_keeps_committed_object(upload_daemon_factory):
+    daemon = upload_daemon_factory(idle=2, sweep=1)
+    client = daemon.client()
+    committed = _one(client, "blob.put", bytes=_b64(b"committed control"))
+    permanent = daemon.object(committed["content_ref"])
+    begin = _begin(client, 2)
+    _part(client, begin["upload_id"], 0, b"a")
+    stage = daemon.stage(begin)
+    assert stage.read_bytes() == b"a" and permanent.read_bytes() == b"committed control"
+    daemon.wait_removed(stage)
+    assert permanent.read_bytes() == b"committed control"
+    assert not daemon.staging()
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="unknown upload")
+
+
+def test_blob_upload_wire_restart_orphan_sweep_and_begin_again(upload_daemon_factory):
+    daemon = upload_daemon_factory(idle=2, sweep=1)
+    client = daemon.client()
+    begin = _begin(client, 2)
+    _part(client, begin["upload_id"], 0, b"a")
+    stage = daemon.stage(begin)
+    first_pid = daemon.process.pid
+    daemon.stop()
+    assert stage.read_bytes() == b"a", "shutdown must leave the orphan for restart sweep evidence"
+    daemon.start()
+    assert daemon.process.pid != first_pid
+    client = daemon.client()
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="unknown upload")
+    daemon.wait_removed(stage)
+    assert not daemon.staging()
+    result = _upload(client, b"ab")
+    assert base64.b64decode(_one(client, "blob.get", content_ref=result["content_ref"])["bytes"]) == b"ab"
+
+
+def _mcp_response(process, request_id: int) -> dict:
+    deadline = time.monotonic() + 45
+    while time.monotonic() < deadline:
+        assert select.select([process.stdout], [], [], max(0, deadline - time.monotonic()))[0], (
+            "MCP child response timed out"
+        )
+        line = process.stdout.readline()
+        assert line, "MCP child closed stdout before its response"
+        result = json.loads(line)
+        if result.get("id") == request_id:
+            return result
+    raise AssertionError("MCP child did not return the requested response id")
+
+
+def test_blob_upload_wire_daemon_owns_expiry_after_mcp_client_exit(upload_daemon_factory):
+    daemon = upload_daemon_factory(idle=20, sweep=1)
+    stderr_path = daemon.root / "client.stderr"
+    with stderr_path.open("wb") as stderr:
+        child = subprocess.Popen(
+            [daemon.binary, "mcp", *daemon.args()], env=daemon.env, cwd=daemon.root,
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=stderr, bufsize=0,
+        )
+
+    def send(message):
+        child.stdin.write((json.dumps(message) + "\n").encode())
+        child.stdin.flush()
+
+    try:
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
+            "protocolVersion": "2024-11-05", "capabilities": {},
+            "clientInfo": {"name": "blob-upload-owner-control", "version": "1"},
+        }})
+        assert "result" in _mcp_response(child, 1)
+        send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        send({"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {
+            "name": "request", "arguments": {
+                "ops": encode([op("blob.begin", size=1)]), "format": "json", "presentation": "verbose",
+            },
+        }})
+        response = _mcp_response(child, 2)
+        assert "error" not in response and not response["result"].get("isError"), response
+        envelope = json.loads(response["result"]["content"][0]["text"])
+        entry = envelope["results"][0]
+        assert entry["ok"], entry
+        begin = entry["result"]
+        stage = daemon.stage(begin)
+        # The daemon can append this capability before the MCP client exits;
+        # that rules out a private upload record in the client's serve process.
+        assert _part(daemon.client(), begin["upload_id"], 0, b"a") == {
+            "next_index": 1, "received_bytes": 1,
+        }
+        child.stdin.close()
+        assert child.wait(timeout=15) == 0, stderr_path.read_text(errors="replace")
+        assert child.pid != daemon.process.pid and stage.read_bytes() == b"a"
+        daemon.wait_removed(stage)
+        assert child.poll() == 0 and not daemon.staging()
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+
+def test_blob_upload_wire_expected_hash_mismatch_discards_stage(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, 1, content_ref=blake3(b"different").hexdigest())
+    _part(client, begin["upload_id"], 0, b"a")
+    stage = daemon.stage(begin)
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="invalid input")
+    assert not stage.exists() and not daemon.objects()
+    _refused(client, "blob.commit", upload_id=begin["upload_id"], contains="unknown upload")
+
+
+def test_blob_upload_wire_empty_object_and_empty_part(upload_daemon_factory):
+    daemon = upload_daemon_factory()
+    client = daemon.client()
+    begin = _begin(client, 0)
+    assert _part(client, begin["upload_id"], 0, b"") == {"next_index": 1, "received_bytes": 0}
+    expected = {"content_ref": blake3(b"").hexdigest(), "size": 0}
+    assert _one(client, "blob.commit", upload_id=begin["upload_id"]) == expected
+    assert _one(client, "blob.begin", size=0, content_ref=expected["content_ref"]) == expected
+    assert not daemon.staging()

--- a/scripts/test-blob-upload-mutations.py
+++ b/scripts/test-blob-upload-mutations.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Compile blob-upload mutants, verify discriminating failures, and restore.
+
+Requires an isolated clean checkout, an explicit native CARGO_TARGET_DIR and
+Python pytest/pydantic/blake3 dependencies. Use a fresh --out outside the checkout.
+--case all runs ADR-173's four
+mutation operators. --case owner additionally proves daemon cleanup ownership
+by leaving the timer and heartbeat alive while suppressing its sweep call.
+Every case retains raw logs and rebuilds the restored source before succeeding.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+def sha(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--case", choices=["all", "tail", "expiry", "sweep", "publisher", "owner"], default="all")
+    args = parser.parse_args()
+    root, binary, out = args.root.resolve(), args.binary.resolve(), args.out.resolve()
+    out.mkdir(parents=True, exist_ok=False)
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    if head != args.head:
+        raise RuntimeError(f"unexpected head {head}")
+    status = subprocess.check_output(["git", "status", "--porcelain"], cwd=root, text=True)
+    if status:
+        raise RuntimeError("controls require a clean source tree")
+    if not os.environ.get("CARGO_TARGET_DIR"):
+        raise RuntimeError("select CARGO_TARGET_DIR explicitly")
+
+    env = dict(os.environ)
+    env["KKERNEL"] = str(binary)
+    env["PYTHONPATH"] = str(root / "python")
+    env["RUSTUP_TOOLCHAIN"] = "1.95.0"
+    target_dir = Path(env["CARGO_TARGET_DIR"])
+    if not target_dir.is_absolute():
+        target_dir = root / target_dir
+    env["CARGO_TARGET_DIR"] = str(target_dir.resolve())
+    target = target_dir.resolve() / "debug" / "kkernel"
+    if env.get("CARGO_BUILD_TARGET") or binary != target:
+        raise RuntimeError(f"select the native build output {target} with no CARGO_BUILD_TARGET")
+    results = {"head": head, "root": str(root), "target": env["CARGO_TARGET_DIR"], "commands": [], "cases": {}, "status": "INCOMPLETE"}
+
+    def persist():
+        (out / "results.json").write_text(json.dumps(results, indent=2) + "\n")
+
+    def run(name, command, expected):
+        completed = subprocess.run(command, cwd=root, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        (out / (name + ".log")).write_bytes(completed.stdout)
+        receipt = {"name": name, "command": command, "exit_code": completed.returncode, "expected_exit_code": expected}
+        if binary.is_file():
+            receipt["binary_sha256"] = sha(binary.read_bytes())
+        results["commands"].append(receipt)
+        persist()
+        text = completed.stdout.decode(errors="replace")
+        if completed.returncode != expected:
+            raise RuntimeError(f"{name}: exit {completed.returncode}, expected {expected}; see log")
+        return text
+
+    def build(name):
+        run(name, ["cargo", "+1.95.0", "build", "--manifest-path", "crates/Cargo.toml", "--locked", "-p", "kkernel"], 0)
+        if not binary.is_file():
+            raise RuntimeError("selected candidate binary was not produced")
+        target = Path(env["CARGO_TARGET_DIR"]).resolve() / "debug" / "kkernel"
+        if binary != target:
+            raise RuntimeError(f"selected binary {binary} differs from this build output {target}")
+
+    test_file = "python/tests/test_blob_upload_wire_integration.py"
+    names = {
+        "tail": "test_blob_upload_wire_tail_mismatch_aborts[same_length_different_bytes]",
+        "expiry": "test_blob_upload_wire_verb_expiry_without_sweeper[put_part]",
+        "sweep": "test_blob_upload_wire_restart_orphan_sweep_and_begin_again",
+        "live": "test_blob_upload_wire_daemon_expiry_without_verbs_keeps_committed_object",
+        "owner": "test_blob_upload_wire_daemon_owns_expiry_after_mcp_client_exit",
+    }
+
+    def witness(label, name, red=False):
+        text = run(label, [sys.executable, "-m", "pytest", "-q", "-s", "--color=no", "--tb=long", "-o", "addopts=", test_file + "::" + names[name]], 1 if red else 0)
+        counts = {kind: int(value) for value, kind in re.findall(r"\b(\d+) (passed|failed|skipped|deselected|error)\b", text)}
+        expected = {"failed": 1} if red else {"passed": 1}
+        if counts != expected:
+            raise RuntimeError(f"{label}: unexpected pytest counts {counts}")
+        if red and name in ("tail", "expiry") and not re.search(
+            r"^E\s+AssertionError: unexpectedly accepted blob\.put_part:", text, re.MULTILINE
+        ):
+            raise RuntimeError(f"{label}: failure was not acceptance of the refused write")
+        if red and name in ("sweep", "owner") and not re.search(
+            r"^E\s+AssertionError: daemon did not expire ", text, re.MULTILINE
+        ):
+            raise RuntimeError(f"{label}: failure was not retained staging")
+
+    upload_source = root / "crates/khive-pack-blob/src/uploads.rs"
+    owner_source = root / "crates/khive-mcp/src/components.rs"
+    originals = {path: path.read_bytes() for path in (upload_source, owner_source)}
+
+    def replace_one(value, before, after):
+        if value.count(before) != 1:
+            raise RuntimeError(f"mutation anchor is not unique: {before!r}")
+        return value.replace(before, after, 1)
+
+    def mutated(case, text):
+        if case == "owner":
+            return replace_one(
+                text,
+                "match manager.sweep().await {",
+                "match Ok::<u64, khive_runtime::RuntimeError>(0) {",
+            ).encode()
+        if case == "tail":
+            changed = replace_one(text, "bytes.len() != tail_len || part_hash != tail_hash", "bytes.len() != tail_len")
+            return replace_one(changed, "let (tail_len, tail_hash)", "let (tail_len, _tail_hash)").encode()
+        if case == "expiry":
+            return replace_one(text, "if record.last_part.elapsed() >= self.policy.idle_for {", "if false {").encode()
+        start = text.index("        match store.sweep_uploads(self.policy.idle_for).await {")
+        end = text.index("        match failure {", start)
+        return (text[:start] + "        let _ = store; // backend staging sweep deliberately removed\n" + text[end:]).encode()
+
+    cases = ["tail", "expiry", "sweep", "publisher"] if args.case == "all" else [args.case]
+    try:
+        for case in cases:
+            if case == "publisher":
+                helper = Path(__file__).resolve().with_name("test-blob-upload-publish-control.py")
+                run("publisher", [sys.executable, str(helper), "--root", str(root), "--out", str(out / "publisher")], 0)
+                continue
+            source = owner_source if case == "owner" else upload_source
+            original = originals[source]
+            if any(path.read_bytes() != data for path, data in originals.items()):
+                raise RuntimeError("source changed between mutation cases")
+            build(case + "-before-build")
+            witness(case + "-before", case)
+            if case == "sweep":
+                witness("sweep-live-before", "live")
+            changed = mutated(case, original.decode())
+            if changed == original:
+                raise RuntimeError("mutation did not change source")
+            results["cases"][case] = {"source": str(source.relative_to(root)), "original_sha256": sha(original), "mutant_sha256": sha(changed), "restored": False}
+            persist()
+            try:
+                source.write_bytes(changed)
+                build(case + "-mutant-build")
+                if case == "sweep":
+                    # This arm is overdetermined by abort_upload, and must
+                    # remain green when only the backend sweep is removed.
+                    witness("sweep-live-mutant", "live")
+                witness(case + "-mutant", case, red=True)
+            finally:
+                source.write_bytes(original)
+                results["cases"][case]["restored"] = source.read_bytes() == original
+                persist()
+                build(case + "-restored-build")
+                witness(case + "-restored", case)
+                if case == "sweep":
+                    witness("sweep-live-restored", "live")
+    except BaseException as error:
+        results["status"] = "FAIL"
+        results["error"] = repr(error)
+        raise
+    finally:
+        for path, original in originals.items():
+            if path.read_bytes() != original:
+                path.write_bytes(original)
+        results["final_source_sha256"] = {
+            str(path.relative_to(root)): sha(path.read_bytes()) for path in originals
+        }
+        results["final_git_status"] = subprocess.check_output(["git", "status", "--porcelain"], cwd=root, text=True)
+        persist()
+    if results["final_git_status"]:
+        results["status"] = "FAIL"
+        persist()
+        raise RuntimeError("mutation run left a dirty source tree")
+    results["status"] = "PASS"
+    persist()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-blob-upload-mutations.py
+++ b/scripts/test-blob-upload-mutations.py
@@ -3,14 +3,20 @@
 
 Requires an isolated clean checkout, an explicit native CARGO_TARGET_DIR and
 Python pytest/pydantic/blake3 dependencies. Use a fresh --out outside the checkout.
---case all runs ADR-173's four
-mutation operators. --case owner additionally proves daemon cleanup ownership
-by leaving the timer and heartbeat alive while suppressing its sweep call.
+--case all runs all five controls, including daemon cleanup ownership.
+--case owner runs that control alone, leaving the timer and heartbeat alive
+while suppressing its sweep call. Rustup selects the pinned toolchain explicitly.
 Every case retains raw logs and rebuilds the restored source before succeeding.
+
+Run with Python dependencies in the same interpreter:
+uv run --no-project --with 'pytest>=8' --with 'pydantic>=2.7' --with 'blake3>=1' \
+python scripts/test-blob-upload-mutations.py --root CHECKOUT --head REVISION \
+--binary TARGET/debug/kkernel --out FRESH_DIRECTORY
 """
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -19,18 +25,26 @@ import subprocess
 import sys
 
 
+CASES = ("tail", "expiry", "sweep", "publisher", "owner")
+
+
 def sha(data):
     return hashlib.sha256(data).hexdigest()
 
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("--root", type=Path, required=True)
     parser.add_argument("--head", required=True)
     parser.add_argument("--binary", type=Path, required=True)
     parser.add_argument("--out", type=Path, required=True)
-    parser.add_argument("--case", choices=["all", "tail", "expiry", "sweep", "publisher", "owner"], default="all")
+    parser.add_argument("--case", choices=("all", *CASES), default="all")
     args = parser.parse_args()
+    missing = [name for name in ("pytest", "pydantic", "blake3") if importlib.util.find_spec(name) is None]
+    if missing:
+        parser.error(f"missing Python dependencies: {', '.join(missing)}; use the uv command in --help")
     root, binary, out = args.root.resolve(), args.binary.resolve(), args.out.resolve()
     out.mkdir(parents=True, exist_ok=False)
     head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
@@ -53,7 +67,8 @@ def main():
     target = target_dir.resolve() / "debug" / "kkernel"
     if env.get("CARGO_BUILD_TARGET") or binary != target:
         raise RuntimeError(f"select the native build output {target} with no CARGO_BUILD_TARGET")
-    results = {"head": head, "root": str(root), "target": env["CARGO_TARGET_DIR"], "commands": [], "cases": {}, "status": "INCOMPLETE"}
+    cases = CASES if args.case == "all" else (args.case,)
+    results = {"head": head, "root": str(root), "target": env["CARGO_TARGET_DIR"], "selected_cases": cases, "commands": [], "cases": {}, "status": "INCOMPLETE"}
 
     def persist():
         (out / "results.json").write_text(json.dumps(results, indent=2) + "\n")
@@ -72,7 +87,7 @@ def main():
         return text
 
     def build(name):
-        run(name, ["cargo", "+1.95.0", "build", "--manifest-path", "crates/Cargo.toml", "--locked", "-p", "kkernel"], 0)
+        run(name, ["rustup", "run", "1.95.0", "cargo", "build", "--manifest-path", "crates/Cargo.toml", "--locked", "-p", "kkernel"], 0)
         if not binary.is_file():
             raise RuntimeError("selected candidate binary was not produced")
         target = Path(env["CARGO_TARGET_DIR"]).resolve() / "debug" / "kkernel"
@@ -128,7 +143,6 @@ def main():
         end = text.index("        match failure {", start)
         return (text[:start] + "        let _ = store; // backend staging sweep deliberately removed\n" + text[end:]).encode()
 
-    cases = ["tail", "expiry", "sweep", "publisher"] if args.case == "all" else [args.case]
     try:
         for case in cases:
             if case == "publisher":

--- a/scripts/test-blob-upload-mutations.py
+++ b/scripts/test-blob-upload-mutations.py
@@ -3,7 +3,9 @@
 
 Requires an isolated clean checkout, an explicit native CARGO_TARGET_DIR and
 Python pytest/pydantic/blake3 dependencies. Use a fresh --out outside the checkout.
---case all runs all five controls, including daemon cleanup ownership.
+--case all runs all six controls, including daemon cleanup ownership and the
+total active-upload ceiling. --case cap suppresses only the total-cap guard;
+its wire witness keeps the per-actor ceiling above the rejected begin.
 --case owner runs that control alone, leaving the timer and heartbeat alive
 while suppressing its sweep call. Rustup selects the pinned toolchain explicitly.
 Every case retains raw logs and rebuilds the restored source before succeeding.
@@ -25,7 +27,7 @@ import subprocess
 import sys
 
 
-CASES = ("tail", "expiry", "sweep", "publisher", "owner")
+CASES = ("tail", "expiry", "sweep", "publisher", "owner", "cap")
 
 
 def sha(data):
@@ -101,6 +103,7 @@ def main():
         "sweep": "test_blob_upload_wire_restart_orphan_sweep_and_begin_again",
         "live": "test_blob_upload_wire_daemon_expiry_without_verbs_keeps_committed_object",
         "owner": "test_blob_upload_wire_daemon_owns_expiry_after_mcp_client_exit",
+        "cap": "test_blob_upload_wire_total_active_cap_refuses_and_abort_releases_slot",
     }
 
     def witness(label, name, red=False):
@@ -113,6 +116,10 @@ def main():
             r"^E\s+AssertionError: unexpectedly accepted blob\.put_part:", text, re.MULTILINE
         ):
             raise RuntimeError(f"{label}: failure was not acceptance of the refused write")
+        if red and name == "cap" and not re.search(
+            r"^E\s+AssertionError: unexpectedly accepted blob\.begin:", text, re.MULTILINE
+        ):
+            raise RuntimeError(f"{label}: failure was not acceptance above the total upload ceiling")
         if red and name in ("sweep", "owner") and not re.search(
             r"^E\s+AssertionError: daemon did not expire ", text, re.MULTILINE
         ):
@@ -139,6 +146,8 @@ def main():
             return replace_one(changed, "let (tail_len, tail_hash)", "let (tail_len, _tail_hash)").encode()
         if case == "expiry":
             return replace_one(text, "if record.last_part.elapsed() >= self.policy.idle_for {", "if false {").encode()
+        if case == "cap":
+            return replace_one(text, "if total >= policy.max_active {", "if false {").encode()
         start = text.index("        match store.sweep_uploads(self.policy.idle_for).await {")
         end = text.index("        match failure {", start)
         return (text[:start] + "        let _ = store; // backend staging sweep deliberately removed\n" + text[end:]).encode()

--- a/scripts/test-blob-upload-publish-control.py
+++ b/scripts/test-blob-upload-publish-control.py
@@ -1,0 +1,60 @@
+"""A copied blob publisher must fail the shared-publication construction witness.
+
+Run in an isolated checkout; the mutation driver checks its head and clean state.
+"""
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--root", type=Path, required=True)
+parser.add_argument("--out", type=Path, required=True)
+args = parser.parse_args()
+root, out = args.root.resolve(), args.out.resolve()
+out.mkdir(parents=True, exist_ok=False)
+target = root / "crates/khive-db/src/stores/blob_uploads.rs"
+original = target.read_bytes()
+source = (root / "crates/khive-db/src/stores/blob.rs").read_bytes()
+anchor = b"            publish_blob_at(\n"
+assert original.count(anchor) == 1, "commit call must be unique"
+start = source.index(b"fn publish_blob_at(")
+assert source.count(b"fn publish_blob_at(") == 1
+opening = source.index(b"{", start)
+depth = 1
+closing = opening + 1
+while depth:
+    byte = source[closing]
+    depth += (byte == ord("{")) - (byte == ord("}"))
+    closing += 1
+copy = source[start:closing].replace(b"fn publish_blob_at(", b"fn publish_upload_copy(", 1)
+mutant = original.replace(anchor, b"            publish_upload_copy(\n", 1)
+mutant += b"\n#[cfg(unix)]\n" + copy + b"\n"
+head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+base = ["cargo", "test", "--manifest-path", "crates/Cargo.toml", "--locked", "-p", "khive-db", "--lib"]
+green = base + ["stores::blob::uploads::tests", "--", "--nocapture"]
+red = base + ["stores::blob::uploads::tests::upload_put_and_commit_share_the_publish_routine", "--", "--exact", "--nocapture"]
+evidence = {"head": head, "original_sha256": hashlib.sha256(original).hexdigest(), "mutant_sha256": hashlib.sha256(mutant).hexdigest()}
+
+def run(name, command):
+    result = subprocess.run(command, cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    (out / (name + ".log")).write_text(result.stdout)
+    return {"command": command, "returncode": result.returncode, "selected": [int(n) for n in re.findall(r"running (\d+) tests?\b", result.stdout)]}, result.stdout
+
+try:
+    evidence["before"], log = run("publisher-before", green)
+    assert evidence["before"]["returncode"] == 0 and evidence["before"]["selected"] == [11], log
+    target.write_bytes(mutant)
+    evidence["mutant"], log = run("publisher-mutant", red)
+    evidence["valid_red"] = (evidence["mutant"]["returncode"] == 101 and evidence["mutant"]["selected"] == [1]
+        and "test result: FAILED." in log and "left: 0" in log and "right: 1" in log)
+    assert evidence["valid_red"], log
+finally:
+    target.write_bytes(original)
+    evidence["bytes_restored"] = target.read_bytes() == original
+    evidence["restored"], log = run("publisher-restored", green)
+    (out / "control.json").write_text(json.dumps(evidence, indent=2) + "\n")
+assert evidence["restored"]["returncode"] == 0 and evidence["restored"]["selected"] == [11], log
+print(json.dumps(evidence, indent=2))

--- a/scripts/test-blob-upload-publish-control.py
+++ b/scripts/test-blob-upload-publish-control.py
@@ -33,7 +33,7 @@ copy = source[start:closing].replace(b"fn publish_blob_at(", b"fn publish_upload
 mutant = original.replace(anchor, b"            publish_upload_copy(\n", 1)
 mutant += b"\n#[cfg(unix)]\n" + copy + b"\n"
 head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
-base = ["cargo", "test", "--manifest-path", "crates/Cargo.toml", "--locked", "-p", "khive-db", "--lib"]
+base = ["rustup", "run", "1.95.0", "cargo", "test", "--manifest-path", "crates/Cargo.toml", "--locked", "-p", "khive-db", "--lib"]
 green = base + ["stores::blob::uploads::tests", "--", "--nocapture"]
 red = base + ["stores::blob::uploads::tests::upload_put_and_commit_share_the_publish_routine", "--", "--exact", "--nocapture"]
 evidence = {"head": head, "original_sha256": hashlib.sha256(original).hexdigest(), "mutant_sha256": hashlib.sha256(mutant).hexdigest()}

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -287,7 +287,7 @@ def main():
         # `kkernel code-ingest` admin CLI, never this MCP verb surface);
         # workspace (#873) contributes zero verbs, adding only the
         # `workspace` entity kind and `contains` endpoint rules; blob
-        # contributes three verbs (blob.put / blob.get / blob.stat, ADR-111)
+        # contributes seven verbs (put/get/stat and begin/put_part/commit/abort, ADR-173)
         # over the `BlobStore` CAS trait, unconfigured (erroring at dispatch)
         # until a backend is installed via [storage.blob] or KHIVE_BLOB_ROOT.
         # The kg pack also carries its one documented sub-namespace,
@@ -300,8 +300,8 @@ def main():
         # with use policy and sandboxed runs over trees).
         # Update this number when the pack set or verb surface changes; a
         # silent drift here is the bug this assertion exists to catch.
-        assert verbs_result["total"] == 129, (
-            f"expected 129 user-facing verbs from the 14 default packs "
+        assert verbs_result["total"] == 133, (
+            f"expected 133 user-facing verbs from the 14 default packs "
             f"(session contributes 4 T1 verbs promoted to Visibility::Verb per "
             f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089; "
             f"resolve is the 18th kg-substrate bare verb per the unified-verb "
@@ -313,7 +313,7 @@ def main():
             f"git.commit/git.branch/git.push (ADR-108); "
             f"code contributes code.ingest per ADR-085 Amendment 2 (PR #1039); "
             f"workspace (#873) contributes zero verbs; "
-            f"blob contributes blob.put/blob.get/blob.stat per ADR-111; "
+            f"blob contributes put/get/stat and begin/put_part/commit/abort per ADR-173; "
             f"brain.mark_turn is the per-actor work-unit marker; "
             f"comm.unread lists unread inbound messages; comm.mark_read is the "
             f"named atomic-capable mark-read surface; comm.delivered confirms "


### PR DESCRIPTION
Large objects could only arrive as one base64 payload, which meant the 64 MiB object ceiling and the daemon frame limit were the same limit in practice: anything that did not fit in a single request could not be stored at all. This adds a staged upload path so a caller can send an object in parts, and gives the daemon ownership of cleaning up what a caller abandons.

**Four verbs.** `blob.begin(size, content_ref?)` opens staging and returns `{upload_id, part_limit, next_index}`; if the optional reference already exists it returns `{content_ref, size}` and stages nothing. `blob.put_part(upload_id, index, bytes)` takes parts in order and returns `{next_index, received_bytes}`. `blob.commit(upload_id)` requires exactly the declared length, verifies the expected reference when one was given, and publishes through the backend's existing routine. `blob.abort(upload_id)` removes staging. `part_limit` is derived from the live request-parser and frame caps rather than hard-coded, minus an 8192-byte request reserve, scaled by three quarters.

**Retries are the interesting case, and they are decided by content.** An identical resend of the last part is acknowledged without changing bytes, hash, index or activity time, so a caller that did not see the response can repeat it safely. A tail whose bytes differ aborts the upload rather than silently accepting a second version of the same index. Crossing the declared size aborts. A successful append records activity from *before* the backend write, so a slow sync cannot push the pack's clock past a stage that is already expiring.

**Expiry belongs to the daemon.** Only the daemon starts the sweep component; each tick expires pack records and asks the backend to sweep orphan staging under the same idle policy the verbs use, and it joins the existing cancellation and drain path. `KHIVE_BLOB_UPLOAD_IDLE_SECS` defaults to 3600 and `KHIVE_BLOB_UPLOAD_SWEEP_INTERVAL_SECS` to 600; an invalid value warns and uses the default. Staging lives below `.uploads/`, which object GC ignores. There is no upload journal, so a restarted daemon answers unknown upload, which is stated as a contract rather than left to be discovered.

Upload ids are capabilities. The originating actor is kept for attribution and is not an ownership restriction. All four verbs refuse on a read-only runtime, and abort and expiry remove staging only: deleting or sweeping committed objects stays administrator-only. A backend without staged-upload support returns Unsupported from the storage contract.

**Acceptance items 5 and 6 are covered by real daemon controls**, not by unit fakes: `python/tests/test_blob_upload_wire_integration.py` drives a scratch daemon over the wire, and `scripts/test-blob-upload-mutations.py` is the harness that proves those controls are load-bearing. Each case builds the binary, witnesses the arm green, applies one named source mutation, requires the arm to fail *with its specific assertion message* rather than merely to fail, restores the source, and witnesses it green again. It refuses to start on a dirty tree or an unset target directory, and fails the run if it leaves one.

All mutation cases were run and each behaved: the tail guard, the verb idle guard, the backend staging sweep, the publication control, and daemon ownership of expiry. The sweep case carries a deliberately overdetermined companion arm that must stay green when only the backend sweep is removed, which is what keeps the isolating arm honest.

**Staged uploads are bounded.** `blob.begin` checked the declared size and nothing else, so a caller repeating `blob.begin(0)` could accumulate records and staging entries without ever sending a byte, reclaimed only by the idle sweep an hour later. There is now a ceiling on both axes: 128 uploads in flight overall and 16 per actor, overridable with `KHIVE_BLOB_UPLOAD_MAX_ACTIVE` and `KHIVE_BLOB_UPLOAD_MAX_PER_ACTOR`, and a caller past either one is refused by name rather than admitted. The slot is reserved before the backend call and released when the upload commits, aborts or is swept, so a cancelled caller cannot leave one held and a stale record cannot keep one. The known-reference shortcut, which stages nothing, does not consume a slot. These are process-local bounds, not persistent disk quotas, and the documentation says so.

A sixth mutation case covers the ceiling on the same terms as the other five: with the limits lowered to two overall and three per actor, the arm passes, removing the total guard makes it fail with `unexpectedly accepted blob.begin:`, and restoring the source makes it pass again, with the file's hash checked before and after.

**One limitation ships named rather than fixed.** On Unix these paths open relative to a retained root descriptor with calls that refuse to follow symlinks, so nothing can be substituted between the check and the use. On other platforms they validate the path and then resolve it again, which a local process able to write inside the blob root can exploit with a junction or a reparse point to redirect an operation outside it. The trust boundary is stated to match, in the module that has the behaviour, in the pack's design document and in the changelog: the blob root, its contents and its ancestors must be writable only by trusted processes, including processes running under the same account. A handle-based replacement needs coverage of concurrent swaps on the affected platform across begin, append, commit, abort and sweep before it can be believed, and the hosted matrix does not run that platform, so writing it blind would produce a fix nobody could check. It is tracked.
