### PR TITLE
refactor(kg): move the pack's SQL statements into files

### DIFF
--- a/crates/khive-pack-kg/sql/events_find_by_id.sql
+++ b/crates/khive-pack-kg/sql/events_find_by_id.sql
@@ -1,0 +1,6 @@
+SELECT id, namespace, verb, substrate, actor, kind, outcome, payload,
+       payload_schema_version, profile_state_version, duration_us, target_id,
+       session_id, aggregate_kind, aggregate_id, created_at
+FROM events
+WHERE id = ?1
+LIMIT 1

--- a/crates/khive-pack-kg/sql/events_insert_if_changed.sql
+++ b/crates/khive-pack-kg/sql/events_insert_if_changed.sql
@@ -1,0 +1,6 @@
+INSERT INTO events
+       (id, namespace, verb, substrate, actor, kind, outcome, payload,
+        payload_schema_version, profile_state_version, duration_us,
+        target_id, session_id, aggregate_kind, aggregate_id, created_at)
+SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16
+WHERE (changes() = 1)

--- a/crates/khive-pack-kg/sql/message_threads_list.sql
+++ b/crates/khive-pack-kg/sql/message_threads_list.sql
@@ -1,0 +1,6 @@
+SELECT DISTINCT json_extract(properties, '$.thread_id') AS thread_id
+FROM notes
+WHERE namespace IN (SELECT value FROM json_each(?1))
+AND deleted_at IS NULL
+AND json_type(properties, '$.thread_id') = 'text'
+AND kind = 'message'

--- a/crates/khive-pack-kg/sql/proposals_find_by_id.sql
+++ b/crates/khive-pack-kg/sql/proposals_find_by_id.sql
@@ -1,0 +1,5 @@
+SELECT proposal_id
+FROM proposals_open
+WHERE proposal_id = ?1
+AND namespace = ?2
+LIMIT 1

--- a/crates/khive-pack-kg/sql/proposals_find_by_prefix.sql
+++ b/crates/khive-pack-kg/sql/proposals_find_by_prefix.sql
@@ -1,0 +1,5 @@
+SELECT proposal_id
+FROM proposals_open
+WHERE proposal_id LIKE ?1
+AND namespace = ?2
+LIMIT 2

--- a/crates/khive-pack-kg/sql/proposals_insert.sql
+++ b/crates/khive-pack-kg/sql/proposals_insert.sql
@@ -1,0 +1,4 @@
+INSERT INTO proposals_open
+       (proposal_id, namespace, proposer, title, status,
+        created_at, updated_at, expiry)
+VALUES (?1, ?2, ?3, ?4, 'open', ?5, ?5, ?6)

--- a/crates/khive-pack-kg/sql/proposals_list.sql
+++ b/crates/khive-pack-kg/sql/proposals_list.sql
@@ -1,0 +1,8 @@
+SELECT proposal_id, proposer, title, status, created_at, updated_at,
+       expiry, last_decision, review_count, approve_count, reject_count
+FROM proposals_open
+WHERE namespace = ?1
+AND (?2 IS NULL OR status = ?2)
+AND (?3 IS NULL OR proposer = ?3)
+ORDER BY updated_at DESC, proposal_id DESC
+LIMIT ?4 OFFSET ?5

--- a/crates/khive-pack-kg/sql/proposals_mark_applied.sql
+++ b/crates/khive-pack-kg/sql/proposals_mark_applied.sql
@@ -1,0 +1,5 @@
+UPDATE proposals_open
+SET status = 'applied', updated_at = ?1
+WHERE proposal_id = ?2
+AND namespace = ?3
+AND status = 'applying'

--- a/crates/khive-pack-kg/sql/proposals_mark_applying.sql
+++ b/crates/khive-pack-kg/sql/proposals_mark_applying.sql
@@ -1,0 +1,5 @@
+UPDATE proposals_open
+SET status = 'applying', updated_at = ?1
+WHERE proposal_id = ?2
+AND namespace = ?3
+AND status = 'approved'

--- a/crates/khive-pack-kg/sql/proposals_mark_withdrawn.sql
+++ b/crates/khive-pack-kg/sql/proposals_mark_withdrawn.sql
@@ -1,0 +1,5 @@
+UPDATE proposals_open
+SET status = 'withdrawn', updated_at = ?1
+WHERE proposal_id = ?2
+AND namespace = ?3
+AND status NOT IN ('applied', 'applying', 'withdrawn', 'rejected')

--- a/crates/khive-pack-kg/sql/proposals_read_parent_status.sql
+++ b/crates/khive-pack-kg/sql/proposals_read_parent_status.sql
@@ -1,0 +1,4 @@
+SELECT status
+FROM proposals_open
+WHERE proposal_id = ?1
+AND namespace = ?2

--- a/crates/khive-pack-kg/sql/proposals_read_projection.sql
+++ b/crates/khive-pack-kg/sql/proposals_read_projection.sql
@@ -1,0 +1,4 @@
+SELECT proposal_id, proposer, status, approve_count, reject_count
+FROM proposals_open
+WHERE proposal_id = ?1
+AND namespace = ?2

--- a/crates/khive-pack-kg/sql/proposals_read_proposer_status.sql
+++ b/crates/khive-pack-kg/sql/proposals_read_proposer_status.sql
@@ -1,0 +1,4 @@
+SELECT proposer, status
+FROM proposals_open
+WHERE proposal_id = ?1
+AND namespace = ?2

--- a/crates/khive-pack-kg/sql/proposals_revert_to_approved.sql
+++ b/crates/khive-pack-kg/sql/proposals_revert_to_approved.sql
@@ -1,0 +1,5 @@
+UPDATE proposals_open
+SET status = 'approved', updated_at = ?1
+WHERE proposal_id = ?2
+AND namespace = ?3
+AND status = 'applying'

--- a/crates/khive-pack-kg/sql/proposals_update_pending_review_status.sql
+++ b/crates/khive-pack-kg/sql/proposals_update_pending_review_status.sql
@@ -1,0 +1,8 @@
+UPDATE proposals_open
+SET status = ?1, updated_at = ?2, last_decision = ?3,
+    review_count = review_count + 1,
+    approve_count = approve_count + ?4,
+    reject_count = reject_count + ?5
+WHERE proposal_id = ?6
+AND namespace = ?7
+AND status NOT IN ('applied', 'applying', 'withdrawn', 'rejected', 'approved')

--- a/crates/khive-pack-kg/sql/proposals_update_review_comment.sql
+++ b/crates/khive-pack-kg/sql/proposals_update_review_comment.sql
@@ -1,0 +1,5 @@
+UPDATE proposals_open
+SET updated_at = ?1, last_decision = ?2,
+    review_count = review_count + 1
+WHERE proposal_id = ?3
+AND namespace = ?4

--- a/crates/khive-pack-kg/sql/proposals_update_review_status.sql
+++ b/crates/khive-pack-kg/sql/proposals_update_review_status.sql
@@ -1,0 +1,8 @@
+UPDATE proposals_open
+SET status = ?1, updated_at = ?2, last_decision = ?3,
+    review_count = review_count + 1,
+    approve_count = approve_count + ?4,
+    reject_count = reject_count + ?5
+WHERE proposal_id = ?6
+AND namespace = ?7
+AND status NOT IN ('applied', 'withdrawn', 'rejected', 'approved')

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -20,6 +20,7 @@ use super::common::{
     parse_event_kind, parse_event_outcome, parse_event_substrate, remap_note_status,
     resolve_uuid_unfiltered, resolve_uuid_unfiltered_including_deleted, to_json, GetParams,
 };
+use crate::sql::sql;
 use crate::KgPack;
 
 impl KgPack {
@@ -283,11 +284,7 @@ impl KgPack {
         let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
         let row = reader
             .query_row(SqlStatement {
-                sql: "SELECT id, namespace, verb, substrate, actor, kind, outcome, payload, \
-                      payload_schema_version, profile_state_version, duration_us, target_id, \
-                      session_id, aggregate_kind, aggregate_id, created_at \
-                      FROM events WHERE id = ?1 LIMIT 1"
-                    .to_string(),
+                sql: sql!("events_find_by_id").to_string(),
                 params: vec![SqlValue::Text(id.to_string())],
                 label: Some("events.get_unfiltered_by_id".into()),
             })
@@ -343,17 +340,13 @@ impl KgPack {
 
         let (sql_str, params) = if Uuid::from_str(raw_id).is_ok() {
             (
-                "SELECT proposal_id FROM proposals_open \
-                 WHERE proposal_id = ?1 AND namespace = ?2 LIMIT 1"
-                    .to_string(),
+                sql!("proposals_find_by_id").to_string(),
                 vec![SqlValue::Text(raw_id.to_string()), SqlValue::Text(ns)],
             )
         } else if raw_id.len() >= 8 && raw_id.chars().all(|c| c.is_ascii_hexdigit()) {
             let pattern = format!("{}%", hex_prefix_to_uuid_pattern(raw_id));
             (
-                "SELECT proposal_id FROM proposals_open \
-                 WHERE proposal_id LIKE ?1 AND namespace = ?2 LIMIT 2"
-                    .to_string(),
+                sql!("proposals_find_by_prefix").to_string(),
                 vec![SqlValue::Text(pattern), SqlValue::Text(ns)],
             )
         } else {

--- a/crates/khive-pack-kg/src/handlers/list.rs
+++ b/crates/khive-pack-kg/src/handlers/list.rs
@@ -16,6 +16,7 @@ use super::common::{
     resolve_kind_spec, resolve_uuid_async, tags_match_any, to_json, validate_entity_type, KindSpec,
     ListParams,
 };
+use crate::sql::sql;
 use crate::KgPack;
 
 const ENTITY_LIST_CAP: u32 = 500;
@@ -86,20 +87,9 @@ async fn resolve_message_thread_filter(
     } else {
         token.visible_namespace_strs()
     };
-    let placeholders = (1..=visible.len())
-        .map(|index| format!("?{index}"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let sql = format!(
-        "SELECT DISTINCT json_extract(properties, '$.thread_id') AS thread_id \
-                   FROM notes WHERE namespace IN ({placeholders}) AND deleted_at IS NULL \
-                   AND json_type(properties, '$.thread_id') = 'text' \
-                   AND kind = 'message'"
-    );
-    let params = visible
-        .into_iter()
-        .map(|namespace| SqlValue::Text(namespace.to_string()))
-        .collect();
+    let visible_json = serde_json::to_string(&visible).map_err(|error| {
+        RuntimeError::Internal(format!("serialize visible namespaces: {error}"))
+    })?;
     let mut reader = runtime
         .sql()
         .reader()
@@ -107,8 +97,8 @@ async fn resolve_message_thread_filter(
         .map_err(RuntimeError::Storage)?;
     let rows = reader
         .query_all(SqlStatement {
-            sql,
-            params,
+            sql: sql!("message_threads_list").to_string(),
+            params: vec![SqlValue::Text(visible_json)],
             label: Some("list.resolve_message_thread_filter".to_string()),
         })
         .await
@@ -779,6 +769,7 @@ impl KgPack {
 mod tests {
     use super::parse_after_cursor;
     use crate::handlers::common::{event_filter_from_params, ListParams};
+    use crate::sql::sql;
 
     #[test]
     fn after_cursor_rejects_prefix_with_keyset_consequence() {
@@ -807,6 +798,53 @@ mod tests {
             assert!(message.contains(field), "{message}");
             assert!(message.contains("can miss or be ambiguous"), "{message}");
             assert!(message.contains("exact stable record"), "{message}");
+        }
+    }
+
+    #[tokio::test]
+    async fn message_thread_namespace_json_scope_handles_empty_single_and_past_bind_limit() {
+        use khive_runtime::{KhiveRuntime, Namespace};
+        use khive_storage::types::{SqlStatement, SqlValue};
+
+        let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+        let namespace = Namespace::parse("scope-one").expect("valid namespace");
+        let token = runtime.authorize(namespace).expect("authorized namespace");
+        runtime
+            .create_note(
+                &token,
+                "message",
+                None,
+                "threaded message",
+                None,
+                Some(serde_json::json!({
+                    "thread_id": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+                })),
+                vec![],
+            )
+            .await
+            .expect("create message note");
+
+        let past_bind_limit = (0..33_000)
+            .map(|index| format!("scope-{index}"))
+            .chain(std::iter::once("scope-one".to_string()))
+            .collect::<Vec<_>>();
+        for (case, namespaces, expected_rows) in [
+            ("empty", Vec::<String>::new(), 0),
+            ("single", vec!["scope-one".to_string()], 1),
+            ("past SQLite bind limit", past_bind_limit, 1),
+        ] {
+            let namespaces_json =
+                serde_json::to_string(&namespaces).expect("serialize namespace scope");
+            let mut reader = runtime.sql().reader().await.expect("SQL reader");
+            let rows = reader
+                .query_all(SqlStatement {
+                    sql: sql!("message_threads_list").to_string(),
+                    params: vec![SqlValue::Text(namespaces_json)],
+                    label: Some("test.message_threads_list".into()),
+                })
+                .await
+                .expect("message thread scope query");
+            assert_eq!(rows.len(), expected_rows, "{case} namespace scope");
         }
     }
 }

--- a/crates/khive-pack-kg/src/handlers/proposal.rs
+++ b/crates/khive-pack-kg/src/handlers/proposal.rs
@@ -17,6 +17,7 @@ use super::common::{
     deser, to_json, ListProposalsParams, ProposeParams, ReviewParams, WithdrawParams,
 };
 use crate::apply_worker::has_multi_step_compound;
+use crate::sql::sql;
 use crate::KgPack;
 
 use khive_runtime::micros_to_iso;
@@ -39,9 +40,7 @@ impl KgPack {
             let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
             let rows = reader
                 .query_all(SqlStatement {
-                    sql: "SELECT proposal_id FROM proposals_open \
-                          WHERE proposal_id LIKE ?1 AND namespace = ?2 LIMIT 2"
-                        .to_string(),
+                    sql: sql!("proposals_find_by_prefix").to_string(),
                     params: vec![SqlValue::Text(pattern), SqlValue::Text(ns)],
                     label: Some("proposals_open.resolve_prefix".into()),
                 })
@@ -161,9 +160,7 @@ impl KgPack {
             let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
             let parent_row = reader
                 .query_row(SqlStatement {
-                    sql: "SELECT status FROM proposals_open \
-                          WHERE proposal_id = ?1 AND namespace = ?2"
-                        .to_string(),
+                    sql: sql!("proposals_read_parent_status").to_string(),
                     params: vec![
                         SqlValue::Text(parent_uuid.to_string()),
                         SqlValue::Text(ns.clone()),
@@ -255,9 +252,7 @@ impl KgPack {
 
         let row = reader
             .query_row(SqlStatement {
-                sql: "SELECT proposer, status FROM proposals_open \
-                      WHERE proposal_id = ?1 AND namespace = ?2"
-                    .to_string(),
+                sql: sql!("proposals_read_proposer_status").to_string(),
                 params: vec![
                     SqlValue::Text(proposal_id.to_string()),
                     SqlValue::Text(ns.clone()),
@@ -389,9 +384,7 @@ impl KgPack {
 
         let row = reader
             .query_row(SqlStatement {
-                sql: "SELECT proposer, status FROM proposals_open \
-                      WHERE proposal_id = ?1 AND namespace = ?2"
-                    .to_string(),
+                sql: sql!("proposals_read_proposer_status").to_string(),
                 params: vec![
                     SqlValue::Text(proposal_id.to_string()),
                     SqlValue::Text(ns.clone()),
@@ -496,55 +489,41 @@ impl KgPack {
         let limit = i64::from(effective);
         let offset = p.offset.unwrap_or(0) as i64;
 
-        let mut sql_str = "\
-            SELECT proposal_id, proposer, title, status, created_at, updated_at, \
-                   expiry, last_decision, review_count, approve_count, reject_count \
-            FROM proposals_open \
-            WHERE namespace = ?1"
-            .to_string();
-        let mut sql_params: Vec<SqlValue> = vec![SqlValue::Text(ns)];
-        let mut param_idx = 2usize;
-
-        if let Some(status) = &p.status {
-            sql_str.push_str(&format!(" AND status = ?{param_idx}"));
-            sql_params.push(SqlValue::Text(status.clone()));
-            param_idx += 1;
-        }
-
-        if let Some(proposer) = &p.proposer {
-            sql_str.push_str(&format!(" AND proposer = ?{param_idx}"));
-            sql_params.push(SqlValue::Text(proposer.clone()));
-            param_idx += 1;
+        let proposer_filter = if let Some(proposer) = &p.proposer {
+            Some(proposer.clone())
         } else {
             let actor_filter = p
                 .actor
                 .as_deref()
                 .unwrap_or_else(|| token.actor().id.as_str());
             if actor_filter != "*" {
-                sql_str.push_str(&format!(" AND proposer = ?{param_idx}"));
-                sql_params.push(SqlValue::Text(actor_filter.to_owned()));
-                param_idx += 1;
+                Some(actor_filter.to_owned())
+            } else {
+                None
             }
-        }
+        };
 
-        sql_str.push_str(&format!(
-            // #1671: `proposal_id` tiebreak makes the offset page order a
-            // deterministic total order across rows that share an
-            // `updated_at` timestamp. Offset paging can still duplicate or
-            // skip rows under concurrent inserts/deletes/updates — the
-            // tiebreak only removes tie-order instability, same caveat as
-            // the entity/graph/note sweeps.
-            " ORDER BY updated_at DESC, proposal_id DESC LIMIT ?{param_idx} OFFSET ?{}",
-            param_idx + 1
-        ));
-        sql_params.push(SqlValue::Integer(limit));
-        sql_params.push(SqlValue::Integer(offset));
+        // #1671: `proposal_id` tiebreak makes the offset page order a
+        // deterministic total order across rows that share an
+        // `updated_at` timestamp. Offset paging can still duplicate or
+        // skip rows under concurrent inserts/deletes/updates — the
+        // tiebreak only removes tie-order instability, same caveat as
+        // the entity/graph/note sweeps.
+        let sql_params = vec![
+            SqlValue::Text(ns),
+            p.status.map(SqlValue::Text).unwrap_or(SqlValue::Null),
+            proposer_filter
+                .map(SqlValue::Text)
+                .unwrap_or(SqlValue::Null),
+            SqlValue::Integer(limit),
+            SqlValue::Integer(offset),
+        ];
 
         let sql = self.runtime.sql();
         let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
         let rows = reader
             .query_all(SqlStatement {
-                sql: sql_str,
+                sql: sql!("proposals_list").to_string(),
                 params: sql_params,
                 label: Some("proposals_open.list".into()),
             })

--- a/crates/khive-pack-kg/src/lib.rs
+++ b/crates/khive-pack-kg/src/lib.rs
@@ -1,5 +1,7 @@
 //! pack-kg — Knowledge Graph verb pack for khive. 24 verbs: entities, notes, edges, queries, proposals, context, resolve, whoami, db_diagnostics.
 
+mod sql;
+
 pub mod apply_worker;
 mod dispatch;
 pub mod entity_type_registry;

--- a/crates/khive-pack-kg/src/projection_worker/helpers.rs
+++ b/crates/khive-pack-kg/src/projection_worker/helpers.rs
@@ -1,25 +1,19 @@
 //! SQL helpers for the proposals projection worker.
 
+use crate::sql::sql;
 use khive_storage::{
     event::Event,
     types::{SqlStatement, SqlValue},
 };
 
 /// Build a conditional event INSERT `SqlStatement` for use in `execute_batch`.
-pub(crate) fn build_conditional_event_insert(
-    event: &Event,
-    guard_sql: &str,
-    guard_params: Vec<SqlValue>,
-) -> SqlStatement {
+pub(crate) fn build_conditional_event_insert(event: &Event) -> SqlStatement {
     let substrate_str = event.substrate.name().to_string();
     let kind_str = event.kind.name().to_string();
     let outcome_str = event.outcome.name().to_string();
     let payload_str = event.payload.to_string();
 
-    let guard_offset = 17usize;
-    let remapped_guard = remap_guard_params(guard_sql, guard_offset);
-
-    let mut params = vec![
+    let params = vec![
         SqlValue::Text(event.id.to_string()),
         SqlValue::Text(event.namespace.clone()),
         SqlValue::Text(event.verb.clone()),
@@ -52,72 +46,9 @@ pub(crate) fn build_conditional_event_insert(
         },
         SqlValue::Integer(event.created_at),
     ];
-    params.extend(guard_params);
-
     SqlStatement {
-        sql: format!(
-            "INSERT INTO events \
-             (id, namespace, verb, substrate, actor, kind, outcome, payload, \
-              payload_schema_version, profile_state_version, duration_us, \
-              target_id, session_id, aggregate_kind, aggregate_id, created_at) \
-             SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16 \
-             WHERE ({remapped_guard})"
-        ),
+        sql: sql!("events_insert_if_changed").to_string(),
         params,
         label: Some("projection_worker.conditional_event_insert".into()),
     }
-}
-
-/// Remap `?1`, `?2`, ... in `guard_sql` to `?{offset}`, `?{offset+1}`, ...
-pub(crate) fn remap_guard_params(guard_sql: &str, offset: usize) -> String {
-    let max_idx: usize = (1..=32)
-        .rev()
-        .find(|&i| {
-            let token = format!("?{i}");
-            let mut pos = 0;
-            while let Some(found) = guard_sql[pos..].find(&token) {
-                let abs = pos + found;
-                let after = abs + token.len();
-                if guard_sql[after..]
-                    .chars()
-                    .next()
-                    .is_none_or(|c| !c.is_ascii_digit())
-                {
-                    return true;
-                }
-                pos = abs + 1;
-            }
-            false
-        })
-        .unwrap_or(0);
-
-    if max_idx == 0 {
-        return guard_sql.to_string();
-    }
-
-    let mut result = guard_sql.to_string();
-    for i in (1..=max_idx).rev() {
-        let old = format!("?{i}");
-        let new = format!("?{}", i + offset - 1);
-        let mut out = String::with_capacity(result.len());
-        let mut pos = 0;
-        while let Some(found) = result[pos..].find(&old) {
-            let abs = pos + found;
-            let after = abs + old.len();
-            if result[after..]
-                .chars()
-                .next()
-                .is_none_or(|c| !c.is_ascii_digit())
-            {
-                out.push_str(&result[pos..abs]);
-                out.push_str(&new);
-            } else {
-                out.push_str(&result[pos..after]);
-            }
-            pos = after;
-        }
-        out.push_str(&result[pos..]);
-        result = out;
-    }
-    result
 }

--- a/crates/khive-pack-kg/src/projection_worker/mod.rs
+++ b/crates/khive-pack-kg/src/projection_worker/mod.rs
@@ -2,6 +2,7 @@
 
 mod helpers;
 
+use crate::sql::sql;
 use helpers::build_conditional_event_insert;
 
 use khive_runtime::{EventAttribution, KhiveRuntime, NamespaceToken, RuntimeError};
@@ -38,11 +39,7 @@ impl ProposalsProjectionWorker {
         let mut writer = sql.writer().await.map_err(RuntimeError::Storage)?;
         writer
             .execute(SqlStatement {
-                sql: "INSERT INTO proposals_open \
-                        (proposal_id, namespace, proposer, title, status, \
-                         created_at, updated_at, expiry) \
-                      VALUES (?1, ?2, ?3, ?4, 'open', ?5, ?5, ?6)"
-                    .to_string(),
+                sql: sql!("proposals_insert").to_string(),
                 params: vec![
                     SqlValue::Text(proposal_id.to_string()),
                     SqlValue::Text(ns),
@@ -87,14 +84,7 @@ impl ProposalsProjectionWorker {
         let rows = if let Some(new_status) = new_status_opt {
             writer
                 .execute(SqlStatement {
-                    sql: "UPDATE proposals_open \
-                          SET status = ?1, updated_at = ?2, last_decision = ?3, \
-                              review_count = review_count + 1, \
-                              approve_count = approve_count + ?4, \
-                              reject_count = reject_count + ?5 \
-                          WHERE proposal_id = ?6 AND namespace = ?7 \
-                            AND status NOT IN ('applied', 'withdrawn', 'rejected', 'approved')"
-                        .to_string(),
+                    sql: sql!("proposals_update_review_status").to_string(),
                     params: vec![
                         SqlValue::Text(new_status.to_string()),
                         SqlValue::Integer(now),
@@ -111,11 +101,7 @@ impl ProposalsProjectionWorker {
         } else {
             writer
                 .execute(SqlStatement {
-                    sql: "UPDATE proposals_open \
-                          SET updated_at = ?1, last_decision = ?2, \
-                              review_count = review_count + 1 \
-                          WHERE proposal_id = ?3 AND namespace = ?4"
-                        .to_string(),
+                    sql: sql!("proposals_update_review_comment").to_string(),
                     params: vec![
                         SqlValue::Integer(now),
                         SqlValue::Text(last_decision_str.to_string()),
@@ -142,11 +128,7 @@ impl ProposalsProjectionWorker {
         let ns = token.namespace().as_str().to_owned();
         let event = EventAttribution::from_token(token).stamp(event);
         let projection_stmt = SqlStatement {
-            sql: "UPDATE proposals_open \
-                  SET status = 'applied', updated_at = ?1 \
-                  WHERE proposal_id = ?2 AND namespace = ?3 \
-                    AND status = 'applying'"
-                .to_string(),
+            sql: sql!("proposals_mark_applied").to_string(),
             params: vec![
                 SqlValue::Integer(now),
                 SqlValue::Text(proposal_id.to_string()),
@@ -154,7 +136,7 @@ impl ProposalsProjectionWorker {
             ],
             label: Some("projection_worker.applied_and_emit.cas".into()),
         };
-        let event_stmt = build_conditional_event_insert(&event, "changes() = 1", vec![]);
+        let event_stmt = build_conditional_event_insert(&event);
 
         let sql = self.runtime.sql();
         let mut writer = sql.writer().await.map_err(RuntimeError::Storage)?;
@@ -183,11 +165,7 @@ impl ProposalsProjectionWorker {
         let mut writer = sql.writer().await.map_err(RuntimeError::Storage)?;
         let rows = writer
             .execute(SqlStatement {
-                sql: "UPDATE proposals_open \
-                      SET status = 'applying', updated_at = ?1 \
-                      WHERE proposal_id = ?2 AND namespace = ?3 \
-                        AND status = 'approved'"
-                    .to_string(),
+                sql: sql!("proposals_mark_applying").to_string(),
                 params: vec![
                     SqlValue::Integer(now),
                     SqlValue::Text(proposal_id.to_string()),
@@ -212,11 +190,7 @@ impl ProposalsProjectionWorker {
         let mut writer = sql.writer().await.map_err(RuntimeError::Storage)?;
         let rows = writer
             .execute(SqlStatement {
-                sql: "UPDATE proposals_open \
-                      SET status = 'withdrawn', updated_at = ?1 \
-                      WHERE proposal_id = ?2 AND namespace = ?3 \
-                        AND status NOT IN ('applied', 'applying', 'withdrawn', 'rejected')"
-                    .to_string(),
+                sql: sql!("proposals_mark_withdrawn").to_string(),
                 params: vec![
                     SqlValue::Integer(now),
                     SqlValue::Text(proposal_id.to_string()),
@@ -241,11 +215,7 @@ impl ProposalsProjectionWorker {
         let mut writer = sql.writer().await.map_err(RuntimeError::Storage)?;
         writer
             .execute(SqlStatement {
-                sql: "UPDATE proposals_open \
-                      SET status = 'approved', updated_at = ?1 \
-                      WHERE proposal_id = ?2 AND namespace = ?3 \
-                        AND status = 'applying'"
-                    .to_string(),
+                sql: sql!("proposals_revert_to_approved").to_string(),
                 params: vec![
                     SqlValue::Integer(now),
                     SqlValue::Text(proposal_id.to_string()),
@@ -280,37 +250,23 @@ impl ProposalsProjectionWorker {
             };
         let last_decision_str = payload.decision.as_str();
 
-        let (projection_stmt, guard_sql, guard_params) = if let Some(new_status) = new_status_opt {
-            let stmt = SqlStatement {
-                    sql: "UPDATE proposals_open \
-                          SET status = ?1, updated_at = ?2, last_decision = ?3, \
-                              review_count = review_count + 1, \
-                              approve_count = approve_count + ?4, \
-                              reject_count = reject_count + ?5 \
-                          WHERE proposal_id = ?6 AND namespace = ?7 \
-                            AND status NOT IN ('applied', 'applying', 'withdrawn', 'rejected', 'approved')"
-                        .to_string(),
-                    params: vec![
-                        SqlValue::Text(new_status.to_string()),
-                        SqlValue::Integer(now),
-                        SqlValue::Text(last_decision_str.to_string()),
-                        SqlValue::Integer(approve_delta),
-                        SqlValue::Integer(reject_delta),
-                        SqlValue::Text(proposal_id.to_string()),
-                        SqlValue::Text(ns.clone()),
-                    ],
-                    label: Some("projection_worker.reviewed_and_emit.cas".into()),
-                };
-            let guard = "changes() = 1";
-            let gp: Vec<SqlValue> = vec![];
-            (stmt, guard, gp)
+        let projection_stmt = if let Some(new_status) = new_status_opt {
+            SqlStatement {
+                sql: sql!("proposals_update_pending_review_status").to_string(),
+                params: vec![
+                    SqlValue::Text(new_status.to_string()),
+                    SqlValue::Integer(now),
+                    SqlValue::Text(last_decision_str.to_string()),
+                    SqlValue::Integer(approve_delta),
+                    SqlValue::Integer(reject_delta),
+                    SqlValue::Text(proposal_id.to_string()),
+                    SqlValue::Text(ns.clone()),
+                ],
+                label: Some("projection_worker.reviewed_and_emit.cas".into()),
+            }
         } else {
-            let stmt = SqlStatement {
-                sql: "UPDATE proposals_open \
-                          SET updated_at = ?1, last_decision = ?2, \
-                              review_count = review_count + 1 \
-                          WHERE proposal_id = ?3 AND namespace = ?4"
-                    .to_string(),
+            SqlStatement {
+                sql: sql!("proposals_update_review_comment").to_string(),
                 params: vec![
                     SqlValue::Integer(now),
                     SqlValue::Text(last_decision_str.to_string()),
@@ -318,14 +274,11 @@ impl ProposalsProjectionWorker {
                     SqlValue::Text(ns.clone()),
                 ],
                 label: Some("projection_worker.reviewed_and_emit.comment".into()),
-            };
-            let guard = "changes() = 1";
-            let gp: Vec<SqlValue> = vec![];
-            (stmt, guard, gp)
+            }
         };
 
         let event_id = event.id;
-        let event_stmt = build_conditional_event_insert(&event, guard_sql, guard_params);
+        let event_stmt = build_conditional_event_insert(&event);
 
         let sql = self.runtime.sql();
         let mut writer = sql.writer().await.map_err(RuntimeError::Storage)?;
@@ -355,11 +308,7 @@ impl ProposalsProjectionWorker {
         let event = EventAttribution::from_token(token).stamp(event);
 
         let projection_stmt = SqlStatement {
-            sql: "UPDATE proposals_open \
-                  SET status = 'withdrawn', updated_at = ?1 \
-                  WHERE proposal_id = ?2 AND namespace = ?3 \
-                    AND status NOT IN ('applied', 'applying', 'withdrawn', 'rejected')"
-                .to_string(),
+            sql: sql!("proposals_mark_withdrawn").to_string(),
             params: vec![
                 SqlValue::Integer(now),
                 SqlValue::Text(proposal_id.to_string()),
@@ -368,11 +317,8 @@ impl ProposalsProjectionWorker {
             label: Some("projection_worker.withdrawn_and_emit.cas".into()),
         };
 
-        let guard_sql = "changes() = 1";
-        let guard_params: Vec<SqlValue> = vec![];
-
         let event_id = event.id;
-        let event_stmt = build_conditional_event_insert(&event, guard_sql, guard_params);
+        let event_stmt = build_conditional_event_insert(&event);
 
         let sql = self.runtime.sql();
         let mut writer = sql.writer().await.map_err(RuntimeError::Storage)?;
@@ -396,10 +342,7 @@ impl ProposalsProjectionWorker {
         let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
         let row = reader
             .query_row(SqlStatement {
-                sql: "SELECT proposal_id, proposer, status, approve_count, reject_count \
-                      FROM proposals_open \
-                      WHERE proposal_id = ?1 AND namespace = ?2"
-                    .to_string(),
+                sql: sql!("proposals_read_projection").to_string(),
                 params: vec![SqlValue::Text(proposal_id.to_string()), SqlValue::Text(ns)],
                 label: Some("projection_worker.proposals_open.get".into()),
             })

--- a/crates/khive-pack-kg/src/sql.rs
+++ b/crates/khive-pack-kg/src/sql.rs
@@ -1,0 +1,13 @@
+//! SQL lives beside the code as `sql/<name>.sql`: one statement per file,
+//! `?N` binds only, never string-built, loaded at compile time by `sql!`.
+
+/// The statement text of `sql/<name>.sql`, checked in at compile time.
+macro_rules! sql {
+    ($name:literal) => {
+        const {
+            include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/sql/", $name, ".sql"))
+                .trim_ascii_end()
+        }
+    };
+}
+pub(crate) use sql;

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -8784,6 +8784,91 @@ async fn list_proposals_status_filter() {
     );
 }
 
+#[tokio::test]
+#[serial_test::serial(config_ledger)]
+async fn list_proposals_actor_filter_and_explicit_proposer_precedence() {
+    let rt = KhiveRuntime::memory().expect("in-memory runtime must succeed");
+
+    let fixture_for = |actor: &str| {
+        let mut builder = VerbRegistryBuilder::new();
+        builder
+            .with_runtime_event_store(&rt)
+            .expect("configure trusted runtime audit store");
+        builder.with_actor_id(Some(actor.to_string()));
+        builder.register(KgPack::new(rt.clone()));
+        Fixture {
+            registry: builder.build().expect("registry build must succeed"),
+        }
+    };
+
+    let alice = fixture_for("alice");
+    let bob = fixture_for("bob");
+    let alice_id = alice
+        .dispatch(
+            "propose",
+            json!({
+                "title": "Alice proposal",
+                "description": "Owned by Alice",
+                "changeset": changeset_add_entity()
+            }),
+        )
+        .await
+        .expect("Alice proposal must succeed")["id"]
+        .as_str()
+        .expect("Alice proposal id")
+        .to_string();
+    let bob_id = bob
+        .dispatch(
+            "propose",
+            json!({
+                "title": "Bob proposal",
+                "description": "Owned by Bob",
+                "changeset": changeset_add_entity()
+            }),
+        )
+        .await
+        .expect("Bob proposal must succeed")["id"]
+        .as_str()
+        .expect("Bob proposal id")
+        .to_string();
+
+    let default_items = alice
+        .dispatch("list", json!({"kind": "proposal"}))
+        .await
+        .expect("default proposal list must succeed");
+    let default_items = list_items(&default_items);
+    assert!(default_items.iter().any(|item| item["id"] == alice_id));
+    assert!(!default_items.iter().any(|item| item["id"] == bob_id));
+
+    let all_items = alice
+        .dispatch("list", json!({"kind": "proposal", "actor": "*"}))
+        .await
+        .expect("unscoped proposal list must succeed");
+    let all_items = list_items(&all_items);
+    assert!(all_items.iter().any(|item| item["id"] == alice_id));
+    assert!(all_items.iter().any(|item| item["id"] == bob_id));
+
+    let explicit_items = alice
+        .dispatch(
+            "list",
+            json!({"kind": "proposal", "actor": "alice", "proposer": "bob"}),
+        )
+        .await
+        .expect("explicit proposer list must succeed");
+    let explicit_items = list_items(&explicit_items);
+    assert!(!explicit_items.iter().any(|item| item["id"] == alice_id));
+    assert!(explicit_items.iter().any(|item| item["id"] == bob_id));
+
+    let empty_status = alice
+        .dispatch(
+            "list",
+            json!({"kind": "proposal", "actor": "*", "status": ""}),
+        )
+        .await
+        .expect("empty status filter must remain a real filter");
+    assert!(list_items(&empty_status).is_empty());
+}
+
 /// Negative path: withdraw on an applied proposal must fail.
 /// propose → approve (auto-applies) → withdraw → expect error mentioning "applied".
 #[tokio::test]

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -7960,7 +7960,7 @@ pub(crate) mod tests {
     #[test]
     fn converted_crates_keep_their_sql_out_of_rust() {
         /// Crates whose statements live in `sql/`. One pull request adds one name.
-        const CONVERTED: &[&str] = &["khive-pack-brain"];
+        const CONVERTED: &[&str] = &["khive-pack-brain", "khive-pack-kg"];
         /// A crate known to still hold SQL in Rust, used only to prove the detector
         /// fires. When this one is converted, move the control to another unconverted
         /// crate rather than deleting it.


### PR DESCRIPTION
Seventeen statements out of `khive-pack-kg` into `crates/khive-pack-kg/sql/`, through the crate-local `sql!` macro. No statement was excluded.

Three were not straight moves, and each one is a shape change worth reading.

The conditional event insert took a guard clause and its parameters from the caller, remapped the guard's bind numbers past the insert's own sixteen, and spliced it into the `WHERE`. Every one of the four construction sites passed the same constant guard with no parameters, so the statement is now fixed text in a file and the remapping helper is gone with it.

The message-thread listing took a namespace scope as a generated `IN (?1, ?2, ...)` list, which put a ceiling on how many namespaces a request could name. It now passes one JSON array and reads it with `json_each`, and a new test drives it past SQLite's bind limit, which the old form could not survive.

The proposals listing assembled its `WHERE` clause from whichever filters were present. It is one statement now, with each optional filter written as `(?n IS NULL OR column = ?n)`, and a new test pins the filter semantics so the rewrite is held to the behaviour it replaced.

`scripts/lint-sql.sh` prepares every query file against the real schema, and `khive-pack-kg` joins the workspace census's converted list.