### PR TITLE
refactor(git): move the pack's SQL statements into files

### DIFF
--- a/crates/khive-pack-git/sql/code_modules_by_snapshot_path_select.sql
+++ b/crates/khive-pack-git/sql/code_modules_by_snapshot_path_select.sql
@@ -1,0 +1,6 @@
+SELECT id, json_extract(properties,'$.source_path') AS source_path
+FROM entities WHERE kind='concept' AND entity_type='module'
+AND namespace=?1 AND deleted_at IS NULL
+AND json_type(properties,'$.source_path')='text'
+AND json_extract(properties,'$.source_revision')=?2
+ORDER BY source_path, id

--- a/crates/khive-pack-git/sql/commit_checkpoint_select.sql
+++ b/crates/khive-pack-git/sql/commit_checkpoint_select.sql
@@ -1,0 +1,3 @@
+SELECT
+    (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind='commits') AS cursor,
+    (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind='commits_checkpoint') AS progress

--- a/crates/khive-pack-git/sql/commit_checkpoint_upsert.sql
+++ b/crates/khive-pack-git/sql/commit_checkpoint_upsert.sql
@@ -1,0 +1,5 @@
+INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at)
+VALUES(?1, 'commits_checkpoint', ?2, ?4), (?1, 'commits', ?3, ?4)
+ON CONFLICT(project_id, kind) DO UPDATE SET
+cursor_value=excluded.cursor_value,
+updated_at=excluded.updated_at

--- a/crates/khive-pack-git/sql/commit_notes_for_project_count.sql
+++ b/crates/khive-pack-git/sql/commit_notes_for_project_count.sql
@@ -1,0 +1,4 @@
+SELECT COUNT(*) FROM notes n
+JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace
+WHERE n.kind = 'commit' AND n.namespace = ?1 AND n.deleted_at IS NULL
+AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL

--- a/crates/khive-pack-git/sql/commits_by_sha_select.sql
+++ b/crates/khive-pack-git/sql/commits_by_sha_select.sql
@@ -1,0 +1,2 @@
+SELECT id FROM notes WHERE kind='commit' AND namespace=?1
+AND deleted_at IS NULL AND json_extract(properties,'$.sha')=?2 LIMIT 1

--- a/crates/khive-pack-git/sql/documents_by_path_select.sql
+++ b/crates/khive-pack-git/sql/documents_by_path_select.sql
@@ -1,0 +1,7 @@
+SELECT id FROM entities WHERE kind='document' AND namespace=?1
+AND deleted_at IS NULL
+AND (json_extract(properties,'$.source_uri')=?2 OR name=?3
+     OR json_extract(properties,'$.source_uri') LIKE ?4 ESCAPE '\')
+ORDER BY CASE WHEN json_extract(properties,'$.source_uri')=?2 OR name=?3
+              THEN 0 ELSE 1 END, id
+LIMIT 1

--- a/crates/khive-pack-git/sql/git_mirror_cursor_table_create.sql
+++ b/crates/khive-pack-git/sql/git_mirror_cursor_table_create.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS git_mirror_cursor (
+    project_id   TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    cursor_value TEXT,
+    updated_at   INTEGER NOT NULL,
+    PRIMARY KEY (project_id, kind)
+)

--- a/crates/khive-pack-git/sql/git_mirror_cursor_updated_index_create.sql
+++ b/crates/khive-pack-git/sql/git_mirror_cursor_updated_index_create.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_git_mirror_cursor_updated
+ON git_mirror_cursor(updated_at DESC)

--- a/crates/khive-pack-git/sql/git_receipts_insert.sql
+++ b/crates/khive-pack-git/sql/git_receipts_insert.sql
@@ -1,0 +1,3 @@
+INSERT INTO git_receipts (id, namespace, actor, session_id, verb, repo, inputs, gate, policy,
+    fork_policy, credential, started_at, finished_at, disposition, result, reason)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)

--- a/crates/khive-pack-git/sql/git_receipts_owned_list.sql
+++ b/crates/khive-pack-git/sql/git_receipts_owned_list.sql
@@ -1,0 +1,5 @@
+SELECT id, namespace, actor, session_id, verb, repo, inputs, gate, policy,
+    fork_policy, credential, started_at, finished_at, disposition, result, reason
+FROM git_receipts WHERE namespace = ?1 AND actor = ?2
+AND (?3 IS NULL OR repo = ?3) AND (?4 IS NULL OR session_id = ?4)
+ORDER BY rowid ASC LIMIT ?5 OFFSET ?6

--- a/crates/khive-pack-git/sql/git_receipts_owned_select.sql
+++ b/crates/khive-pack-git/sql/git_receipts_owned_select.sql
@@ -1,0 +1,3 @@
+SELECT id, namespace, actor, session_id, verb, repo, inputs, gate, policy,
+    fork_policy, credential, started_at, finished_at, disposition, result, reason
+FROM git_receipts WHERE namespace = ?1 AND actor = ?2 AND id = ?3

--- a/crates/khive-pack-git/sql/git_receipts_persist.sql
+++ b/crates/khive-pack-git/sql/git_receipts_persist.sql
@@ -1,0 +1,5 @@
+UPDATE git_receipts SET gate = ?1, policy = ?2, fork_policy = ?3,
+credential = ?4, finished_at = ?5, disposition = ?6, result = ?7, reason = ?8
+WHERE id = ?9 AND namespace = ?10 AND actor = ?11 AND disposition = 'unknown'
+AND session_id IS ?12 AND verb = ?13 AND repo = ?14 AND inputs = ?15
+AND started_at = ?16

--- a/crates/khive-pack-git/sql/ingest_cursor_snapshot_select.sql
+++ b/crates/khive-pack-git/sql/ingest_cursor_snapshot_select.sql
@@ -1,0 +1,4 @@
+SELECT kind, updated_at, typeof(cursor_value) AS value_type,
+length(CAST(cursor_value AS BLOB)) AS value_bytes,
+CASE WHEN length(CAST(cursor_value AS BLOB)) <= ?4 THEN CAST(cursor_value AS BLOB) END AS value
+FROM git_mirror_cursor WHERE project_id=?1 AND kind IN (?2, ?3)

--- a/crates/khive-pack-git/sql/notes_by_number_select.sql
+++ b/crates/khive-pack-git/sql/notes_by_number_select.sql
@@ -1,0 +1,3 @@
+SELECT id FROM notes WHERE kind=?1 AND namespace=?2
+AND deleted_at IS NULL AND json_extract(properties,'$.number')=?3
+AND json_extract(properties,'$.project_id')=?4 LIMIT 1

--- a/crates/khive-pack-git/sql/orphaned_project_notes_count.sql
+++ b/crates/khive-pack-git/sql/orphaned_project_notes_count.sql
@@ -1,0 +1,5 @@
+SELECT COUNT(*) FROM notes n
+JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace
+WHERE n.namespace = ?1 AND n.deleted_at IS NULL
+AND n.kind IN ('commit', 'issue', 'pull_request')
+AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL

--- a/crates/khive-pack-git/sql/orphaned_projects_select.sql
+++ b/crates/khive-pack-git/sql/orphaned_projects_select.sql
@@ -1,0 +1,4 @@
+SELECT id, deleted_at FROM entities WHERE kind='project' AND namespace=?1
+AND deleted_at IS NOT NULL
+AND (json_extract(properties,'$.repo_slug')=?2
+     OR json_extract(properties,'$.repo_url')=?3)

--- a/crates/khive-pack-git/sql/page_checkpoint_select.sql
+++ b/crates/khive-pack-git/sql/page_checkpoint_select.sql
@@ -1,0 +1,3 @@
+SELECT
+    (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2) AS floor,
+    (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?3) AS progress

--- a/crates/khive-pack-git/sql/page_checkpoint_with_floor_upsert.sql
+++ b/crates/khive-pack-git/sql/page_checkpoint_with_floor_upsert.sql
@@ -1,0 +1,4 @@
+INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at)
+VALUES(?1, ?2, ?3, ?4), (?1, ?5, ?6, ?4)
+ON CONFLICT(project_id, kind) DO UPDATE SET
+cursor_value=excluded.cursor_value, updated_at=excluded.updated_at

--- a/crates/khive-pack-git/sql/page_checkpoint_without_floor_upsert.sql
+++ b/crates/khive-pack-git/sql/page_checkpoint_without_floor_upsert.sql
@@ -1,0 +1,4 @@
+INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at)
+VALUES(?1, ?2, ?3, ?4)
+ON CONFLICT(project_id, kind) DO UPDATE SET
+cursor_value=excluded.cursor_value, updated_at=excluded.updated_at

--- a/crates/khive-pack-git/sql/pr_open_receipts_by_number_select.sql
+++ b/crates/khive-pack-git/sql/pr_open_receipts_by_number_select.sql
@@ -1,0 +1,1 @@
+SELECT actor, credential FROM git_receipts WHERE namespace=?1 AND repo=?2 AND verb='git.pr_open' AND disposition != 'not_committed' AND json_extract(result,'$.number')=?3 LIMIT 1001

--- a/crates/khive-pack-git/sql/projects_by_legacy_repo_url_select.sql
+++ b/crates/khive-pack-git/sql/projects_by_legacy_repo_url_select.sql
@@ -1,0 +1,5 @@
+SELECT id FROM entities WHERE kind='project' AND namespace=?1
+AND deleted_at IS NULL
+AND json_extract(properties,'$.repo_slug') IS NULL
+AND json_extract(properties,'$.repo_url')=?2
+ORDER BY created_at ASC, id ASC

--- a/crates/khive-pack-git/sql/projects_by_slug_select.sql
+++ b/crates/khive-pack-git/sql/projects_by_slug_select.sql
@@ -1,0 +1,4 @@
+SELECT id FROM entities WHERE kind='project' AND namespace=?1
+AND deleted_at IS NULL
+AND json_extract(properties,'$.repo_slug')=?2
+ORDER BY created_at ASC, id ASC

--- a/crates/khive-pack-git/sql/projects_without_canonical_slug_select.sql
+++ b/crates/khive-pack-git/sql/projects_without_canonical_slug_select.sql
@@ -1,0 +1,7 @@
+SELECT id, json_extract(properties,'$.repo_url') AS repo_url
+FROM entities WHERE kind='project' AND namespace=?1
+AND deleted_at IS NULL
+AND json_extract(properties,'$.repo_url') IS NOT NULL
+AND (json_extract(properties,'$.repo_slug') IS NULL
+     OR json_extract(properties,'$.repo_slug')<>?2)
+ORDER BY created_at ASC, id ASC

--- a/crates/khive-pack-git/sql/push_receipts_by_head_select.sql
+++ b/crates/khive-pack-git/sql/push_receipts_by_head_select.sql
@@ -1,0 +1,5 @@
+SELECT id, repo, disposition, credential FROM git_receipts
+WHERE namespace=?1 AND verb='git.push' AND disposition IN ('committed','unknown')
+AND lower(json_extract(result,'$.sha'))=?2 AND json_extract(result,'$.ref')=?3
+AND lower(json_extract(result,'$.remote')) IN (?4,?5)
+ORDER BY rowid DESC LIMIT 1001

--- a/crates/khive-pack-git/sql/soft_deleted_projects_without_canonical_slug_select.sql
+++ b/crates/khive-pack-git/sql/soft_deleted_projects_without_canonical_slug_select.sql
@@ -1,0 +1,6 @@
+SELECT id, deleted_at, json_extract(properties,'$.repo_url') AS repo_url
+FROM entities WHERE kind='project' AND namespace=?1
+AND deleted_at IS NOT NULL
+AND json_extract(properties,'$.repo_url') IS NOT NULL
+AND (json_extract(properties,'$.repo_slug') IS NULL
+     OR json_extract(properties,'$.repo_slug')<>?2)

--- a/crates/khive-pack-git/src/handlers.rs
+++ b/crates/khive-pack-git/src/handlers.rs
@@ -22,6 +22,7 @@ use crate::source::{
     canonical_remote_identity, parse_source, redact_repo_url, remote_url_to_slug, repo_basename,
     repo_identity, DigestSource, REPO_SLUG_PROPERTY,
 };
+use crate::sql::sql;
 use crate::GitPack;
 
 /// Recover the typed error when a digest ingest/resolution failure chain
@@ -531,11 +532,7 @@ async fn find_projects_by_slug(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
-            sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
-                  AND deleted_at IS NULL \
-                  AND json_extract(properties,'$.repo_slug')=?2 \
-                  ORDER BY created_at ASC, id ASC"
-                .into(),
+            sql: sql!("projects_by_slug_select").into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(identity.to_string()),
@@ -572,12 +569,7 @@ async fn find_projects_by_legacy_repo_url(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
-            sql: "SELECT id FROM entities WHERE kind='project' AND namespace=?1 \
-                  AND deleted_at IS NULL \
-                  AND json_extract(properties,'$.repo_slug') IS NULL \
-                  AND json_extract(properties,'$.repo_url')=?2 \
-                  ORDER BY created_at ASC, id ASC"
-                .into(),
+            sql: sql!("projects_by_legacy_repo_url_select").into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(repo_url.to_string()),
@@ -610,14 +602,7 @@ async fn find_projects_without_canonical_slug(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
-            sql: "SELECT id, json_extract(properties,'$.repo_url') AS repo_url \
-                  FROM entities WHERE kind='project' AND namespace=?1 \
-                  AND deleted_at IS NULL \
-                  AND json_extract(properties,'$.repo_url') IS NOT NULL \
-                  AND (json_extract(properties,'$.repo_slug') IS NULL \
-                       OR json_extract(properties,'$.repo_slug')<>?2) \
-                  ORDER BY created_at ASC, id ASC"
-                .into(),
+            sql: sql!("projects_without_canonical_slug_select").into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(identity.to_string()),
@@ -657,13 +642,7 @@ async fn find_soft_deleted_projects_without_canonical_slug(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
-            sql: "SELECT id, deleted_at, json_extract(properties,'$.repo_url') AS repo_url \
-                  FROM entities WHERE kind='project' AND namespace=?1 \
-                  AND deleted_at IS NOT NULL \
-                  AND json_extract(properties,'$.repo_url') IS NOT NULL \
-                  AND (json_extract(properties,'$.repo_slug') IS NULL \
-                       OR json_extract(properties,'$.repo_slug')<>?2)"
-                .into(),
+            sql: sql!("soft_deleted_projects_without_canonical_slug_select").into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(identity.to_string()),
@@ -774,11 +753,7 @@ async fn find_orphaned_anchor(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
-            sql: "SELECT id, deleted_at FROM entities WHERE kind='project' AND namespace=?1 \
-                  AND deleted_at IS NOT NULL \
-                  AND (json_extract(properties,'$.repo_slug')=?2 \
-                       OR json_extract(properties,'$.repo_url')=?3)"
-                .into(),
+            sql: sql!("orphaned_projects_select").into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(identity.to_string()),
@@ -834,12 +809,7 @@ async fn find_orphaned_anchor(
     for dead_project_id in dead_project_ids {
         let count = r
             .query_scalar(SqlStatement {
-                sql: "SELECT COUNT(*) FROM notes n \
-                      JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace \
-                      WHERE n.namespace = ?1 AND n.deleted_at IS NULL \
-                      AND n.kind IN ('commit', 'issue', 'pull_request') \
-                      AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL"
-                    .into(),
+                sql: sql!("orphaned_project_notes_count").into(),
                 params: vec![
                     SqlValue::Text(token.namespace().as_str().to_string()),
                     SqlValue::Text(dead_project_id.to_string()),

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -20,6 +20,7 @@ use khive_storage::types::{SqlStatement, SqlValue};
 use crate::hook;
 use crate::refs;
 use crate::source::remote_url_to_slug;
+use crate::sql::sql;
 
 fn mask_git_ingest(text: &str) -> std::borrow::Cow<'_, str> {
     secret_gate::mask_for_redaction_surface(secret_gate::RedactionSurface::GitIngest, text)
@@ -1096,9 +1097,7 @@ async fn find_commit_by_sha(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
-            sql: "SELECT id FROM notes WHERE kind='commit' AND namespace=?1 \
-                  AND deleted_at IS NULL AND json_extract(properties,'$.sha')=?2 LIMIT 1"
-                .into(),
+            sql: sql!("commits_by_sha_select").into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(sha.to_string()),
@@ -1124,10 +1123,7 @@ async fn find_by_number(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
-            sql: "SELECT id FROM notes WHERE kind=?1 AND namespace=?2 \
-                  AND deleted_at IS NULL AND json_extract(properties,'$.number')=?3 \
-                  AND json_extract(properties,'$.project_id')=?4 LIMIT 1"
-                .into(),
+            sql: sql!("notes_by_number_select").into(),
             params: vec![
                 SqlValue::Text(kind.to_string()),
                 SqlValue::Text(token.namespace().as_str().to_string()),
@@ -1183,14 +1179,7 @@ async fn find_document_for_path(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
-            sql: "SELECT id FROM entities WHERE kind='document' AND namespace=?1 \
-                  AND deleted_at IS NULL \
-                  AND (json_extract(properties,'$.source_uri')=?2 OR name=?3 \
-                       OR json_extract(properties,'$.source_uri') LIKE ?4 ESCAPE '\\') \
-                  ORDER BY CASE WHEN json_extract(properties,'$.source_uri')=?2 OR name=?3 \
-                                THEN 0 ELSE 1 END, id \
-                  LIMIT 1"
-                .into(),
+            sql: sql!("documents_by_path_select").into(),
             params: vec![
                 SqlValue::Text(namespace),
                 SqlValue::Text(path.to_string()),
@@ -1217,13 +1206,7 @@ async fn load_code_modules_by_snapshot_path(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let rows = r
         .query_all(SqlStatement {
-            sql: "SELECT id, json_extract(properties,'$.source_path') AS source_path \
-                  FROM entities WHERE kind='concept' AND entity_type='module' \
-                  AND namespace=?1 AND deleted_at IS NULL \
-                  AND json_type(properties,'$.source_path')='text' \
-                  AND json_extract(properties,'$.source_revision')=?2 \
-                  ORDER BY source_path, id"
-                .into(),
+            sql: sql!("code_modules_by_snapshot_path_select").into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(source_revision.to_string()),
@@ -1279,10 +1262,7 @@ async fn read_commit_checkpoint(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_row(SqlStatement {
-            sql: "SELECT \
-                  (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind='commits') AS cursor, \
-                  (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind='commits_checkpoint') AS progress"
-                .into(),
+            sql: sql!("commit_checkpoint_select").into(),
             params: vec![SqlValue::Text(project_id.to_string())],
             label: Some("git_ingest_read_commit_checkpoint".into()),
         })
@@ -1333,12 +1313,7 @@ async fn write_commit_checkpoint(
     let sql = runtime.sql();
     let mut w = sql.writer().await.map_err(anyhow::Error::new)?;
     w.execute(SqlStatement {
-        sql: "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) \
-              VALUES(?1, 'commits_checkpoint', ?2, ?4), (?1, 'commits', ?3, ?4) \
-              ON CONFLICT(project_id, kind) DO UPDATE SET \
-                cursor_value=excluded.cursor_value, \
-                updated_at=excluded.updated_at"
-            .into(),
+        sql: sql!("commit_checkpoint_upsert").into(),
         params: vec![
             SqlValue::Text(project_id.to_string()),
             SqlValue::Text(progress),
@@ -1415,14 +1390,20 @@ async fn read_page_checkpoint(
     warnings: &mut Vec<String>,
 ) -> Result<PageCheckpoint> {
     // One read snapshot: a concurrent atomic checkpoint cannot tear this pair.
-    let row = runtime.sql().reader().await?.query_row(SqlStatement {
-        sql: "SELECT \
-              (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2) AS floor, \
-              (SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?3) AS progress".into(),
-        params: vec![SqlValue::Text(project_id.to_string()), SqlValue::Text(kind.into()),
-            SqlValue::Text(format!("{kind}_checkpoint"))],
-        label: Some("git_ingest_read_page_checkpoint".into()),
-    }).await?;
+    let row = runtime
+        .sql()
+        .reader()
+        .await?
+        .query_row(SqlStatement {
+            sql: sql!("page_checkpoint_select").into(),
+            params: vec![
+                SqlValue::Text(project_id.to_string()),
+                SqlValue::Text(kind.into()),
+                SqlValue::Text(format!("{kind}_checkpoint")),
+            ],
+            label: Some("git_ingest_read_page_checkpoint".into()),
+        })
+        .await?;
     let floor = match row.as_ref().and_then(|r| r.get("floor")) {
         Some(SqlValue::Text(raw)) => match chrono::DateTime::parse_from_rfc3339(raw) {
             Ok(dt) => Some(
@@ -1469,28 +1450,23 @@ async fn write_page_checkpoint(
 ) -> Result<()> {
     // One statement commits the timestamp and exact acknowledgments together.
     // An undated-only window has no main timestamp row yet.
-    let mut statement = SqlStatement {
-        sql: "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) \
-              VALUES(?1, ?2, ?3, ?4)"
-            .into(),
-        params: vec![
-            SqlValue::Text(project_id.to_string()),
-            SqlValue::Text(format!("{kind}_checkpoint")),
-            SqlValue::Text(serde_json::to_string(checkpoint)?),
-            SqlValue::Integer(Utc::now().timestamp_micros()),
-        ],
+    let mut params = vec![
+        SqlValue::Text(project_id.to_string()),
+        SqlValue::Text(format!("{kind}_checkpoint")),
+        SqlValue::Text(serde_json::to_string(checkpoint)?),
+        SqlValue::Integer(Utc::now().timestamp_micros()),
+    ];
+    let statement_sql = if let Some(floor) = &checkpoint.floor {
+        params.extend([SqlValue::Text(kind.into()), SqlValue::Text(floor.clone())]);
+        sql!("page_checkpoint_with_floor_upsert")
+    } else {
+        sql!("page_checkpoint_without_floor_upsert")
+    };
+    let statement = SqlStatement {
+        sql: statement_sql.into(),
+        params,
         label: Some("git_ingest_write_page_checkpoint".into()),
     };
-    if let Some(floor) = &checkpoint.floor {
-        statement.sql.push_str(", (?1, ?5, ?6, ?4)");
-        statement
-            .params
-            .extend([SqlValue::Text(kind.into()), SqlValue::Text(floor.clone())]);
-    }
-    statement.sql.push_str(
-        " ON CONFLICT(project_id, kind) DO UPDATE SET \
-        cursor_value=excluded.cursor_value, updated_at=excluded.updated_at",
-    );
     runtime.sql().writer().await?.execute(statement).await?;
     Ok(())
 }
@@ -2481,11 +2457,7 @@ async fn count_commit_notes_for_project(
     let mut r = sql.reader().await.map_err(anyhow::Error::new)?;
     let row = r
         .query_scalar(SqlStatement {
-            sql: "SELECT COUNT(*) FROM notes n \
-                  JOIN graph_edges e ON e.source_id = n.id AND e.namespace = n.namespace \
-                  WHERE n.kind = 'commit' AND n.namespace = ?1 AND n.deleted_at IS NULL \
-                  AND e.relation = 'annotates' AND e.target_id = ?2 AND e.deleted_at IS NULL"
-                .into(),
+            sql: sql!("commit_notes_for_project_count").into(),
             params: vec![
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Text(project_id.to_string()),

--- a/crates/khive-pack-git/src/ingest_cursor.rs
+++ b/crates/khive-pack-git/src/ingest_cursor.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use crate::sql::sql;
 use crate::GitPack;
 
 const MAX_VALUE_BYTES: i64 = 256 * 1024;
@@ -70,15 +71,22 @@ impl GitPack {
         let checkpoint_kind = format!("{kind}_checkpoint");
         // One SELECT snapshot cannot tear the atomically written pair. Limit
         // materialized value bytes even when a damaged row exceeds writer bounds.
-        let rows = self.runtime().sql().reader().await?.query_all(SqlStatement {
-            sql: "SELECT kind, updated_at, typeof(cursor_value) AS value_type, \
-                  length(CAST(cursor_value AS BLOB)) AS value_bytes, \
-                  CASE WHEN length(CAST(cursor_value AS BLOB)) <= ?4 THEN CAST(cursor_value AS BLOB) END AS value \
-                  FROM git_mirror_cursor WHERE project_id=?1 AND kind IN (?2, ?3)".into(),
-            params: vec![SqlValue::Text(project_id.clone()), SqlValue::Text(kind.into()),
-                SqlValue::Text(checkpoint_kind.clone()), SqlValue::Integer(MAX_VALUE_BYTES)],
-            label: Some("git.ingest_cursor.snapshot".into()),
-        }).await?;
+        let rows = self
+            .runtime()
+            .sql()
+            .reader()
+            .await?
+            .query_all(SqlStatement {
+                sql: sql!("ingest_cursor_snapshot_select").into(),
+                params: vec![
+                    SqlValue::Text(project_id.clone()),
+                    SqlValue::Text(kind.into()),
+                    SqlValue::Text(checkpoint_kind.clone()),
+                    SqlValue::Integer(MAX_VALUE_BYTES),
+                ],
+                label: Some("git.ingest_cursor.snapshot".into()),
+            })
+            .await?;
         let mut cursor = Value::Null;
         let mut checkpoint = Value::Null;
         for row in rows {

--- a/crates/khive-pack-git/src/lib.rs
+++ b/crates/khive-pack-git/src/lib.rs
@@ -31,6 +31,8 @@
 //! `kkernel git-ingest` remains the unbounded, all-kinds admin CLI path over
 //! the same shared `ingest::run_ingest` core.
 
+mod sql;
+
 #[cfg(test)]
 mod backend_policy_tests;
 pub mod cache;

--- a/crates/khive-pack-git/src/receipts.rs
+++ b/crates/khive-pack-git/src/receipts.rs
@@ -2,12 +2,11 @@ use khive_runtime::{KhiveRuntime, RuntimeError};
 use khive_storage::types::{SqlRow, SqlStatement, SqlValue};
 use serde_json::{json, Value};
 
-pub const RECEIPTS_TABLE_SQL: &str = include_str!("../sql/git_receipts.sql");
-pub const RECEIPTS_ACTOR_INDEX_SQL: &str = include_str!("../sql/git_receipts_actor_index.sql");
-pub const RECEIPTS_SESSION_INDEX_SQL: &str = include_str!("../sql/git_receipts_session_index.sql");
+use crate::sql::sql;
 
-const COLUMNS: &str = "id, namespace, actor, session_id, verb, repo, inputs, gate, policy, \
-    fork_policy, credential, started_at, finished_at, disposition, result, reason";
+pub const RECEIPTS_TABLE_SQL: &str = sql!("git_receipts");
+pub const RECEIPTS_ACTOR_INDEX_SQL: &str = sql!("git_receipts_actor_index");
+pub const RECEIPTS_SESSION_INDEX_SQL: &str = sql!("git_receipts_session_index");
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Disposition {
@@ -244,10 +243,7 @@ pub async fn insert(rt: &KhiveRuntime, receipt: &Receipt) -> Result<(), RuntimeE
     let mut writer = rt.sql().writer().await?;
     let changed = writer
         .execute(SqlStatement {
-            sql: format!(
-                "INSERT INTO git_receipts ({COLUMNS}) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)"
-            ),
+            sql: sql!("git_receipts_insert").into(),
             params: vec![
                 SqlValue::Text(receipt.id.clone()),
                 SqlValue::Text(receipt.namespace.clone()),
@@ -282,12 +278,7 @@ pub async fn persist(rt: &KhiveRuntime, receipt: &Receipt) -> Result<(), Runtime
     let mut writer = rt.sql().writer().await?;
     let changed = writer
         .execute(SqlStatement {
-            sql: "UPDATE git_receipts SET gate = ?1, policy = ?2, fork_policy = ?3, \
-                  credential = ?4, finished_at = ?5, disposition = ?6, result = ?7, reason = ?8 \
-                  WHERE id = ?9 AND namespace = ?10 AND actor = ?11 AND disposition = 'unknown' \
-                  AND session_id IS ?12 AND verb = ?13 AND repo = ?14 AND inputs = ?15 \
-                  AND started_at = ?16"
-                .into(),
+            sql: sql!("git_receipts_persist").into(),
             params: vec![
                 SqlValue::Text(receipt.gate.to_string()),
                 json_sql(&receipt.policy),
@@ -329,9 +320,7 @@ pub async fn load_owned(
     let mut reader = rt.sql().reader().await?;
     let rows = reader
         .query_all(SqlStatement {
-            sql: format!(
-                "SELECT {COLUMNS} FROM git_receipts WHERE namespace = ?1 AND actor = ?2 AND id = ?3"
-            ),
+            sql: sql!("git_receipts_owned_select").into(),
             params: vec![
                 SqlValue::Text(namespace.to_string()),
                 SqlValue::Text(actor.to_string()),
@@ -370,11 +359,7 @@ pub async fn list_owned(
     let rows = reader
         .query_all(SqlStatement {
             // Appended receipts do not shift offsets, even with a regressing clock.
-            sql: format!(
-                "SELECT {COLUMNS} FROM git_receipts WHERE namespace = ?1 AND actor = ?2 \
-                 AND (?3 IS NULL OR repo = ?3) AND (?4 IS NULL OR session_id = ?4) \
-                 ORDER BY rowid ASC LIMIT ?5 OFFSET ?6"
-            ),
+            sql: sql!("git_receipts_owned_list").into(),
             params: vec![
                 SqlValue::Text(namespace.to_string()),
                 SqlValue::Text(actor.to_string()),

--- a/crates/khive-pack-git/src/remote_handlers.rs
+++ b/crates/khive-pack-git/src/remote_handlers.rs
@@ -12,6 +12,7 @@ use crate::local_handlers::{
 };
 use crate::receipts::{self, Disposition, Receipt};
 use crate::remote_transport::{ApiRequest, PushRequest, RemoteError};
+use crate::sql::sql;
 use crate::write_argv::{validate_ref_name, validate_repo_path};
 use crate::{credentials, local_git, GitPack};
 
@@ -766,11 +767,20 @@ impl GitPack {
             .reader()
             .await
             .map_err(RuntimeError::from)?;
-        let rows = reader.query_all(SqlStatement {
-            sql:"SELECT actor, credential FROM git_receipts WHERE namespace=?1 AND repo=?2 AND verb='git.pr_open' AND disposition != 'not_committed' AND json_extract(result,'$.number')=?3 LIMIT 1001".into(),
-            params:vec![SqlValue::Text(receipt.namespace.clone()),SqlValue::Text(receipt.repo.clone()),SqlValue::Integer(i64::try_from(number).map_err(|_| Failure::invalid("number too large"))?)],
-            label:Some("git_pr_opener".into()),
-        }).await.map_err(RuntimeError::from)?;
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: sql!("pr_open_receipts_by_number_select").into(),
+                params: vec![
+                    SqlValue::Text(receipt.namespace.clone()),
+                    SqlValue::Text(receipt.repo.clone()),
+                    SqlValue::Integer(
+                        i64::try_from(number).map_err(|_| Failure::invalid("number too large"))?,
+                    ),
+                ],
+                label: Some("git_pr_opener".into()),
+            })
+            .await
+            .map_err(RuntimeError::from)?;
         if rows.len() > 1000 {
             return Err(Failure::refused("opener_evidence_limit"));
         }
@@ -808,17 +818,20 @@ impl GitPack {
             .reader()
             .await
             .map_err(RuntimeError::from)?;
-        let rows = reader.query_all(SqlStatement {
-            sql: "SELECT id, repo, disposition, credential FROM git_receipts \
-                  WHERE namespace=?1 AND verb='git.push' AND disposition IN ('committed','unknown') \
-                  AND lower(json_extract(result,'$.sha'))=?2 AND json_extract(result,'$.ref')=?3 \
-                  AND lower(json_extract(result,'$.remote')) IN (?4,?5) \
-                  ORDER BY rowid DESC LIMIT 1001".into(),
-            params: vec![SqlValue::Text(receipt.namespace.clone()),SqlValue::Text(expected.into()),
-                SqlValue::Text(format!("refs/heads/{branch}")),SqlValue::Text(remote.clone()),
-                SqlValue::Text(format!("{remote}.git"))],
-            label: Some("git_last_pusher".into()),
-        }).await.map_err(RuntimeError::from)?;
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: sql!("push_receipts_by_head_select").into(),
+                params: vec![
+                    SqlValue::Text(receipt.namespace.clone()),
+                    SqlValue::Text(expected.into()),
+                    SqlValue::Text(format!("refs/heads/{branch}")),
+                    SqlValue::Text(remote.clone()),
+                    SqlValue::Text(format!("{remote}.git")),
+                ],
+                label: Some("git_last_pusher".into()),
+            })
+            .await
+            .map_err(RuntimeError::from)?;
         // No SQL reader is held across local Git process execution.
         drop(reader);
         for row in rows.iter().take(1000) {

--- a/crates/khive-pack-git/src/sql.rs
+++ b/crates/khive-pack-git/src/sql.rs
@@ -1,0 +1,13 @@
+//! SQL lives beside the code as `sql/<name>.sql`: one statement per file,
+//! `?N` binds only, never string-built, loaded at compile time by `sql!`.
+
+/// The statement text of `sql/<name>.sql`, checked in at compile time.
+macro_rules! sql {
+    ($name:literal) => {
+        const {
+            include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/sql/", $name, ".sql"))
+                .trim_ascii_end()
+        }
+    };
+}
+pub(crate) use sql;

--- a/crates/khive-pack-git/src/vocab.rs
+++ b/crates/khive-pack-git/src/vocab.rs
@@ -11,6 +11,8 @@ use khive_types::{
     IdResolutionMode, ParamDef, VerbCategory, Visibility,
 };
 
+use crate::sql::sql;
+
 /// Shared open/closed lifecycle for `issue` and `pull_request`. See
 /// crates/khive-pack-git/docs/api/vocab.md#git_lifecycle.
 const GIT_LIFECYCLE: NoteLifecycleSpec = NoteLifecycleSpec {
@@ -43,15 +45,8 @@ pub(crate) static GIT_SCHEMA_PLAN_STMTS: [&str; 5] = [
     crate::receipts::RECEIPTS_TABLE_SQL,
     crate::receipts::RECEIPTS_ACTOR_INDEX_SQL,
     crate::receipts::RECEIPTS_SESSION_INDEX_SQL,
-    "CREATE TABLE IF NOT EXISTS git_mirror_cursor (\
-        project_id   TEXT NOT NULL,\
-        kind         TEXT NOT NULL,\
-        cursor_value TEXT,\
-        updated_at   INTEGER NOT NULL,\
-        PRIMARY KEY (project_id, kind)\
-    )",
-    "CREATE INDEX IF NOT EXISTS idx_git_mirror_cursor_updated \
-        ON git_mirror_cursor(updated_at DESC)",
+    sql!("git_mirror_cursor_table_create"),
+    sql!("git_mirror_cursor_updated_index_create"),
 ];
 
 /// ADR-088 Amendment 1: parent→child commit lineage as `precedes` edges

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -7960,7 +7960,7 @@ pub(crate) mod tests {
     #[test]
     fn converted_crates_keep_their_sql_out_of_rust() {
         /// Crates whose statements live in `sql/`. One pull request adds one name.
-        const CONVERTED: &[&str] = &["khive-pack-brain"];
+        const CONVERTED: &[&str] = &["khive-pack-brain", "khive-pack-git"];
         /// A crate known to still hold SQL in Rust, used only to prove the detector
         /// fires. When this one is converted, move the control to another unconverted
         /// crate rather than deleting it.

--- a/scripts/tests/test_lint_sql.py
+++ b/scripts/tests/test_lint_sql.py
@@ -1,11 +1,26 @@
 """SQL fragment dependencies and isolation in the repository lint."""
 import pathlib
+import re
 import shutil
 import subprocess
 import tempfile
 import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# lint-sql.sh classifies a file by its first keyword, never by its name or its
+# directory. The rule is mirrored here because this fixture has to select the same
+# population the fragment groups do.
+DDL = re.compile(r"\s*(CREATE|ALTER|DROP|PRAGMA|BEGIN|COMMIT)\b", re.IGNORECASE)
+
+
+def declares_schema(path):
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("--"):
+            continue
+        return bool(DDL.match(line))
+    return True  # an empty file declares nothing and prepares nothing
 
 
 class SqlLintTests(unittest.TestCase):
@@ -24,13 +39,45 @@ class SqlLintTests(unittest.TestCase):
         )
 
     def copy_git_fragments(self):
-        shutil.copytree(ROOT / "crates/khive-pack-git/sql", self.root / "crates/khive-pack-git/sql")
+        """Copy khive-pack-git's schema fragments, and only those.
+
+        This copied the whole `sql/` directory until that directory also held
+        query statements extracted out of Rust. A query is prepared against the
+        migration chain, which an isolated tree does not carry, so copying
+        everything reddened the fixture over eleven tables the chain declares —
+        a true statement about the fixture and nothing at all about the question
+        these tests ask. The population here is the fragments: select them by the
+        linter's own rule, and count what was copied instead of a literal that
+        goes stale the next time a statement lands in that directory.
+        """
+        source = ROOT / "crates/khive-pack-git/sql"
+        destination = self.root / "crates/khive-pack-git/sql"
+        destination.mkdir(parents=True)
+        names = []
+        for path in sorted(source.glob("*.sql")):
+            if declares_schema(path):
+                shutil.copy2(path, destination / path.name)
+                names.append(path.name)
+        # The subject is an index resolving a table declared in a different file,
+        # so a pass means nothing unless both are in the fixture.
+        self.assertIn("git_receipts.sql", names)
+        self.assertTrue(
+            any(name.endswith("_index.sql") or "_index_" in name for name in names),
+            f"no index fragment among {names}, so this fixture cannot show "
+            "one file resolving a table another file declares",
+        )
+        return len(names)
 
     def test_real_git_indexes_see_their_table(self):
-        self.copy_git_fragments()
+        copied = self.copy_git_fragments()
         result = self.run_lint()
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("3 file(s) OK", result.stdout)
+        # The whole line, so a count is never a substring of a larger one, and the
+        # prepared column asserts the fixture holds no query files.
+        self.assertIn(
+            f"SQL lint: {copied} file(s) OK (0 prepared, {copied} executed)",
+            result.stdout,
+        )
 
     def test_broken_fragment_is_still_refused(self):
         self.copy_git_fragments()
@@ -40,6 +87,34 @@ class SqlLintTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("zz-broken.sql: FAILED", result.stdout)
         self.assertIn("no such table", result.stdout)
+
+    def test_a_query_file_is_prepared_against_the_schema_it_reads(self):
+        """A statement file resolves names the DDL beside it declares, and only those.
+
+        The extraction program's whole premise is that a moved statement is
+        checked rather than merely stored, so both arms belong here: one query
+        over a table the fixture declares passes, and one over a table it does
+        not is refused by name.
+        """
+        directory = self.root / "crates/reader/sql"
+        directory.mkdir(parents=True)
+        (directory / "00-table.sql").write_text(
+            "CREATE TABLE rows_seen (\n    id INTEGER,\n    seen_at TEXT\n);\n"
+        )
+        (directory / "by_id_select.sql").write_text(
+            "SELECT seen_at FROM rows_seen WHERE id = ?1;\n"
+        )
+        result = self.run_lint()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("SQL lint: 2 file(s) OK (1 prepared, 1 executed)", result.stdout)
+
+        (directory / "absent_select.sql").write_text(
+            "SELECT seen_at FROM rows_never_seen WHERE id = ?1;\n"
+        )
+        result = self.run_lint()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("absent_select.sql: FAILED to prepare", result.stdout)
+        self.assertIn("no such table: rows_never_seen", result.stdout)
 
     def test_each_directory_has_an_independent_database(self):
         for name in ["first", "second"]:


### PR DESCRIPTION
Twenty-five statements out of twenty-four construction sites in `khive-pack-git`, into `crates/khive-pack-git/sql/`, reached through the crate-local `sql!` macro. The three DDL files the crate already had move onto the same macro so there is one way in.

Most of it is a byte-for-byte move. Three statements were not: the receipts table shares a `COLUMNS` constant that `format!` spliced into an insert, a select and a list query, so the column list is now written out in each file. Two more were built by `push_str`, appending a second `VALUES` row when a page checkpoint carries a floor and then appending the `ON CONFLICT` tail either way; that is two statements rather than one dynamic one, and they are two files.

Verified by reconstruction rather than by reading: every file was compared against the statement text the previous code would have produced, including the constant expansion and the `push_str` assembly, and each one matches. `scripts/lint-sql.sh` prepares the query files against the real schema, so a typo'd column fails at lint time.

`khive-pack-git` joins the workspace census's converted list, which from here on fails if a statement comes back into a Rust literal.