### PR TITLE
fix(kg): delete reports the kind it resolved, not the one it was handed

### DIFF
--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -3138,3 +3138,116 @@ async fn every_kg_write_emits_its_domain_event() {
         );
     }
 }
+
+/// `delete` names what it removed. The response `kind` used to be the caller's own
+/// request parameter handed back, so a delete by a bare id or a hex prefix answered
+/// `null` and a delete that named a kind answered that same string whatever the row
+/// turned out to be. Neither value carried anything the server resolved, which is the
+/// one thing a caller cannot work out for itself after the row is gone.
+#[tokio::test]
+async fn delete_reports_the_kind_it_resolved_not_the_one_it_was_given() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+    let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+    // Entity, deleted by a bare id: the caller named no kind at all.
+    let entity = rt
+        .create_entity(
+            &token,
+            "concept",
+            None,
+            "resolved kind subject",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create entity");
+    let out = registry
+        .dispatch("delete", json!({"id": entity.id.to_string()}))
+        .await
+        .expect("delete by bare id must succeed");
+    assert_eq!(out["deleted"], json!(true));
+    assert_eq!(
+        out["kind"],
+        json!("concept"),
+        "a bare-id delete must report the kind the row carried, not null: {out}"
+    );
+
+    // Note, deleted by a bare id: the other substrate, same question.
+    let note = rt
+        .create_note(
+            &token,
+            "insight",
+            None,
+            "resolved kind note",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+    let out = registry
+        .dispatch("delete", json!({"id": note.id.to_string()}))
+        .await
+        .expect("delete note by bare id must succeed");
+    assert_eq!(out["kind"], json!("insight"), "note kind: {out}");
+
+    // Deleted with the generic spelling: the specific kind still comes back. This is
+    // the arm the old code passed by accident, because it echoed "entity" verbatim.
+    let generic = rt
+        .create_entity(
+            &token,
+            "project",
+            None,
+            "generic spelling subject",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create entity");
+    let out = registry
+        .dispatch(
+            "delete",
+            json!({"id": generic.id.to_string(), "kind": "entity"}),
+        )
+        .await
+        .expect("delete with the generic kind must succeed");
+    assert_eq!(
+        out["kind"],
+        json!("project"),
+        "a generic `entity` request must resolve to the specific kind: {out}"
+    );
+
+    // The mismatch guard is unchanged: naming the wrong kind still refuses, and this
+    // arm is what stops the fix from being read as "kind is now ignored".
+    let guarded = rt
+        .create_entity(
+            &token,
+            "concept",
+            None,
+            "mismatch subject",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create entity");
+    let err = registry
+        .dispatch(
+            "delete",
+            json!({"id": guarded.id.to_string(), "kind": "project"}),
+        )
+        .await
+        .expect_err("a kind that does not match the row must refuse");
+    assert!(
+        format!("{err}").contains("kind mismatch"),
+        "expected a kind mismatch refusal, got: {err}"
+    );
+}

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -408,31 +408,38 @@ impl KgPack {
                         )));
                     }
                 }
+                // Report the kind the row carries, not the one the caller typed. The row
+                // was read a few lines up to enforce the mismatch guard, so this costs
+                // nothing, and a caller who deleted by a bare id or a hex prefix learns
+                // what it actually removed.
+                let resolved_kind = entity.kind.clone();
                 let deleted = self.runtime.delete_entity(token, id, hard).await?;
                 if !deleted {
                     return Err(RuntimeError::NotFound(format!("entity {}", p.id)));
                 }
-                to_json(&serde_json::json!({ "deleted": deleted, "id": p.id, "kind": p.kind }))
+                to_json(
+                    &serde_json::json!({ "deleted": deleted, "id": p.id, "kind": resolved_kind }),
+                )
             }
             KindSpec::Note { specific } => {
+                // Read the row whether or not the caller named a kind. It used to be read
+                // only to enforce the mismatch guard, which meant the response could
+                // report a kind only when the caller had already supplied one.
+                let label = specific.as_deref().unwrap_or("note");
+                let note = if hard {
+                    self.runtime
+                        .get_note_including_deleted(token, id)
+                        .await?
+                        .ok_or_else(|| RuntimeError::NotFound(format!("{} {}", label, p.id)))?
+                } else {
+                    self.runtime
+                        .notes(token)?
+                        .get_note(id)
+                        .await
+                        .map_err(RuntimeError::Storage)?
+                        .ok_or_else(|| RuntimeError::NotFound(format!("{} {}", label, p.id)))?
+                };
                 if let Some(ref expected) = specific {
-                    let note = if hard {
-                        self.runtime
-                            .get_note_including_deleted(token, id)
-                            .await?
-                            .ok_or_else(|| {
-                                RuntimeError::NotFound(format!("{} {}", expected, p.id))
-                            })?
-                    } else {
-                        self.runtime
-                            .notes(token)?
-                            .get_note(id)
-                            .await
-                            .map_err(RuntimeError::Storage)?
-                            .ok_or_else(|| {
-                                RuntimeError::NotFound(format!("{} {}", expected, p.id))
-                            })?
-                    };
                     if note.kind != *expected {
                         return Err(RuntimeError::InvalidInput(format!(
                             "kind mismatch: {} exists with kind '{}', not '{}'",
@@ -440,11 +447,14 @@ impl KgPack {
                         )));
                     }
                 }
+                let resolved_kind = note.kind.clone();
                 let deleted = self.runtime.delete_note(token, id, hard).await?;
                 if !deleted {
                     return Err(RuntimeError::NotFound(format!("note {}", p.id)));
                 }
-                to_json(&serde_json::json!({ "deleted": deleted, "id": p.id, "kind": p.kind }))
+                to_json(
+                    &serde_json::json!({ "deleted": deleted, "id": p.id, "kind": resolved_kind }),
+                )
             }
             KindSpec::Edge => {
                 let deleted = self.runtime.delete_edge(token, id, hard).await?;

--- a/crates/khive-runtime/src/reference_ring.rs
+++ b/crates/khive-runtime/src/reference_ring.rs
@@ -231,10 +231,12 @@ fn is_entity_kind_value(v: &str) -> bool {
 ///   a `content` key: the two shapes never overlap, so key presence alone
 ///   is a reliable substrate discriminator.
 /// - `delete` returns a synthetic `{deleted, id, kind}` summary carrying
-///   neither field; its `kind` is the caller-supplied request param verbatim,
-///   which may be absent/ambiguous. Absent or ambiguous `kind` never admits:
-///   a delete admission is a nice-to-have, so skipping is always the safe
-///   choice over guessing.
+///   neither field; its `kind` is the one the handler RESOLVED off the row
+///   before removing it, so a caller who deleted by a bare id or a hex prefix
+///   still names a substrate here. A pack resolver's own delete path can still
+///   answer without one. An absent or unrecognised `kind` never admits: a
+///   delete admission is a nice-to-have, so skipping is always the safe choice
+///   over guessing.
 fn substrate_admits_as_entity(obj: &serde_json::Map<String, Value>) -> bool {
     if matches!(
         obj.get("kind").and_then(Value::as_str),
@@ -360,10 +362,11 @@ mod tests {
     }
 
     #[test]
-    fn ring_admissions_for_delete_uses_echoed_kind_param() {
+    fn ring_admissions_for_delete_uses_resolved_kind() {
         let id = Uuid::new_v4();
         // delete's synthetic summary has neither `content` nor `entity_type`;
-        // it falls back to the caller-echoed `kind` param.
+        // it falls back to `kind`, which the handler resolves off the row it
+        // removed rather than echoing back what the caller typed.
         let entity_delete = json!({"deleted": true, "id": id.to_string(), "kind": "concept"});
         assert_eq!(
             ring_admissions_for("delete", &entity_delete),
@@ -377,6 +380,8 @@ mod tests {
         );
         let note_delete = json!({"deleted": true, "id": id.to_string(), "kind": "observation"});
         assert!(ring_admissions_for("delete", &note_delete).is_empty());
+        // A pack resolver's own delete path answers without a kind. That still
+        // has to skip rather than guess, so the arm stays.
         let unspecified_delete = json!({"deleted": true, "id": id.to_string(), "kind": null});
         assert!(ring_admissions_for("delete", &unspecified_delete).is_empty());
     }


### PR DESCRIPTION
`delete`'s response `kind` was the caller's own request parameter handed straight back:

```
delete(id=X, kind="note")  ->  {deleted: true, id: X, kind: "note"}
delete(id=X)               ->  {deleted: true, id: X, kind: null}
```

Deleting by a bare id or a hex prefix answered `null`, and naming a kind answered that same string whatever the row turned out to be. Neither value carried anything the server resolved, which is the one thing a caller cannot work out for itself once the row is gone. On a destructive call against an id that came from a prefix or a name, a populated field that only repeats the caller reads as confirmation and confirms nothing, which is worse than an empty one: an empty field invites someone to fill it.

Both substrates now report the kind read off the row. The entity branch already had it in hand, since the row is read a few lines earlier to enforce the mismatch guard. The note branch read the row only when the caller named a kind, which is exactly why it could answer only in the case where it had nothing to add; it now reads it either way and the guard applies to the same value. The edge branch already answered `edge` rather than an echo, so the three branches now agree on what the field means.

**This field has a reader, and its documented contract changes.** `reference_ring.rs` decides from the response alone whether a delete admits an id to the ring, and its doc comment said in as many words that the value is the request parameter verbatim and therefore never admits. That sentence was the contract, so it is corrected in the same change rather than left for someone to find: a delete by bare id now names a substrate, and the ring admits entity kinds accordingly. The arm covering an absent `kind` stays, because a pack resolver's own delete path still answers without one and guessing there is worse than skipping.

The test covers a bare-id entity delete, a bare-id note delete, a delete naming the generic `entity` spelling which must still resolve to the specific kind, and the mismatch refusal. That last arm is what stops the change from being read as the `kind` parameter now being ignored.
