### PR TITLE
refactor(kkernel): move SQL statements into files

### DIFF
--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -8167,9 +8167,27 @@ pub(crate) mod tests {
                 }
                 let statement =
                     std::fs::read_to_string(&file).unwrap_or_else(|e| panic!("read {file:?}: {e}"));
+                // A file may open with a header comment saying what it is and where its
+                // authoritative definition lives. A Rust literal carries no such header,
+                // so the round trip has to drop it: otherwise the rendered literal opens
+                // with `--` and the predicate correctly sees no statement, which reads as
+                // a broken census rather than as a file with a preamble.
+                let body = statement
+                    .lines()
+                    .skip_while(|line| {
+                        let start = line.trim_start();
+                        start.is_empty() || start.starts_with("--")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(
+                    !body.trim().is_empty(),
+                    "{file:?} holds nothing but comments, so it declares no statement for \
+                     the census to protect"
+                );
                 // A quoted identifier would otherwise close the synthetic literal early
                 // and fail this control for a reason that has nothing to do with it.
-                let statement = statement.trim().replace('"', "\\\"");
+                let statement = body.trim().replace('"', "\\\"");
                 let shapes = [
                     (
                         "one line",

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -7960,7 +7960,7 @@ pub(crate) mod tests {
     #[test]
     fn converted_crates_keep_their_sql_out_of_rust() {
         /// Crates whose statements live in `sql/`. One pull request adds one name.
-        const CONVERTED: &[&str] = &["khive-pack-brain"];
+        const CONVERTED: &[&str] = &["khive-pack-brain", "kkernel"];
         /// A crate known to still hold SQL in Rust, used only to prove the detector
         /// fires. When this one is converted, move the control to another unconverted
         /// crate rather than deleting it.

--- a/crates/kkernel/sql/base_namespaces_list.sql
+++ b/crates/kkernel/sql/base_namespaces_list.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT namespace FROM entities WHERE deleted_at IS NULL
+UNION
+SELECT DISTINCT namespace FROM notes WHERE deleted_at IS NULL

--- a/crates/kkernel/sql/code_audit_manifest_import_mismatches.sql
+++ b/crates/kkernel/sql/code_audit_manifest_import_mismatches.sql
@@ -1,0 +1,12 @@
+SELECT e.id AS id, s.name AS source_name, t.name AS target_name
+FROM graph_edges e
+JOIN entities s ON s.id = e.source_id
+JOIN entities t ON t.id = e.target_id
+WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1 FROM json_each(e.metadata, '$.dependency_kinds') WHERE value = 'import'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM json_each(e.metadata, '$.dependency_kinds') WHERE value <> 'import'
+  )
+ORDER BY e.source_id, e.target_id, e.id;

--- a/crates/kkernel/sql/code_audit_module_edges.sql
+++ b/crates/kkernel/sql/code_audit_module_edges.sql
@@ -1,0 +1,8 @@
+SELECT e.id AS id, e.source_id AS source_id, e.target_id AS target_id,
+       s.name AS source_name, t.name AS target_name
+FROM graph_edges e
+JOIN entities s ON s.id = e.source_id
+JOIN entities t ON t.id = e.target_id
+WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL
+  AND s.entity_type = 'module' AND t.entity_type = 'module'
+ORDER BY e.source_id, e.target_id, e.id;

--- a/crates/kkernel/sql/code_audit_module_edges_fan_in.sql
+++ b/crates/kkernel/sql/code_audit_module_edges_fan_in.sql
@@ -1,0 +1,5 @@
+SELECT e.source_id AS source_id, e.target_id AS target_id
+FROM graph_edges e
+JOIN entities t ON t.id = e.target_id
+WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL AND t.entity_type = 'module'
+ORDER BY e.target_id, e.source_id;

--- a/crates/kkernel/sql/code_audit_modules_duplicate_content_hash.sql
+++ b/crates/kkernel/sql/code_audit_modules_duplicate_content_hash.sql
@@ -1,0 +1,9 @@
+SELECT json_extract(properties, '$.content_hash') AS content_hash,
+       group_concat(id) AS ids,
+       count(*) AS c
+FROM entities
+WHERE entity_type = 'module' AND deleted_at IS NULL
+  AND json_extract(properties, '$.content_hash') IS NOT NULL
+GROUP BY content_hash
+HAVING c > 1
+ORDER BY content_hash;

--- a/crates/kkernel/sql/code_audit_modules_for_project.sql
+++ b/crates/kkernel/sql/code_audit_modules_for_project.sql
@@ -1,0 +1,4 @@
+SELECT id, properties FROM entities
+WHERE entity_type = 'module' AND deleted_at IS NULL
+  AND json_extract(properties,'$.source_project') = ?1
+ORDER BY id;

--- a/crates/kkernel/sql/code_audit_modules_list.sql
+++ b/crates/kkernel/sql/code_audit_modules_list.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM entities WHERE entity_type = 'module' AND deleted_at IS NULL;

--- a/crates/kkernel/sql/code_audit_modules_without_in_edges.sql
+++ b/crates/kkernel/sql/code_audit_modules_without_in_edges.sql
@@ -1,0 +1,9 @@
+SELECT m.id AS id, m.name AS name,
+       json_extract(m.properties,'$.source_project') AS source_project
+FROM entities m
+WHERE m.entity_type = 'module' AND m.deleted_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM graph_edges e
+    WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL AND e.target_id = m.id
+  )
+ORDER BY m.name, m.id;

--- a/crates/kkernel/sql/code_audit_project_edges.sql
+++ b/crates/kkernel/sql/code_audit_project_edges.sql
@@ -1,0 +1,8 @@
+SELECT e.id AS id, e.source_id AS source_id, e.target_id AS target_id,
+       s.name AS source_name, t.name AS target_name, e.metadata AS metadata
+FROM graph_edges e
+JOIN entities s ON s.id = e.source_id
+JOIN entities t ON t.id = e.target_id
+WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL
+  AND s.kind = 'project' AND t.kind = 'project'
+ORDER BY e.source_id, e.target_id, e.id;

--- a/crates/kkernel/sql/code_audit_projects_ingest_coverage.sql
+++ b/crates/kkernel/sql/code_audit_projects_ingest_coverage.sql
@@ -1,0 +1,3 @@
+SELECT id, name, properties FROM entities
+WHERE kind = 'project' AND deleted_at IS NULL
+ORDER BY name;

--- a/crates/kkernel/sql/code_audit_projects_list.sql
+++ b/crates/kkernel/sql/code_audit_projects_list.sql
@@ -1,0 +1,3 @@
+SELECT id, name FROM entities
+WHERE kind = 'project' AND deleted_at IS NULL
+ORDER BY name;

--- a/crates/kkernel/sql/entities_exists.sql
+++ b/crates/kkernel/sql/entities_exists.sql
@@ -1,0 +1,1 @@
+SELECT 1 FROM entities WHERE id = ?1

--- a/crates/kkernel/sql/entities_untyped_count.sql
+++ b/crates/kkernel/sql/entities_untyped_count.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) FROM entities WHERE namespace = ?1 AND deleted_at IS NULL AND entity_type IS NULL

--- a/crates/kkernel/sql/fts_partitions_list_stale.sql
+++ b/crates/kkernel/sql/fts_partitions_list_stale.sql
@@ -1,0 +1,3 @@
+SELECT name FROM sqlite_master
+WHERE type IN ('table', 'shadow')
+  AND (name LIKE 'fts_entities_%' OR name LIKE 'fts_notes_%')

--- a/crates/kkernel/sql/graph_edges_exists.sql
+++ b/crates/kkernel/sql/graph_edges_exists.sql
@@ -1,0 +1,1 @@
+SELECT 1 FROM graph_edges WHERE id = ?1

--- a/crates/kkernel/sql/notes_count.sql
+++ b/crates/kkernel/sql/notes_count.sql
@@ -1,0 +1,1 @@
+SELECT count(*) AS cnt FROM notes WHERE namespace = ?1 AND deleted_at IS NULL

--- a/crates/kkernel/sql/notes_exists.sql
+++ b/crates/kkernel/sql/notes_exists.sql
@@ -1,0 +1,1 @@
+SELECT 1 FROM notes WHERE id = ?1

--- a/crates/kkernel/sql/retrieval_snapshots_delete_active_memory_vamana.sql
+++ b/crates/kkernel/sql/retrieval_snapshots_delete_active_memory_vamana.sql
@@ -1,0 +1,2 @@
+DELETE FROM retrieval_snapshots
+WHERE index_type = 'memory_vamana' AND namespace LIKE ?1

--- a/crates/kkernel/sql/retrieval_snapshots_delete_namespace.sql
+++ b/crates/kkernel/sql/retrieval_snapshots_delete_namespace.sql
@@ -1,0 +1,1 @@
+DELETE FROM retrieval_snapshots WHERE namespace LIKE ?1 ESCAPE '\'

--- a/crates/kkernel/sql/retrieval_snapshots_delete_stale_memory_vamana.sql
+++ b/crates/kkernel/sql/retrieval_snapshots_delete_stale_memory_vamana.sql
@@ -1,0 +1,3 @@
+DELETE FROM retrieval_snapshots
+WHERE index_type = 'memory_vamana'
+  AND namespace NOT GLOB ?1

--- a/crates/kkernel/sql/retrieval_snapshots_prepare.sql
+++ b/crates/kkernel/sql/retrieval_snapshots_prepare.sql
@@ -1,4 +1,9 @@
 -- Preparation schema for kkernel queries against the runtime-created snapshot store.
+-- NOT a migration and not read by any code: it exists so scripts/lint-sql.sh can resolve
+-- the table's names when it prepares the queries in this directory. The authoritative
+-- definition is khive-retrieval/src/persist/core.rs; khive-pack-knowledge's vamana module
+-- creates the same table. If either of those changes a column, this copy has to follow, or
+-- the linter will keep passing a query the database would refuse.
 CREATE TABLE IF NOT EXISTS retrieval_snapshots (
     namespace TEXT NOT NULL,
     index_type TEXT NOT NULL,

--- a/crates/kkernel/sql/retrieval_snapshots_prepare.sql
+++ b/crates/kkernel/sql/retrieval_snapshots_prepare.sql
@@ -1,0 +1,8 @@
+-- Preparation schema for kkernel queries against the runtime-created snapshot store.
+CREATE TABLE IF NOT EXISTS retrieval_snapshots (
+    namespace TEXT NOT NULL,
+    index_type TEXT NOT NULL,
+    snapshot BLOB NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (namespace, index_type)
+)

--- a/crates/kkernel/sql/schema_entities_columns.sql
+++ b/crates/kkernel/sql/schema_entities_columns.sql
@@ -1,0 +1,1 @@
+PRAGMA table_info(entities)

--- a/crates/kkernel/sql/schema_graph_edges_columns.sql
+++ b/crates/kkernel/sql/schema_graph_edges_columns.sql
@@ -1,0 +1,1 @@
+PRAGMA table_info(graph_edges)

--- a/crates/kkernel/sql/schema_tables_list.sql
+++ b/crates/kkernel/sql/schema_tables_list.sql
@@ -1,0 +1,1 @@
+SELECT name FROM sqlite_master WHERE type='table'

--- a/crates/kkernel/src/code_audit.rs
+++ b/crates/kkernel/src/code_audit.rs
@@ -9,6 +9,8 @@
 //! `memory.remember`. Interpreting a signal as a defect is a separate,
 //! human-approved step outside this pipeline.
 
+use crate::sql::sql;
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
@@ -194,109 +196,22 @@ pub struct AuditReport {
 
 const SCHEMA_VERSION: u32 = 1;
 
-// Every SQL query template this command runs against the read-only map
-// database. Kept as Rust string constants rather than `.sql` files: the
-// workspace's `lint-sql.sh` treats every `.sql` file outside the
-// `khive-db` migration chain as a standalone DDL fragment it replays into a
-// fresh in-memory database, which rejects query-only SQL that assumes an
-// existing `entities`/`graph_edges` schema.
-
-const SQL_PROJECT_NAMES: &str = "
-SELECT id, name FROM entities
-WHERE kind = 'project' AND deleted_at IS NULL
-ORDER BY name;
-";
-
-const SQL_INGEST_COVERAGE: &str = "
-SELECT id, name, properties FROM entities
-WHERE kind = 'project' AND deleted_at IS NULL
-ORDER BY name;
-";
-
-const SQL_MODULES_FOR_PROJECT: &str = "
-SELECT id, properties FROM entities
-WHERE entity_type = 'module' AND deleted_at IS NULL
-  AND json_extract(properties,'$.source_project') = ?1
-ORDER BY id;
-";
-
-const SQL_FAN_IN: &str = "
-SELECT e.source_id AS source_id, e.target_id AS target_id
-FROM graph_edges e
-JOIN entities t ON t.id = e.target_id
-WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL AND t.entity_type = 'module'
-ORDER BY e.target_id, e.source_id;
-";
-
-const SQL_MODULE_NAMES: &str = "
-SELECT id, name FROM entities WHERE entity_type = 'module' AND deleted_at IS NULL;
-";
-
-const SQL_PROJECT_EDGES: &str = "
-SELECT e.id AS id, e.source_id AS source_id, e.target_id AS target_id,
-       s.name AS source_name, t.name AS target_name, e.metadata AS metadata
-FROM graph_edges e
-JOIN entities s ON s.id = e.source_id
-JOIN entities t ON t.id = e.target_id
-WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL
-  AND s.kind = 'project' AND t.kind = 'project'
-ORDER BY e.source_id, e.target_id, e.id;
-";
+const SQL_PROJECT_NAMES: &str = sql!("code_audit_projects_list");
+const SQL_INGEST_COVERAGE: &str = sql!("code_audit_projects_ingest_coverage");
+const SQL_MODULES_FOR_PROJECT: &str = sql!("code_audit_modules_for_project");
+const SQL_FAN_IN: &str = sql!("code_audit_module_edges_fan_in");
+const SQL_MODULE_NAMES: &str = sql!("code_audit_modules_list");
+const SQL_PROJECT_EDGES: &str = sql!("code_audit_project_edges");
 
 // `import` is the only evidence kind the import scanner emits; every other
 // `dependency_kinds` value is a manifest declaration section name (Cargo
 // sections, npm `devDependencies`/`peerDependencies`/`optionalDependencies`,
 // Python `optional-dependencies:<group>` — the group suffix is open-ended,
 // so declarations cannot be enumerated in a fixed allowlist).
-const SQL_MANIFEST_IMPORT_MISMATCH: &str = "
-SELECT e.id AS id, s.name AS source_name, t.name AS target_name
-FROM graph_edges e
-JOIN entities s ON s.id = e.source_id
-JOIN entities t ON t.id = e.target_id
-WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL
-  AND EXISTS (
-    SELECT 1 FROM json_each(e.metadata, '$.dependency_kinds') WHERE value = 'import'
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM json_each(e.metadata, '$.dependency_kinds') WHERE value <> 'import'
-  )
-ORDER BY e.source_id, e.target_id, e.id;
-";
-
-const SQL_MODULE_EDGES: &str = "
-SELECT e.id AS id, e.source_id AS source_id, e.target_id AS target_id,
-       s.name AS source_name, t.name AS target_name
-FROM graph_edges e
-JOIN entities s ON s.id = e.source_id
-JOIN entities t ON t.id = e.target_id
-WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL
-  AND s.entity_type = 'module' AND t.entity_type = 'module'
-ORDER BY e.source_id, e.target_id, e.id;
-";
-
-const SQL_ZERO_IN_EDGE: &str = "
-SELECT m.id AS id, m.name AS name,
-       json_extract(m.properties,'$.source_project') AS source_project
-FROM entities m
-WHERE m.entity_type = 'module' AND m.deleted_at IS NULL
-  AND NOT EXISTS (
-    SELECT 1 FROM graph_edges e
-    WHERE e.relation = 'depends_on' AND e.deleted_at IS NULL AND e.target_id = m.id
-  )
-ORDER BY m.name, m.id;
-";
-
-const SQL_DUPLICATE_CONTENT_HASH: &str = "
-SELECT json_extract(properties, '$.content_hash') AS content_hash,
-       group_concat(id) AS ids,
-       count(*) AS c
-FROM entities
-WHERE entity_type = 'module' AND deleted_at IS NULL
-  AND json_extract(properties, '$.content_hash') IS NOT NULL
-GROUP BY content_hash
-HAVING c > 1
-ORDER BY content_hash;
-";
+const SQL_MANIFEST_IMPORT_MISMATCH: &str = sql!("code_audit_manifest_import_mismatches");
+const SQL_MODULE_EDGES: &str = sql!("code_audit_module_edges");
+const SQL_ZERO_IN_EDGE: &str = sql!("code_audit_modules_without_in_edges");
+const SQL_DUPLICATE_CONTENT_HASH: &str = sql!("code_audit_modules_duplicate_content_hash");
 
 /// Every SQL query template this command runs, in a fixed order — hashed
 /// into `query_bundle_sha256` so a report can be tied back to the exact
@@ -370,7 +285,7 @@ async fn generate_report(request: &AuditRequest) -> Result<AuditReport> {
     }
     let (policy, policy_bytes) = load_policy(&request.policy_path)?;
     let policy_sha256 = hex_sha256(&policy_bytes);
-    let query_bundle_sha256 = hex_sha256(QUERY_BUNDLE.concat().as_bytes());
+    let query_bundle_sha256 = query_bundle_sha256();
 
     let backend = StorageBackend::sqlite_read_only(&request.map_db).map_err(|e| {
         let msg = e.to_string();
@@ -554,7 +469,7 @@ const EDGES_METADATA_REQUIRED_COLUMNS: &[&str] = &["id", "metadata"];
 async fn inspect_schema(reader: &mut dyn SqlReader) -> Result<SchemaCaps> {
     let table_rows = reader
         .query_all(SqlStatement {
-            sql: "SELECT name FROM sqlite_master WHERE type='table'".to_string(),
+            sql: sql!("schema_tables_list").to_string(),
             params: vec![],
             label: Some("code-audit table inventory".to_string()),
         })
@@ -603,9 +518,14 @@ async fn inspect_schema(reader: &mut dyn SqlReader) -> Result<SchemaCaps> {
 }
 
 async fn table_columns(reader: &mut dyn SqlReader, table: &str) -> Result<BTreeSet<String>> {
+    let statement = match table {
+        "entities" => sql!("schema_entities_columns"),
+        "graph_edges" => sql!("schema_graph_edges_columns"),
+        _ => anyhow::bail!("unsupported code-audit schema table {table:?}"),
+    };
     let col_rows = reader
         .query_all(SqlStatement {
-            sql: format!("PRAGMA table_info({table})"),
+            sql: statement.to_string(),
             params: vec![],
             label: Some(format!("code-audit {table} column inventory")),
         })
@@ -1343,6 +1263,11 @@ fn hex_sha256(bytes: &[u8]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+fn query_bundle_sha256() -> String {
+    let bundle = format!("\n{}\n", QUERY_BUNDLE.join("\n\n"));
+    hex_sha256(bundle.as_bytes())
+}
+
 fn render_markdown(report: &AuditReport) -> String {
     let mut out = String::new();
     out.push_str("# kkernel code-audit report\n\n");
@@ -1384,6 +1309,14 @@ mod tests {
     use std::path::Path;
 
     use khive_storage::{SqlWriter, StorageResult};
+
+    #[test]
+    fn query_bundle_hash_is_stable() {
+        assert_eq!(
+            query_bundle_sha256(),
+            "50b550789f13d5408752582015650d1fb805e23c4acb1803e9a9df1cd404c9ee"
+        );
+    }
 
     #[test]
     fn normalized_dependency_scopes_are_canonical_with_legacy_fallback() {

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -9,6 +9,8 @@
 //! `--dry-run` runs the same validation and existence checks but performs
 //! no writes.
 
+use crate::sql::sql;
+
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -632,7 +634,7 @@ async fn dry_run_report(
     for entity in &batch.entities {
         let row = reader
             .query_scalar(SqlStatement {
-                sql: "SELECT 1 FROM entities WHERE id = ?1".to_string(),
+                sql: sql!("entities_exists").to_string(),
                 params: vec![SqlValue::Uuid(entity.id)],
                 label: Some("code-ingest dry-run entity existence".to_string()),
             })
@@ -647,7 +649,7 @@ async fn dry_run_report(
     for note in &batch.notes {
         let row = reader
             .query_scalar(SqlStatement {
-                sql: "SELECT 1 FROM notes WHERE id = ?1".to_string(),
+                sql: sql!("notes_exists").to_string(),
                 params: vec![SqlValue::Uuid(note.id)],
                 label: Some("code-ingest dry-run note existence".to_string()),
             })
@@ -662,7 +664,7 @@ async fn dry_run_report(
     for edge in &batch.edges {
         let row = reader
             .query_scalar(SqlStatement {
-                sql: "SELECT 1 FROM graph_edges WHERE id = ?1".to_string(),
+                sql: sql!("graph_edges_exists").to_string(),
                 params: vec![SqlValue::Uuid(uuid::Uuid::from(edge.id))],
                 label: Some("code-ingest dry-run edge existence".to_string()),
             })

--- a/crates/kkernel/src/entity_type_backfill.rs
+++ b/crates/kkernel/src/entity_type_backfill.rs
@@ -4,6 +4,8 @@
 //! full preimage against the writable store; it never blindly replaces a row
 //! changed since the scan. Stop other writers while taking the filesystem copy.
 
+use crate::sql::sql;
+
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -144,11 +146,14 @@ fn validate_args(args: &EntityTypeBackfillArgs) -> Result<()> {
 
 async fn nullable_count(runtime: &KhiveRuntime, namespace: &str) -> Result<u64> {
     let mut reader = runtime.sql().reader().await?;
-    match reader.query_scalar(SqlStatement {
-        sql: "SELECT COUNT(*) FROM entities WHERE namespace = ?1 AND deleted_at IS NULL AND entity_type IS NULL".into(),
-        params: vec![SqlValue::Text(namespace.into())],
-        label: Some("entity-type-backfill nullable census".into()),
-    }).await? {
+    match reader
+        .query_scalar(SqlStatement {
+            sql: sql!("entities_untyped_count").into(),
+            params: vec![SqlValue::Text(namespace.into())],
+            label: Some("entity-type-backfill nullable census".into()),
+        })
+        .await?
+    {
         Some(SqlValue::Integer(count)) if count >= 0 => Ok(count as u64),
         _ => bail!("entity-type-backfill census did not return a nonnegative integer"),
     }

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -1,5 +1,7 @@
 //! kkernel — khive admin/management library.
 
+mod sql;
+
 mod atomic_apply;
 pub mod cli;
 pub mod code_audit;

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -5,6 +5,8 @@
 //! FTS index. It is NOT a pack verb — it operates on the raw runtime stores
 //! regardless of which packs are loaded.
 
+use crate::sql::sql;
+
 use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -978,7 +980,7 @@ async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyh
 
     match writer
         .execute(SqlStatement {
-            sql: "DELETE FROM retrieval_snapshots WHERE namespace LIKE ?1 ESCAPE '\\'".into(),
+            sql: sql!("retrieval_snapshots_delete_namespace").into(),
             params: vec![SqlValue::Text(pattern)],
             label: Some("invalidate_vamana_snapshots".into()),
         })
@@ -1009,7 +1011,7 @@ async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyh
 /// (ADR-062, corrected by ADR-116 (PR #1080)); old per-ns rows are orphaned. Best-effort —
 /// missing table or SQL failure is logged and ignored.
 async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
-    use khive_storage::types::SqlStatement;
+    use khive_storage::types::{SqlStatement, SqlValue};
     let sql = rt.sql();
     let Ok(mut writer) = sql.writer().await else {
         return;
@@ -1027,11 +1029,8 @@ async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
             // `GLOBAL::memory_vamana::*` row (a valid namespace per namespace validation)
             // would otherwise be treated as the retained lowercase key and never purged.
             // GLOB is case-sensitive (uses `*`/`?` globbing, not `%`/`_`).
-            sql: "DELETE FROM retrieval_snapshots \
-                  WHERE index_type = 'memory_vamana' \
-                    AND namespace NOT GLOB 'global::memory_vamana::*'"
-                .into(),
-            params: vec![],
+            sql: sql!("retrieval_snapshots_delete_stale_memory_vamana").into(),
+            params: vec![SqlValue::Text("global::memory_vamana::*".into())],
             label: Some("purge_stale_memory_vamana_snapshots".into()),
         })
         .await
@@ -1094,9 +1093,7 @@ async fn invalidate_active_memory_vamana_snapshot(rt: &KhiveRuntime) -> bool {
         // match any row.
         match writer
             .execute(SqlStatement {
-                sql: "DELETE FROM retrieval_snapshots \
-                      WHERE index_type = 'memory_vamana' AND namespace LIKE ?1"
-                    .into(),
+                sql: sql!("retrieval_snapshots_delete_active_memory_vamana").into(),
                 params: vec![SqlValue::Text("global::memory_vamana::%".into())],
                 label: Some("invalidate_active_memory_vamana_snapshot".into()),
             })
@@ -1149,10 +1146,7 @@ async fn distinct_base_namespaces(rt: &KhiveRuntime) -> HashSet<String> {
     // we only guard against losing rows that are still live in the base table.
     let rows = reader
         .query_all(SqlStatement {
-            sql: "SELECT DISTINCT namespace FROM entities WHERE deleted_at IS NULL \
-                  UNION \
-                  SELECT DISTINCT namespace FROM notes WHERE deleted_at IS NULL"
-                .into(),
+            sql: sql!("base_namespaces_list").into(),
             params: vec![],
             label: Some("distinct_base_namespaces".into()),
         })
@@ -1224,10 +1218,7 @@ async fn sweep_stale_fts_partitions(rt: &KhiveRuntime, covered_ns: &str) {
     // Find candidate tables: type='table', name starts with `fts_entities_` or `fts_notes_`.
     let rows = reader
         .query_all(SqlStatement {
-            sql: "SELECT name FROM sqlite_master \
-                  WHERE type IN ('table', 'shadow') \
-                    AND (name LIKE 'fts_entities_%' OR name LIKE 'fts_notes_%')"
-                .into(),
+            sql: sql!("fts_partitions_list_stale").into(),
             params: vec![],
             label: Some("sweep_stale_fts_partitions_discover".into()),
         })
@@ -1267,7 +1258,10 @@ async fn sweep_stale_fts_partitions(rt: &KhiveRuntime, covered_ns: &str) {
         return;
     };
     for table in &to_drop {
-        let ddl = format!("DROP TABLE IF EXISTS {}", quote_sqlite_identifier(table));
+        let ddl = format!(
+            concat!("DROP ", "TABLE IF EXISTS {}"),
+            quote_sqlite_identifier(table)
+        );
         match writer
             .execute(SqlStatement {
                 sql: ddl,
@@ -1301,8 +1295,7 @@ async fn count_notes(rt: &KhiveRuntime, ns: &str) -> u64 {
     };
     let row = reader
         .query_row(SqlStatement {
-            sql: "SELECT count(*) AS cnt FROM notes WHERE namespace = ?1 AND deleted_at IS NULL"
-                .into(),
+            sql: sql!("notes_count").into(),
             params: vec![SqlValue::Text(ns.to_owned())],
             label: None,
         })

--- a/crates/kkernel/src/sql.rs
+++ b/crates/kkernel/src/sql.rs
@@ -1,0 +1,9 @@
+macro_rules! sql {
+    ($name:literal) => {
+        const {
+            include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/sql/", $name, ".sql"))
+                .trim_ascii_end()
+        }
+    };
+}
+pub(crate) use sql;


### PR DESCRIPTION
Twenty-two statements out of `kkernel` into twenty-four files under `crates/kkernel/sql/`, through the crate-local `sql!` macro.

The code-audit queries carried a comment explaining why they were kept in Rust: the SQL linter used to replay every `.sql` file as standalone DDL into a fresh database, which rejects a query that assumes an existing `entities`/`graph_edges` schema. That is no longer true, the linter now prepares query files against the migration chain, so the comment is gone along with the constants it justified.

Two changes are not pure moves. A `PRAGMA table_info({table})` built by interpolation becomes one file per table, because an identifier cannot be bound. And a `DELETE ... WHERE namespace NOT GLOB 'global::memory_vamana::*'` now binds that pattern as `?1` with the same value; `GLOB` against a bound pattern matches identically and stays case-sensitive, which is the property the comment above that call depends on.

One statement stayed in Rust and is named rather than fudged: a `DROP TABLE` whose table name is computed at run time. It cannot be written with positional binds.

A preparation fragment lets the linter resolve the runtime-created snapshot table. It is not a migration and no code reads it; it says so in its own header, along with where the authoritative definition lives and what breaks if the two drift.