### PR TITLE
docs(adr): installable pack distributions beside linked packs

### DIFF
--- a/docs/adr/ADR-017-pack-standard.md
+++ b/docs/adr/ADR-017-pack-standard.md
@@ -939,3 +939,71 @@ dedicated ADR. v1 is compile-time.
 - ADR-023: Pack Verb Surface, Visibility, and Composition — third-party packs ship as
   Rust crates implementing the `Pack` trait and self-register via `inventory::submit!`;
   the YAML-manifest model is rescinded.
+
+## Amendment (2026-09-12): a runtime-owned adapter, because static declarations are not an install format
+
+**Status**: proposed
+
+`Pack` is const associated items in `khive-types` — `NAME`, `NOTE_KINDS`, `ENTITY_KINDS`,
+`HANDLERS`, `EDGE_RULES`, `REQUIRES` — and "Why const associated items in `Pack`?" gives the
+reason: vocabulary is static, methods would force vtable dispatch and allocation for metadata
+that never changes. That reasoning is sound and this amendment does not touch it.
+
+It also makes `Pack` unable to describe an installed distribution. Every field is
+`&'static str` by construction, which is another way of saying the metadata must be known to
+the compiler. The metadata of an installed pack is read from a package at install time and
+lives exactly as long as the installation. No amount of care with the trait closes that gap:
+the trait is a compile-time contract and an install format is not a compile-time thing.
+
+### The amendment
+
+**The runtime owns an adapter** that presents an installed distribution through the same
+`PackRuntime` seam the linked packs use. The adapter holds owned metadata, validated at
+install, and answers the questions `Pack`'s consts answer for a linked pack: which note and
+entity kinds it registers, its handler definitions with their visibility, its edge endpoint
+rules, and what it requires.
+
+`Pack` itself is unchanged. It is not made dynamic, not given methods, and not parameterized
+over ownership. Linked packs keep the exact shape and the exact cost they have today.
+
+### What this buys, and it is the reason for doing it this way
+
+Everything downstream of the seam keeps **one** code path. Vocabulary merging, the boot-time
+collision checks, pack-extensible edge endpoints, the storage profile and pack-auxiliary
+schema, and the dispatch path do not learn that two kinds of pack exist. A rule that holds for
+linked packs holds for installed ones because the same code enforces it on the same shape.
+
+What moves is the **moment** of validation, not its content. For a linked pack, a kind
+collision or a malformed edge rule is caught at boot, and some of it is caught by the compiler
+before that. For an installed pack the same checks run at install time, against the live
+accepted set, and a failure refuses the installation rather than failing a restart. Same
+invariant, earlier or later clock.
+
+### The four costs this ADR named, answered per profile
+
+"Compile-time vs runtime composition" rejected dynamic loading on ABI compatibility, version
+skew, security surface, and linking complexity, and said that if a marketplace of third-party
+packs became a real need it would get its own ADR. Taking them in order:
+
+- **ABI.** The data-only profile has no ABI, because it ships no code. The component profile
+  pins an interface world, which is a versioned contract checked at install, not a native
+  calling convention that must match a build.
+- **Version skew.** The installation pins package, host interface, schema and resource
+  revisions separately, and an upgrade that would increase permissions or downgrade a revision
+  is refused rather than resolved.
+- **Security surface.** For data-only there is no code to sandbox; the surface is the
+  validator, and it refuses unknown predicates instead of ignoring them. For components the
+  surface is the guest sandbox and the typed imports the host grants, not the host process.
+- **Linking complexity.** `dlopen` stays rejected, so no symbol resolution or lifetime
+  management enters the host.
+
+### What does not change
+
+- `Pack`'s const shape for linked packs, and `inventory` as their only discovery mechanism.
+- `kg` owning shared CRUD, `KindHook` as the specialization route, closed relations with
+  additive-only endpoint rules.
+- **"Why no special treatment for built-in packs?"**, which now cuts in both directions: an
+  installed pack gets no special treatment either. It receives no privilege a linked pack
+  lacks, and no exemption from a check a linked pack passes.
+
+Nothing in this amendment authorizes implementation.

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -689,3 +689,56 @@ defaults an omitted result limit to 100, and returns no partial paths when the
 shared work or deadline budget is exceeded. These are verb semantics, so they
 belong in the generated handler help and public API reference as well as the
 storage contract; they do not add a new verb or change its speech act.
+
+## Amendment: an independently installed distribution is a pack (2026-09-12)
+
+**Status**: proposed
+
+§10 "Pack installation" says end users do not install packs at runtime, that there is no
+dynamic loading, and that using a third-party pack means building kkernel with it. It also
+says a future ADR may revisit that once a clear use case emerges. This amendment is that
+revisit, and it is narrow.
+
+**A pack may now arrive as an independently installed distribution**, either data-only or as
+a hosted component, beside the packs linked into the binary. Such a distribution is a pack in
+every sense this ADR defines, and the rules below are kept rather than relaxed:
+
+- **Two-tier visibility (§2)** is unchanged. An installed distribution declares handlers with
+  `Verb` or `Subhandler` visibility and only the former reach the wire.
+- **Verb naming (§4)** is unchanged. Installed verbs are pack-prefixed. The bare namespace
+  stays reserved to `kg`, and an installed distribution may not claim a bare verb.
+- **Composition (§7)** is unchanged, and this is the part worth being explicit about: no verb
+  override, no middleware, no verb inheritance, no horizontal sharing of a verb name. The two
+  extension routes stay the only two — new pack-private verbs, or a `KindHook` on an existing
+  substrate verb.
+- **Field naming (§5)** and **kind-polymorphic substrate verbs (§6)** apply as written.
+- **Discovery (§9)** is unchanged for linked packs: `inventory` at link time, `REQUIRES`
+  topological sort, `BootError::VerbCollision` at boot.
+
+### The one addition
+
+Collision checking acquires a second moment. For linked packs it happens at boot, against the
+set the binary carries. For an installed distribution it must also happen **at install time,
+against the deployment's live accepted set**, and a colliding install is refused then. Waiting
+for the next boot would accept a distribution that cannot be served and would turn a rejected
+install into a failed restart. The collision domain is the deployment's accepted set, which is
+the linked packs plus every installation bound to that store.
+
+### What an installed distribution may not do
+
+- Supply an open-ended expression language. Rules are bounded declarations the host
+  interprets: identity, kinds with closed schemas, regex, enum, size and required-set
+  constraints, verb parameter schemas, capability requests, a pure pre-write validation, a
+  post-write enrichment subscription, a promotion adapter, skills and resources. Nothing
+  evaluates arbitrary expressions.
+- Take authority from prose. A description tells a caller what a verb does and never grants a
+  capability, selects a namespace, or decides who may approve anything.
+- Be admitted with a predicate the host does not know. An unrecognized rule refuses the
+  install rather than being skipped.
+
+§10's stated reason for the v1 choice was that type safety and ABI stability outweighed
+zero-rebuild ergonomics. That trade holds where there is an ABI. The data-only profile has no
+ABI because it has no code, and the component profile pins an interface world rather than a
+native ABI, so neither reopens the cost §10 was avoiding.
+
+Nothing in this amendment authorizes implementation.

--- a/docs/adr/ADR-026-rust-binary-packaging.md
+++ b/docs/adr/ADR-026-rust-binary-packaging.md
@@ -427,7 +427,7 @@ sentence:
    have may ship as a component compiled to WebAssembly, loaded and driven by the native
    binary.
 
-The two are consistent because every blocker listed above is about the kernel's hot path.
+The two are consistent because every constraint listed above is about the kernel's hot path.
 Trigram indexing, vector search and embedding inference stay native and in-process. A guest
 component does not run that path. It runs its own work, pays guest cost for its own work
 only, and reaches the host solely through typed imports the host grants.

--- a/docs/adr/ADR-026-rust-binary-packaging.md
+++ b/docs/adr/ADR-026-rust-binary-packaging.md
@@ -404,3 +404,44 @@ skips every package already on the registry at the release version and publishes
 is missing. Its alias skip requires the published alias to carry the exact `khive`
 dependency; a published alias with a different dependency stops the script with an error
 instead of being reported as done.
+
+## Amendment 4 (2026-09-12): two different WebAssembly questions, separated
+
+**Status**: proposed
+
+"Why not WASM" and "Future WASM subpackage (optional, not v1)" answer one question: should
+the kkernel itself be compiled to WebAssembly and shipped as a guest? **That answer stands,
+unchanged, for the reasons given there** — `sqlite-vec` has no upstream WASM build, embedding
+inference wants native SIMD, the multi-threaded tokio runtime does not exist in WASM, SQLite
+throughput is native-bound, and atomic `tmp+rename` is awkward across WASI host shims. Open
+question 1, a reduced-functionality fallback subpackage for esoteric platforms, is untouched
+and still open.
+
+What this amendment changes is a reading, not a measurement. "WASM is not v1" has been taken
+to mean that WebAssembly has no place anywhere in khive. Two questions were riding on one
+sentence:
+
+1. **The kernel as a guest.** Rejected here, and the rejection stands.
+2. **Components as guests hosted by the native kernel.** Not a deferral any more. This
+   becomes a gated phase: a pack distribution that supplies an algorithm the host does not
+   have may ship as a component compiled to WebAssembly, loaded and driven by the native
+   binary.
+
+The two are consistent because every blocker listed above is about the kernel's hot path.
+Trigram indexing, vector search and embedding inference stay native and in-process. A guest
+component does not run that path. It runs its own work, pays guest cost for its own work
+only, and reaches the host solely through typed imports the host grants.
+
+### What gates the phase
+
+No component is admitted until all of the following exist and have been demonstrated: a
+pinned interface world and a pinned runtime revision; an enumerated set of denied imports; a
+hook that is bounded and pure, with its bounds enforced by the host rather than promised by
+the guest; and containment of traps and timeouts, shown by a guest that traps and a guest
+that runs long, with the host unharmed in both.
+
+Until that phase passes, the only installable profile is data-only, which carries no
+executable payload at all.
+
+Nothing in this amendment authorizes implementation, and none of ADR-026's original
+performance figures were re-measured for it.

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -1,6 +1,8 @@
 # ADR-027: Dynamic Pack Loading via Self-Registration
 
-**Status**: accepted\
+**Status**: accepted, and partly superseded by Amendment 4 (2026-09-12), which keeps this
+record's answer for packs linked into the binary and supersedes it for independently
+installed pack distributions. Native dynamic loading stays rejected.\
 **Date**: 2026-05-23\
 **Authors**: khive maintainers
 
@@ -495,3 +497,84 @@ this amendment to reflect the deviation.
 - [ADR-028](ADR-028-pack-scoped-backends.md) — extends pack configuration with per-pack
   backend assignment
 - `inventory` crate — compile-time plugin registration via linker sections
+
+## Amendment 4 (2026-09-12): installable pack distributions, and what stays rejected
+
+**Status**: proposed
+
+This ADR gave one answer to "how does a pack get into the process": it is linked at build
+time and discovered through `inventory`. That answer stays exactly as written for **built-in
+packs**, which remain the only packs the binary links. It is **superseded for a second
+class**: a versioned pack **distribution** that a running deployment installs and binds to
+one graph, without rebuilding the binary.
+
+The need this ADR called hypothetical has arrived. A curation application whose record
+kinds, closed schemas and validation rules are entirely data, authored outside this
+repository and installed into one tenant's store, cannot be served by "build kkernel with
+that pack as a dependency": the deployment would rebuild per application, and every
+installation would be a release.
+
+### What stays rejected
+
+- **Native dynamic loading.** `dlopen` remains rejected for the reasons in "Why not dlopen /
+  WASM dynamic loading" and Alternative B: ABI stability across version skew, symbol and
+  lifetime management, and arbitrary native code inside the store host. Nothing below
+  reopens it.
+- **A second discovery mechanism for linked packs.** `inventory` stays the only way a linked
+  pack is found. `REQUIRES` topological ordering, boot-time verb collisions and
+  `KHIVE_PACKS` selection are unchanged.
+
+### The two installable profiles
+
+1. **Data-only.** No executable payload. The distribution carries an identity, its record
+   kinds with closed schemas, bounded declarative rules (regex, enum, size, required-set),
+   verb parameter schemas and descriptions, its capability requests, a promotion adapter, and
+   its skills and resources. The native host interprets all of it. There is no ABI, because
+   there is no code.
+2. **Programmable.** A component compiled to WebAssembly against a pinned interface world,
+   hosted by the native kernel. This profile exists for a distribution that supplies an
+   algorithm the host does not have. The kernel itself is not ported; see the amendment on
+   ADR-026, which separates that question from this one.
+
+The first profile lands first and on its own. The second is a separate, later phase and
+nothing in it is authorized by this amendment.
+
+### The installation is the deployment's, not the distribution's
+
+Four identities stay distinct, and conflating any two of them is the failure this design is
+shaped against:
+
+| identity          | what it holds                                                                                  | who owns it               |
+| ----------------- | ---------------------------------------------------------------------------------------------- | ------------------------- |
+| distribution      | kinds, schemas, rules, verb contracts, capability requests, promotion format; immutable digest | the publisher             |
+| installation      | the accepted version, the granted capabilities, the graph binding, the generation              | the installing deployment |
+| graph instance    | the namespace the installation is bound to, with its history                                   | the installing deployment |
+| execution sandbox | a separate, revocable resource, never the store host                                           | the installing deployment |
+
+A distribution requests capabilities. It never holds them. An upgrade pins package, host
+interface, schema and resource revisions separately; added capabilities require fresh
+approval; a failed migration leaves the prior generation active; uninstall revokes grants
+first and keeps data and history by default.
+
+### Refusal is the default, and it is enumerated
+
+An install is refused, with no partial state, on any of: digest mismatch, unknown field,
+unsupported predicate, missing resource, verb-name collision against the live catalogue,
+dependency cycle, denied capability grant, an empty required set, a version downgrade, or a
+permission increase relative to the accepted installation. An **unknown predicate refuses the
+install**; it is never ignored and never treated as vacuously true, because a rule the host
+does not understand is a rule it cannot enforce.
+
+A description is documentation for a caller. It carries instructions and never authority: no
+text supplied by a distribution grants a capability, selects a namespace, or changes who may
+approve anything.
+
+### Ordering, stated as a constraint rather than a plan
+
+No git, exec or code verb is exposed to an installed distribution before an execution sandbox
+exists whose revocation is verified by reading state back: a durable disabled flag, an
+incremented epoch, zero active sandboxes, terminal outcomes for what was running, and a
+refused effect at the old epoch. A control that only hides tools from a listing does not
+satisfy it.
+
+Nothing in this amendment authorizes implementation.


### PR DESCRIPTION
Four reciprocal amendments, all **proposed**. Documentation only, no code, and nothing here authorizes implementation.

A consuming deployment needs to install a versioned pack distribution into a running store and bind it to one graph, without rebuilding the binary per application. Today's records answer that question with one answer for all packs: link at build time, discover through `inventory`. That answer is kept where it is right and superseded where it is not.

**ADR-027** keeps its answer for packs linked into the binary and is superseded for independently installed distributions. Native `dlopen` stays rejected, and `inventory` stays the only discovery mechanism for linked packs. The amendment names the two installable profiles (data-only, and a hosted component), the four identities that must not be conflated (distribution, installation, graph instance, execution sandbox), and the enumerated refusals. An unknown predicate refuses the install rather than being ignored, because a rule the host does not understand is a rule it cannot enforce.

**ADR-026** separates two questions its wording had riding on one sentence. Compiling the kernel to WebAssembly stays rejected, with its original reasons unchanged and its open question on a fallback subpackage untouched. Components hosted *by* the native kernel move from a deferral to a gated phase. The two are consistent because every blocker in the original section is about the kernel's hot path, which a guest component does not run.

**ADR-023** revisits section 10 as that section invited. An installed distribution is a pack: two-tier visibility, verb naming and the composition rules are kept rather than relaxed. One addition: collision checking also happens at install time against the deployment's live accepted set, because deferring it to the next boot turns a rejected install into a failed restart.

**ADR-017** adds a runtime-owned adapter and leaves the `Pack` trait alone. Its const associated items are `&'static` by construction, which is another way of saying the metadata must be known to the compiler; an installed distribution's metadata is read from a package at install time. The adapter presents it through the same `PackRuntime` seam, so vocabulary merging, boot-time collision checks, pack-extensible edge endpoints and the dispatch path keep one code path. What moves is the moment of validation, not its content. The four costs the original section named are answered per profile, and "no special treatment for built-in packs" now cuts both ways.

Docs only, so no behaviour changes and no test moves with it.
