### PR TITLE
fix(kg): allow replacing note tags through update

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -462,7 +462,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
         name: "update",
         description: "Patch entity, note, or edge fields. Accepted fields depend on substrate: \
                        entities accept name/description/properties/tags/entity_type; notes accept \
-                       name/content/salience/decay_factor/properties; edges accept relation/weight/properties.",
+                       name/content/salience/decay_factor/properties/tags; edges accept relation/weight/properties.",
         visibility: Visibility::Verb,
         category: VerbCategory::Declaration,
         params: &[
@@ -544,7 +544,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 24] = [
                 name: "tags",
                 param_type: "array of string",
                 required: false,
-                description: "Replace tag list.",
+                description: "Replace the tag list on entities or notes; omission preserves it and [] clears it. Note tags are stored in properties.tags, and this parameter takes precedence over properties.tags in the same request, including when empty.",
                 resolution_mode: IdResolutionMode::NotApplicable,
             },
             ParamDef {
@@ -1732,6 +1732,28 @@ mod tests {
     }
 
     // ── update/help param-documentation regressions ──────────────────────────
+
+    #[test]
+    fn update_params_documents_note_tag_replacement_and_precedence() {
+        let h = find_handler("update");
+        assert!(h
+            .description
+            .contains("name/content/salience/decay_factor/properties/tags"));
+        let tags = h.params.iter().find(|p| p.name == "tags").unwrap();
+        for detail in [
+            "entities or notes",
+            "omission preserves",
+            "[] clears",
+            "properties.tags",
+            "takes precedence",
+            "including when empty",
+        ] {
+            assert!(
+                tags.description.contains(detail),
+                "missing tag contract: {detail}"
+            );
+        }
+    }
 
     /// update.help must document `content` for notes.
     #[test]

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -1742,70 +1742,312 @@ async fn update_edge_symmetric_conflict_returns_tombstoned_survivor_with_deleted
     );
 }
 
-// HIGH regression: update(note_id, tags=[...]) must return an explicit error.
-// Notes have no top-level tags column; tags live in properties["tags"].
-// Before the fix, tags was silently dropped on the note path (the error string
-// even advertised it as valid — making the bug worse for callers following docs).
 #[tokio::test]
-async fn update_note_with_entity_field_tags_returns_error() {
-    use crate::KgPack;
-    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
-
-    let rt = KhiveRuntime::memory().expect("in-memory runtime");
-    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
-
-    let note = rt
-        .create_note(
+async fn update_note_tags_replaces_created_tags_and_preserves_unrelated_properties() {
+    let (_, token, pack, registry) = configured_kg_pack().await;
+    let note = pack
+        .handle_create(
             &token,
-            "observation",
-            None,
-            "note content unchanged",
-            None,
-            None,
-            vec![],
+            json!({
+                "kind": "observation",
+                "content": "note content unchanged",
+                "tags": ["queued", "old"],
+                "properties": {"keep": {"value": 7}},
+            }),
+            &registry,
         )
         .await
         .expect("create note");
+    assert_eq!(note["properties"]["tags"], json!(["queued", "old"]));
 
-    let pack = KgPack::new(rt.clone());
-    let mut builder = VerbRegistryBuilder::new();
-    builder.register(KgPack::new(rt.clone()));
-    let registry = builder.build().expect("registry build");
-
-    let result = pack
+    let updated = pack
         .handle_update(
             &token,
-            json!({ "id": note.id.to_string(), "tags": ["rust", "ml"] }),
+            json!({"id": note["id"], "tags": ["active", "rust"]}),
             &registry,
         )
-        .await;
-
-    assert!(
-        result.is_err(),
-        "update note with entity-only field 'tags' must return an error, got ok"
-    );
-    let err_msg = format!("{}", result.unwrap_err());
-    assert!(
-        err_msg.contains("tags"),
-        "error must name the invalid field 'tags'; got: {err_msg}"
-    );
-    assert!(
-        err_msg.contains("content"),
-        "error must list 'content' as a valid note field; got: {err_msg}"
-    );
-
-    // Confirm note content is unchanged.
-    let unchanged = rt
-        .notes(&token)
-        .unwrap()
-        .get_note(note.id)
         .await
-        .unwrap()
-        .expect("note must still exist");
+        .expect("replace note tags");
+    assert_eq!(updated["properties"]["tags"], json!(["active", "rust"]));
+    let fetched = pack
+        .handle_get(&token, &token, json!({"id": note["id"]}), &registry)
+        .await
+        .expect("read updated note");
     assert_eq!(
-        unchanged.content, "note content unchanged",
-        "note content must be unchanged after rejected update"
+        fetched["properties"],
+        json!({"tags": ["active", "rust"], "keep": {"value": 7}})
     );
+    assert_eq!(fetched["content"], "note content unchanged");
+    assert_eq!(fetched["tags"], json!(["active", "rust"]));
+}
+
+#[tokio::test]
+async fn update_note_omitted_tags_preserves_tags_while_patching_other_fields() {
+    let (_, token, pack, registry) = configured_kg_pack().await;
+    let note = pack
+        .handle_create(
+            &token,
+            json!({
+                "kind": "observation", "content": "before", "tags": ["queued"],
+                "properties": {"keep": 7},
+            }),
+            &registry,
+        )
+        .await
+        .unwrap();
+    pack.handle_update(
+        &token,
+        json!({"id": note["id"], "content": "after", "properties": {"added": true}}),
+        &registry,
+    )
+    .await
+    .expect("update other fields without tags");
+    let fetched = pack
+        .handle_get(&token, &token, json!({"id": note["id"]}), &registry)
+        .await
+        .unwrap();
+    assert_eq!(fetched["content"], "after");
+    assert_eq!(
+        fetched["properties"],
+        json!({"tags": ["queued"], "keep": 7, "added": true})
+    );
+}
+
+#[tokio::test]
+async fn update_note_empty_tags_clears_created_tags() {
+    let (_, token, pack, registry) = configured_kg_pack().await;
+    let note = pack
+        .handle_create(
+            &token,
+            json!({"kind": "observation", "content": "clear tags", "tags": ["queued"], "properties": {"keep": 7}}),
+            &registry,
+        )
+        .await
+        .unwrap();
+    pack.handle_update(&token, json!({"id": note["id"], "tags": []}), &registry)
+        .await
+        .expect("clear note tags");
+    let fetched = pack
+        .handle_get(&token, &token, json!({"id": note["id"]}), &registry)
+        .await
+        .unwrap();
+    assert_eq!(fetched["properties"], json!({"tags": [], "keep": 7}));
+    assert_eq!(fetched["tags"], json!([]));
+}
+
+#[tokio::test]
+async fn update_entity_tags_still_replace_preserve_and_clear() {
+    let (_, token, pack, registry) = configured_kg_pack().await;
+    let entity = pack
+        .handle_create(
+            &token,
+            json!({
+                "kind": "concept", "name": "tagged entity", "tags": ["queued", "old"],
+                "properties": {"keep": 7}, "skip_dedup_check": true,
+            }),
+            &registry,
+        )
+        .await
+        .unwrap();
+    for (patch, expected) in [
+        (
+            json!({"id": entity["id"], "tags": ["active"]}),
+            json!(["active"]),
+        ),
+        (
+            json!({"id": entity["id"], "name": "renamed entity"}),
+            json!(["active"]),
+        ),
+        (json!({"id": entity["id"], "tags": []}), json!([])),
+    ] {
+        pack.handle_update(&token, patch, &registry).await.unwrap();
+        let fetched = pack
+            .handle_get(&token, &token, json!({"id": entity["id"]}), &registry)
+            .await
+            .unwrap();
+        assert_eq!(fetched["tags"], expected);
+        assert_eq!(fetched["properties"], json!({"keep": 7}));
+    }
+}
+
+#[tokio::test]
+async fn update_note_properties_tags_route_still_replaces_and_clears() {
+    let (_, token, pack, registry) = configured_kg_pack().await;
+    let note = pack
+        .handle_create(
+            &token,
+            json!({"kind": "observation", "content": "nested tags", "tags": ["queued"], "properties": {"keep": 7}}),
+            &registry,
+        )
+        .await
+        .unwrap();
+    for tags in [json!(["nested"]), json!([])] {
+        pack.handle_update(
+            &token,
+            json!({"id": note["id"], "properties": {"tags": tags, "added": true}}),
+            &registry,
+        )
+        .await
+        .expect("patch existing properties.tags route");
+        let fetched = pack
+            .handle_get(&token, &token, json!({"id": note["id"]}), &registry)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetched["properties"],
+            json!({"tags": tags, "keep": 7, "added": true})
+        );
+    }
+}
+
+#[tokio::test]
+async fn update_note_top_level_tags_override_properties_tags_including_empty() {
+    let (_, token, pack, registry) = configured_kg_pack().await;
+    for tags in [json!(["top-level"]), json!([])] {
+        let note = pack
+            .handle_create(
+                &token,
+                json!({"kind": "observation", "content": "conflicting tags", "tags": ["queued"], "properties": {"keep": 7}}),
+                &registry,
+            )
+            .await
+            .unwrap();
+        pack.handle_update(
+            &token,
+            json!({"id": note["id"], "tags": tags, "properties": {"tags": ["nested"], "added": true}}),
+            &registry,
+        )
+        .await
+        .expect("top-level tags win over nested tags");
+        let fetched = pack
+            .handle_get(&token, &token, json!({"id": note["id"]}), &registry)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetched["properties"],
+            json!({"tags": tags, "keep": 7, "added": true})
+        );
+    }
+}
+
+#[tokio::test]
+async fn update_note_tags_are_normalized_before_hook_and_hook_changes_are_preserved() {
+    use khive_runtime::{
+        KhiveRuntime, KindHook, NamespaceToken, PackRuntime, RuntimeError, VerbRegistry,
+        VerbRegistryBuilder,
+    };
+    use khive_types::{HandlerDef, Pack};
+    use serde_json::Value;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Default)]
+    struct TagHook(Mutex<Vec<Value>>);
+
+    #[async_trait::async_trait]
+    impl KindHook for TagHook {
+        async fn prepare_create(
+            &self,
+            _: &KhiveRuntime,
+            _: &mut Value,
+        ) -> Result<(), RuntimeError> {
+            Ok(())
+        }
+
+        async fn after_create(
+            &self,
+            _: &KhiveRuntime,
+            _: uuid::Uuid,
+            _: &Value,
+        ) -> Result<(), RuntimeError> {
+            Ok(())
+        }
+
+        async fn prepare_note_update(
+            &self,
+            _: &KhiveRuntime,
+            _: &NamespaceToken,
+            _: &khive_storage::Note,
+            args: &mut Value,
+        ) -> Result<(), RuntimeError> {
+            self.0.lock().unwrap().push(args.clone());
+            args["properties"]["tags"] = json!(["hook-approved"]);
+            args["properties"]["hook_seen"] = json!(true);
+            Ok(())
+        }
+    }
+
+    struct TagHookPack(Arc<TagHook>);
+
+    impl Pack for TagHookPack {
+        const NAME: &'static str = "tag-update-test";
+        const NOTE_KINDS: &'static [&'static str] = &["tag-hook-note"];
+        const ENTITY_KINDS: &'static [&'static str] = &[];
+        const HANDLERS: &'static [HandlerDef] = &[];
+    }
+
+    #[async_trait::async_trait]
+    impl PackRuntime for TagHookPack {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn note_kinds(&self) -> &'static [&'static str] {
+            Self::NOTE_KINDS
+        }
+        fn entity_kinds(&self) -> &'static [&'static str] {
+            Self::ENTITY_KINDS
+        }
+        fn handlers(&self) -> &'static [HandlerDef] {
+            Self::HANDLERS
+        }
+        fn kind_hook(&self, kind: &str) -> Option<Arc<dyn KindHook>> {
+            (kind == "tag-hook-note").then(|| self.0.clone() as Arc<dyn KindHook>)
+        }
+        async fn dispatch(
+            &self,
+            _: &str,
+            _: Value,
+            _: &VerbRegistry,
+            _: &NamespaceToken,
+        ) -> Result<Value, RuntimeError> {
+            unreachable!()
+        }
+    }
+
+    let (rt, token, pack, _) = configured_kg_pack().await;
+    let hook = Arc::new(TagHook::default());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(crate::KgPack::new(rt));
+    builder.register(TagHookPack(hook.clone()));
+    let registry = builder.build().unwrap();
+    for tags in [json!(["top-level"]), json!([])] {
+        let note = pack
+            .handle_create(
+                &token,
+                json!({"kind": "tag-hook-note", "content": "hook tags", "tags": ["queued"], "properties": {"keep": 7}}),
+                &registry,
+            )
+            .await
+            .unwrap();
+        pack.handle_update(
+            &token,
+            json!({"id": note["id"], "tags": tags, "properties": {"tags": ["nested"], "added": true}}),
+            &registry,
+        )
+        .await
+        .unwrap();
+        let seen = hook.0.lock().unwrap().last().unwrap().clone();
+        assert!(seen.get("tags").is_none());
+        assert_eq!(seen["properties"], json!({"tags": tags, "added": true}));
+        let fetched = pack
+            .handle_get(&token, &token, json!({"id": note["id"]}), &registry)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetched["properties"],
+            json!({"tags": ["hook-approved"], "keep": 7, "added": true, "hook_seen": true})
+        );
+    }
+    assert_eq!(hook.0.lock().unwrap().len(), 2);
 }
 
 // MEDIUM regression: update(entity_id, salience=...) must return an explicit

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -72,8 +72,6 @@ fn reject_inapplicable_fields(spec: &KindSpec, p: &UpdateParams) -> Result<(), R
         KindSpec::Note { .. } => {
             let bad = if p.description.is_some() {
                 Some("description")
-            } else if p.tags.is_some() {
-                Some("tags")
             } else if p.relation.is_some() {
                 Some("relation")
             } else if p.weight.is_some() {
@@ -83,7 +81,10 @@ fn reject_inapplicable_fields(spec: &KindSpec, p: &UpdateParams) -> Result<(), R
             } else {
                 None
             };
-            (bad, "name, content, salience, decay_factor, properties")
+            (
+                bad,
+                "name, content, salience, decay_factor, properties, tags",
+            )
         }
         KindSpec::Edge => {
             let bad = if p.name.is_some() {

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -641,7 +641,7 @@ pub async fn prepare_add_note(
 /// Mirrors `khive-pack-kg::handlers::update::reject_inapplicable_fields`: a
 /// hard `InvalidInput` when a caller passes a field that does not apply to
 /// the resolved substrate (e.g. `salience` on an entity, or
-/// `description`/`tags` on a note). That function has no dependency edge
+/// `description` on a note). That function has no dependency edge
 /// back to `khive-runtime`, so its exact field-applicability check list and
 /// error message shape are reimplemented here rather than imported: same
 /// pattern as `optional_string_patch` above. Presence is checked directly on
@@ -680,8 +680,6 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
         "note" => {
             let bad = if present("description") {
                 Some("description")
-            } else if present("tags") {
-                Some("tags")
             } else if present("relation") {
                 Some("relation")
             } else if present("weight") {
@@ -693,7 +691,10 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
             } else {
                 None
             };
-            (bad, "name, content, salience, decay_factor, properties")
+            (
+                bad,
+                "name, content, salience, decay_factor, properties, tags",
+            )
         }
         // `update` admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`, so
         // this arm must reject entity/note-only fields (e.g. `name`) on an
@@ -789,6 +790,9 @@ async fn prepare_note_update_plan_from_snapshot(
     validate_note_update_expected_kind(&note, expected_kind)?;
 
     reject_inapplicable_update_fields(args, "note")?;
+    let mut normalized_args = args.clone();
+    crate::curation::normalize_note_update_tags(&mut normalized_args)?;
+    let args = &normalized_args;
     let name = optional_string_patch(args, "name")?;
     let content = optional_str(args, "content").map(str::to_string);
     let properties = optional_properties(args, "properties")?;
@@ -2160,9 +2164,8 @@ mod tests {
         assert_eq!(updated.tags, vec!["keep-tag"]);
     }
 
-    /// Symmetric note-substrate case: `description` and `tags` are
-    /// entity-only fields; passing either for a note must be rejected the
-    /// same way update.rs rejects them.
+    /// Symmetric note-substrate case: `description` is entity-only and
+    /// must be rejected the same way update.rs rejects it.
     #[tokio::test]
     async fn atomic_update_note_rejects_entity_only_field_description() {
         let runtime = scratch_runtime();
@@ -2208,6 +2211,190 @@ mod tests {
             outcome,
             crate::atomic_runner::AtomicRunOutcome::Committed { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn atomic_update_note_tags_replace_preserve_clear_and_override_nested_tags() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let mut note = khive_storage::note::Note::new("local", "observation", "tagged note");
+        note.properties = Some(json!({"tags": ["old"], "keep": {"value": 1}}));
+        let note_id = note.id;
+        runtime
+            .notes(&token)
+            .expect("notes store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        for (mut args, expected_tags) in [
+            (
+                json!({"tags": ["new", "shared"], "properties": {"tags": ["nested"], "added": true}}),
+                json!(["new", "shared"]),
+            ),
+            (
+                json!({"name": "renamed note", "properties": {"omitted": true}}),
+                json!(["new", "shared"]),
+            ),
+            (
+                json!({"tags": null, "properties": null}),
+                json!(["new", "shared"]),
+            ),
+            (
+                json!({"tags": [], "properties": {"tags": ["nested-after-clear"]}}),
+                json!([]),
+            ),
+            (
+                json!({"tags": ["after-null-properties"], "properties": null}),
+                json!(["after-null-properties"]),
+            ),
+        ] {
+            args["id"] = json!(note_id.to_string());
+            let original_args = args.clone();
+            let plan = prepare_update(&runtime, &token, &args, None)
+                .await
+                .expect("valid atomic note tags patch");
+            assert_eq!(
+                args, original_args,
+                "preparation must not mutate caller args"
+            );
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("atomic note update");
+            assert!(matches!(
+                outcome,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ));
+            let updated = runtime
+                .notes(&token)
+                .expect("notes store")
+                .get_note(note_id)
+                .await
+                .expect("read note")
+                .expect("note exists");
+            let properties = updated.properties.expect("note properties");
+            assert_eq!(properties["tags"], expected_tags);
+            assert_eq!(properties["keep"], json!({"value": 1}));
+            assert_eq!(properties["added"], json!(true));
+            assert_eq!(updated.content, "tagged note");
+            if original_args.get("name").is_some() {
+                assert_eq!(updated.name.as_deref(), Some("renamed note"));
+                assert_eq!(properties["omitted"], json!(true));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn atomic_update_entity_tags_keep_replace_preserve_and_clear_semantics() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let mut entity = khive_storage::Entity::new("local", "concept", "tagged entity");
+        entity.tags = vec!["old".to_string()];
+        entity.properties = Some(json!({"keep": true}));
+        let entity_id = entity.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(entity)
+            .await
+            .expect("seed entity");
+        for (mut args, expected_tags) in [
+            (json!({"tags": ["new", "shared"]}), json!(["new", "shared"])),
+            (json!({"name": "renamed entity"}), json!(["new", "shared"])),
+            (json!({"tags": null}), json!(["new", "shared"])),
+            (json!({"tags": []}), json!([])),
+        ] {
+            args["id"] = json!(entity_id.to_string());
+            let plan = prepare_update(&runtime, &token, &args, None)
+                .await
+                .expect("valid atomic entity tags patch");
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("atomic entity update");
+            assert!(matches!(
+                outcome,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ));
+            let updated = runtime
+                .get_entity(&token, entity_id)
+                .await
+                .expect("read entity");
+            assert_eq!(json!(updated.tags), expected_tags);
+            assert_eq!(updated.properties, Some(json!({"keep": true})));
+        }
+    }
+
+    #[tokio::test]
+    async fn atomic_update_note_invalid_tags_leave_snapshot_unchanged() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let mut note = khive_storage::note::Note::new("local", "observation", "unchanged note");
+        note.properties = Some(json!({"tags": ["keep"], "other": true}));
+        let note_id = note.id;
+        runtime
+            .notes(&token)
+            .expect("notes store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+        let before = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(note_id)
+            .await
+            .expect("read note")
+            .expect("note exists");
+
+        for (mut args, expected_error) in [
+            (
+                json!({"tags": "invalid"}),
+                "tags must be an array of strings",
+            ),
+            (
+                json!({"tags": ["valid", 1]}),
+                "tags must be an array of strings",
+            ),
+            (
+                json!({"tags": {"nested": true}}),
+                "tags must be an array of strings",
+            ),
+            (
+                json!({"tags": ["valid"], "properties": []}),
+                "properties must be an object",
+            ),
+            (
+                json!({"tags": [], "properties": "invalid"}),
+                "properties must be an object",
+            ),
+            (
+                json!({"tags": "invalid", "description": "entity field"}),
+                "field 'description' is not valid for a note",
+            ),
+        ] {
+            args["id"] = json!(note_id.to_string());
+            args["content"] = json!("must not persist");
+            let error = prepare_update(&runtime, &token, &args, None)
+                .await
+                .expect_err("invalid tags patch must not produce a plan");
+            assert!(
+                matches!(error, RuntimeError::InvalidInput(ref message) if message.contains(expected_error)),
+                "unexpected error: {error:?}"
+            );
+            let after = runtime
+                .notes(&token)
+                .expect("notes store")
+                .get_note(note_id)
+                .await
+                .expect("read note")
+                .expect("note exists");
+            assert_eq!(after, before);
+        }
     }
 
     /// Updating a note's content inside an atomic unit must, after commit,

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -493,6 +493,36 @@ pub struct NotePatch {
     pub write_options: crate::note_write::NoteWriteOptions,
 }
 
+/// Normalize the public note tag replacement into its stored property before
+/// kind hooks inspect the patch. An explicit list, including an empty one,
+/// wins over properties.tags; omission and null preserve the property patch.
+pub(crate) fn normalize_note_update_tags(args: &mut Value) -> RuntimeResult<()> {
+    let args = args
+        .as_object_mut()
+        .ok_or_else(|| RuntimeError::InvalidInput("update arguments must be an object".into()))?;
+    let Some(tags) = args.get("tags").filter(|value| !value.is_null()) else {
+        return Ok(());
+    };
+    let tags: Vec<String> = serde_json::from_value(tags.clone()).map_err(|error| {
+        RuntimeError::InvalidInput(format!("tags must be an array of strings: {error}"))
+    })?;
+    let mut properties = match args.get("properties") {
+        None | Some(Value::Null) => serde_json::Map::new(),
+        Some(Value::Object(properties)) => properties.clone(),
+        Some(_) => {
+            return Err(RuntimeError::InvalidInput(
+                "properties must be an object".into(),
+            ));
+        }
+    };
+    properties.insert("tags".into(), serde_json::json!(tags));
+    args.insert("properties".into(), Value::Object(properties));
+    // A hook may normalize this property further. Remove the alias so later
+    // preparation cannot overwrite the hook's result by applying it again.
+    args.remove("tags");
+    Ok(())
+}
+
 impl NotePatch {
     /// Construct a `NotePatch` from the public fields only.
     /// Use this from external crates; `kind_status` is set to `None`.

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -3230,6 +3230,7 @@ impl VerbRegistry {
         note: &khive_storage::Note,
         args: &mut Value,
     ) -> Result<(), RuntimeError> {
+        crate::curation::normalize_note_update_tags(args)?;
         if let Some(hook) = self.find_kind_hook(&note.kind) {
             hook.prepare_note_update(runtime, token, note, args).await?;
         }

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -392,25 +392,30 @@ request(ops="stats()")
 
 Patch entity, note, or edge fields. Field set depends on substrate: entities accept
 `name`/`description`/`properties`/`tags`; notes accept
-`name`/`content`/`salience`/`decay_factor`/`properties`; edges accept
+`name`/`content`/`salience`/`decay_factor`/`properties`/`tags`; edges accept
 `relation`/`weight`/`properties`.
 
 Entity/note text updates use the same full-source storage and bounded embedding contract as
 singleton `create`; a successful response includes `warnings` when embedding actually truncated.
 
-| Param          | Type            | Required | Notes                                                                     |
-| -------------- | --------------- | -------- | ------------------------------------------------------------------------- |
-| `id`           | uuid            | yes      | Record to patch.                                                          |
-| `kind`         | string          | no       | Substrate hint (`entity`\|`note`\|`edge`); omit to resolve from the UUID. |
-| `name`         | string          | no       | Entities and notes.                                                       |
-| `description`  | string          | no       | Entities only.                                                            |
-| `content`      | string          | no       | Notes only (body text).                                                   |
-| `salience`     | number          | no       | Notes only, 0.0–1.0.                                                      |
-| `decay_factor` | number          | no       | Notes only, >= 0.                                                         |
-| `relation`     | string          | no       | Edges only, one of the 17 canonical relations.                            |
-| `weight`       | number          | no       | Edges only, 0.0–1.0.                                                      |
-| `properties`   | object          | no       | Shallow-merged in.                                                        |
-| `tags`         | array\<string\> | no       | Replaces the tag list.                                                    |
+| Param          | Type            | Required | Notes                                                                             |
+| -------------- | --------------- | -------- | --------------------------------------------------------------------------------- |
+| `id`           | uuid            | yes      | Record to patch.                                                                  |
+| `kind`         | string          | no       | Substrate hint (`entity`\|`note`\|`edge`); omit to resolve from the UUID.         |
+| `name`         | string          | no       | Entities and notes.                                                               |
+| `description`  | string          | no       | Entities only.                                                                    |
+| `content`      | string          | no       | Notes only (body text).                                                           |
+| `salience`     | number          | no       | Notes only, 0.0–1.0.                                                              |
+| `decay_factor` | number          | no       | Notes only, >= 0.                                                                 |
+| `relation`     | string          | no       | Edges only, one of the 17 canonical relations.                                    |
+| `weight`       | number          | no       | Edges only, 0.0–1.0.                                                              |
+| `properties`   | object          | no       | Shallow-merged in.                                                                |
+| `tags`         | array\<string\> | no       | Entities and notes: replaces the tag list; omission preserves it, `[]` clears it. |
+
+Note tags remain stored and returned in `properties.tags`. Updating that property directly
+also replaces the list. When a request supplies both `tags` and `properties.tags`, top-level
+`tags` wins, including `tags=[]`; tags are never unioned. Other properties are shallow-merged
+as usual.
 
 ```
 request(ops="update(id=\"<uuid>\", salience=0.7)")


### PR DESCRIPTION
`update` accepts `tags` on an entity and refuses them on a note, with
`field 'tags' is not valid for a note`. The capability is not missing: a note's
tags live in `properties.tags`, and `properties` is a documented shallow merge,
so `update(id=..., properties={"tags": [...]})` already replaces the list and
leaves every other property alone. The gap is that one operation has two
spellings, and that the refusal tells a caller the field is invalid rather than
where it lives.

That asymmetry is also published. The record-update surface advertises `tags`
for every kind, so a caller following it is told a note takes a field the
runtime refuses.

This accepts top-level `tags` on note update and writes it through to
`properties.tags` with the same replace semantics the entity path uses: a list
replaces the set, an empty list clears it, and omitting the field leaves it
alone. Precedence is explicit. An explicit list, including an empty one, wins
over `properties.tags` in the same call; omission and an explicit null preserve
the property patch. Normalization runs before kind hooks inspect the patch, and
the alias is removed afterwards so later preparation cannot overwrite what a
hook decided.

The same rule applies on the atomic preparation path, which reimplements the
field-applicability check by design and is updated in step.

Entity behavior is unchanged, the nested `properties.tags` route keeps working,
no migration is involved, and no stored record changes shape. The tests cover
replacement, clearing, preservation under an unrelated patch, precedence
including the empty-list case, hook-visible normalization, a malformed tag list
leaving the snapshot untouched, and the unchanged entity semantics as controls.
