### PR TITLE
fix(daemon): stop the channel loops at shutdown instead of racing the store

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -487,6 +487,7 @@ fn spawn_email_channel_loops(
                             verb_reg_poll,
                             ingest_ns_clone,
                             default_actor_clone,
+                            khive_runtime::daemon_shutdown_token(),
                         )
                         .await;
                     });
@@ -501,6 +502,7 @@ fn spawn_email_channel_loops(
                                 ingest_ns_outbox,
                                 mailbox_clone,
                                 allowlist_clone,
+                                khive_runtime::daemon_shutdown_token(),
                             ));
                             tracing::info!("email channel outbox loop started");
                         }
@@ -837,14 +839,22 @@ async fn handle_channel_ingest_failure(
     }
 }
 
-/// Wait `interval` between channel-loop cycles, unless daemon shutdown fires
-/// first. Returns `false` when the daemon is shutting down, which is the
+/// Wait `interval` between channel-loop cycles, unless the caller's shutdown
+/// token fires first. Returns `false` when shutdown is observed, which is the
 /// caller's signal to leave its loop.
 ///
 /// The wait is the only cancellation point on purpose: a channel cycle issues
 /// verbs against the store, so dropping one mid-flight would abandon a cursor
 /// read or an ingest partway. Between cycles there is nothing in flight, so
 /// the loop ends where a restart costs at most one re-poll.
+///
+/// The token is a parameter, never read from
+/// `khive_runtime::daemon_shutdown_token()` inside a loop. That singleton is
+/// cancelled once per process, and this crate's test binary runs an in-process
+/// daemon whose shutdown cancels it for every later test in the same process —
+/// so a loop reading it directly stops before its first cycle in any test that
+/// happens to run after one of those. Production passes the singleton at the
+/// spawn site, which is where the process's daemon role is already known.
 #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
 async fn channel_cycle_wait(
     interval: std::time::Duration,
@@ -877,6 +887,7 @@ async fn channel_poll_loop(
     registry: khive_runtime::VerbRegistry,
     ingest_namespace: String,
     default_inbound_actor: String,
+    shutdown: tokio_util::sync::CancellationToken,
 ) {
     use chrono::{DateTime, Utc};
     use khive_channel_email::{is_backoff_eligible, ImapBackoff};
@@ -922,7 +933,6 @@ async fn channel_poll_loop(
     // channel is first seen on -- uses this single startup timestamp
     // instead of that tick's own `now`.
     let startup_since = Utc::now();
-    let shutdown = khive_runtime::daemon_shutdown_token();
 
     loop {
         if !channel_cycle_wait(next_interval, &shutdown).await {
@@ -1476,6 +1486,7 @@ async fn channel_outbox_loop(
     ingest_namespace: String,
     mailbox: String,
     allowlist: Vec<String>,
+    shutdown: tokio_util::sync::CancellationToken,
 ) {
     let domain = mailbox.split('@').nth(1).unwrap_or("localhost").to_string();
     let namespace = match khive_runtime::Namespace::parse(&ingest_namespace) {
@@ -1489,8 +1500,6 @@ async fn channel_outbox_loop(
             return;
         }
     };
-
-    let shutdown = khive_runtime::daemon_shutdown_token();
 
     loop {
         if !channel_cycle_wait(OUTBOUND_RETRY_BASE, &shutdown).await {
@@ -1832,7 +1841,13 @@ fn spawn_telegram_channel_loops(
                             );
                             return;
                         }
-                        telegram_poll_loop(tg_ch_poll, verb_reg_poll, ingest_ns_poll).await;
+                        telegram_poll_loop(
+                            tg_ch_poll,
+                            verb_reg_poll,
+                            ingest_ns_poll,
+                            khive_runtime::daemon_shutdown_token(),
+                        )
+                        .await;
                     });
                     tracing::info!("telegram channel polling loop started");
                 }
@@ -1843,6 +1858,7 @@ fn spawn_telegram_channel_loops(
                                 tg_ch_outbox,
                                 rt,
                                 ingest_ns_outbox,
+                                khive_runtime::daemon_shutdown_token(),
                             ));
                             tracing::info!("telegram channel outbox loop started");
                         }
@@ -1906,6 +1922,7 @@ async fn telegram_poll_loop(
     telegram_channel: std::sync::Arc<khive_channel_telegram::TelegramChannel>,
     registry: khive_runtime::VerbRegistry,
     ingest_namespace: String,
+    shutdown: tokio_util::sync::CancellationToken,
 ) {
     use chrono::Utc;
     use khive_channel::Channel;
@@ -1913,7 +1930,6 @@ async fn telegram_poll_loop(
 
     const ERROR_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
     let mut unknown_ingest_attempts = std::collections::HashMap::<String, u8>::new();
-    let shutdown = khive_runtime::daemon_shutdown_token();
 
     loop {
         // This loop polls before it waits, so shutdown is read at the top as
@@ -1997,6 +2013,7 @@ async fn telegram_outbox_loop(
     telegram_channel: std::sync::Arc<khive_channel_telegram::TelegramChannel>,
     runtime: khive_runtime::KhiveRuntime,
     ingest_namespace: String,
+    shutdown: tokio_util::sync::CancellationToken,
 ) {
     let namespace = match khive_runtime::Namespace::parse(&ingest_namespace) {
         Ok(ns) => ns,
@@ -2009,8 +2026,6 @@ async fn telegram_outbox_loop(
             return;
         }
     };
-
-    let shutdown = khive_runtime::daemon_shutdown_token();
 
     loop {
         if !channel_cycle_wait(OUTBOUND_RETRY_BASE, &shutdown).await {
@@ -12411,6 +12426,7 @@ backend = "kg-backend"
                 registry,
                 "test-ns".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             // Iteration 1 (happy-path 5s sleep elapses, poll fails, backoff
@@ -12467,6 +12483,7 @@ backend = "kg-backend"
                 registry,
                 "test-ns".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             // Step the paused clock through both iterations; with no store
@@ -12603,6 +12620,7 @@ backend = "kg-backend"
                 registry.clone(),
                 "local".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             // Three happy-path 5s ticks: the first drives the partial-failure
@@ -12769,6 +12787,7 @@ backend = "kg-backend"
                 registry.clone(),
                 "test-ns".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             // Wait for at least two poll_page calls (deterministic condition
@@ -12943,6 +12962,7 @@ backend = "kg-backend"
                 registry.clone(),
                 "local".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             for _ in 0..2000 {
@@ -13097,6 +13117,7 @@ backend = "kg-backend"
                 registry.clone(),
                 "test-ns".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
@@ -13431,6 +13452,7 @@ backend = "kg-backend"
                 registry.clone(),
                 "test-ns".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             // Tick 1: control succeeds (records the tick's floor); the
@@ -13522,6 +13544,7 @@ backend = "kg-backend"
                 registry.clone(),
                 "test-ns".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             // Tick 1: control succeeds; the ingest-failing channel is polled
@@ -13602,6 +13625,7 @@ backend = "kg-backend"
                 registry.clone(),
                 "test-ns".to_string(),
                 "actor:test".to_string(),
+                tokio_util::sync::CancellationToken::new(),
             ));
 
             // Real-time wait for the loop's first (~5s) tick to fire.
@@ -13776,5 +13800,36 @@ backend = "kg-backend"
             channel_cycle_wait(std::time::Duration::from_millis(10), &token).await,
             "an uncancelled wait must complete its interval and keep the loop polling"
         );
+    }
+
+    #[cfg(feature = "channel-email")]
+    #[tokio::test]
+    async fn channel_poll_loop_leaves_on_its_own_token_not_a_process_global() {
+        // The loop is handed a token nobody else holds, so this asserts the
+        // parameter is the one it reads: with the pre-fix body (which read
+        // `khive_runtime::daemon_shutdown_token()`) cancelling this token
+        // does nothing and the join below times out.
+        let runtime = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");
+        let mut builder = khive_runtime::VerbRegistryBuilder::new();
+        khive_runtime::PackRegistry::register_packs(
+            &["kg".to_string(), "comm".to_string()],
+            runtime.clone(),
+            &mut builder,
+        )
+        .expect("register kg+comm through the factory path");
+        let registry = builder.build().expect("registry builds");
+        let token = tokio_util::sync::CancellationToken::new();
+        let task = tokio::spawn(channel_poll_loop(
+            std::sync::Arc::new(khive_channel::ChannelRegistry::new()),
+            registry,
+            "test-ns".to_string(),
+            "actor:test".to_string(),
+            token.clone(),
+        ));
+        token.cancel();
+        tokio::time::timeout(std::time::Duration::from_secs(10), task)
+            .await
+            .expect("the loop must observe the token it was handed and return")
+            .expect("the loop task must not panic");
     }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -473,7 +473,7 @@ fn spawn_email_channel_loops(
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
                 if admission.inbound_poll {
-                    tokio::task::spawn(async move {
+                    khive_runtime::track_background_task(async move {
                         if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await
                         {
                             tracing::error!(
@@ -495,7 +495,7 @@ fn spawn_email_channel_loops(
                 if admission.outbound_delivery {
                     match runtime_outbox {
                         Some(rt) => {
-                            tokio::task::spawn(channel_outbox_loop(
+                            khive_runtime::track_background_task(channel_outbox_loop(
                                 email_ch_clone,
                                 rt,
                                 ingest_ns_outbox,
@@ -837,6 +837,25 @@ async fn handle_channel_ingest_failure(
     }
 }
 
+/// Wait `interval` between channel-loop cycles, unless daemon shutdown fires
+/// first. Returns `false` when the daemon is shutting down, which is the
+/// caller's signal to leave its loop.
+///
+/// The wait is the only cancellation point on purpose: a channel cycle issues
+/// verbs against the store, so dropping one mid-flight would abandon a cursor
+/// read or an ingest partway. Between cycles there is nothing in flight, so
+/// the loop ends where a restart costs at most one re-poll.
+#[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+async fn channel_cycle_wait(
+    interval: std::time::Duration,
+    shutdown: &tokio_util::sync::CancellationToken,
+) -> bool {
+    tokio::select! {
+        _ = shutdown.cancelled() => false,
+        _ = tokio::time::sleep(interval) => true,
+    }
+}
+
 /// Background task that polls all registered channels every 5 seconds and
 /// ingests new inbound messages via `comm.ingest`.
 ///
@@ -903,9 +922,13 @@ async fn channel_poll_loop(
     // channel is first seen on -- uses this single startup timestamp
     // instead of that tick's own `now`.
     let startup_since = Utc::now();
+    let shutdown = khive_runtime::daemon_shutdown_token();
 
     loop {
-        tokio::time::sleep(next_interval).await;
+        if !channel_cycle_wait(next_interval, &shutdown).await {
+            tracing::info!("email channel polling loop: daemon shutdown observed, stopping");
+            return;
+        }
         next_interval = CHANNEL_POLL_INTERVAL;
 
         let now = Utc::now();
@@ -1467,8 +1490,13 @@ async fn channel_outbox_loop(
         }
     };
 
+    let shutdown = khive_runtime::daemon_shutdown_token();
+
     loop {
-        tokio::time::sleep(OUTBOUND_RETRY_BASE).await;
+        if !channel_cycle_wait(OUTBOUND_RETRY_BASE, &shutdown).await {
+            tracing::info!("email channel outbox loop: daemon shutdown observed, stopping");
+            return;
+        }
         let stop = channel_outbox_once(
             email_channel.as_ref(),
             &runtime,
@@ -1795,7 +1823,7 @@ fn spawn_telegram_channel_loops(
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
                 if admission.inbound_poll {
-                    tokio::task::spawn(async move {
+                    khive_runtime::track_background_task(async move {
                         if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await
                         {
                             tracing::error!(
@@ -1811,7 +1839,7 @@ fn spawn_telegram_channel_loops(
                 if admission.outbound_delivery {
                     match outbox_runtime {
                         Some(rt) => {
-                            tokio::task::spawn(telegram_outbox_loop(
+                            khive_runtime::track_background_task(telegram_outbox_loop(
                                 tg_ch_outbox,
                                 rt,
                                 ingest_ns_outbox,
@@ -1885,8 +1913,15 @@ async fn telegram_poll_loop(
 
     const ERROR_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
     let mut unknown_ingest_attempts = std::collections::HashMap::<String, u8>::new();
+    let shutdown = khive_runtime::daemon_shutdown_token();
 
     loop {
+        // This loop polls before it waits, so shutdown is read at the top as
+        // well as inside the error backoff below.
+        if shutdown.is_cancelled() {
+            tracing::info!("telegram channel polling loop: daemon shutdown observed, stopping");
+            return;
+        }
         match telegram_channel.poll(Utc::now()).await {
             Ok(envelopes) => {
                 let kind = telegram_channel.kind();
@@ -1942,7 +1977,12 @@ async fn telegram_poll_loop(
                     channel = telegram_channel.kind(),
                     "telegram channel poll failed: {e}"
                 );
-                tokio::time::sleep(ERROR_BACKOFF).await;
+                if !channel_cycle_wait(ERROR_BACKOFF, &shutdown).await {
+                    tracing::info!(
+                        "telegram channel polling loop: daemon shutdown observed, stopping"
+                    );
+                    return;
+                }
             }
         }
     }
@@ -1970,8 +2010,13 @@ async fn telegram_outbox_loop(
         }
     };
 
+    let shutdown = khive_runtime::daemon_shutdown_token();
+
     loop {
-        tokio::time::sleep(OUTBOUND_RETRY_BASE).await;
+        if !channel_cycle_wait(OUTBOUND_RETRY_BASE, &shutdown).await {
+            tracing::info!("telegram channel outbox loop: daemon shutdown observed, stopping");
+            return;
+        }
         telegram_outbox_once(telegram_channel.as_ref(), &runtime, &namespace).await;
     }
 }
@@ -13696,6 +13741,40 @@ backend = "kg-backend"
             "the guard must await sweep shutdown before returning on the \
              transport-resolution error path — an unawaited (dropped) handle \
              leaves this flag unset at the moment the guard returns"
+        );
+    }
+
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    #[tokio::test]
+    async fn channel_cycle_wait_reports_shutdown_instead_of_finishing_its_interval() {
+        let token = tokio_util::sync::CancellationToken::new();
+        let canceller = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            canceller.cancel();
+        });
+        // The interval outlasts the cancellation by minutes, so a wait that
+        // does not read the token cannot return inside this bound: the arm
+        // fails on the timeout rather than hanging the suite.
+        let ran_a_full_interval = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            channel_cycle_wait(std::time::Duration::from_secs(300), &token),
+        )
+        .await
+        .expect("shutdown must end the wait, well inside the daemon's drain window");
+        assert!(
+            !ran_a_full_interval,
+            "a cancelled token must report shutdown so the loop stops, not a completed interval"
+        );
+    }
+
+    #[cfg(any(feature = "channel-email", feature = "channel-telegram"))]
+    #[tokio::test]
+    async fn channel_cycle_wait_completes_its_interval_while_the_daemon_runs() {
+        let token = tokio_util::sync::CancellationToken::new();
+        assert!(
+            channel_cycle_wait(std::time::Duration::from_millis(10), &token).await,
+            "an uncancelled wait must complete its interval and keep the loop polling"
         );
     }
 }

--- a/docs/adr/ADR-119-daemon-component-supervision.md
+++ b/docs/adr/ADR-119-daemon-component-supervision.md
@@ -741,7 +741,14 @@ log of a daemon that is on its way out.
 ### Decision
 
 The four transport channel loops (email poll, email outbox, telegram poll, telegram outbox) are
-spawned through `track_background_task` and observe `daemon_shutdown_token()`.
+spawned through `track_background_task` and observe a cancellation token handed to them at the
+spawn site. The daemon start path passes `daemon_shutdown_token()`, the same way the component
+supervisor start path already does; a loop never reads that singleton itself. The singleton is
+cancelled exactly once per process, and this crate's own test binary runs an in-process daemon
+whose shutdown cancels it for every later test in that process, so a loop that reaches for it
+directly returns before its first cycle in any test that runs after one of those. Taking the token
+as a parameter leaves the production wiring identical and makes a loop's shutdown observable in a
+test that owns the token it cancels.
 
 Cancellation is read between cycles and never inside one. A cycle issues verbs against the store,
 so dropping one mid-flight would abandon a cursor read or an ingest partway; stopping between
@@ -758,6 +765,8 @@ migration the base decision describes is unchanged and still owed.
   a wait that ignores the token fails the assertion instead of hanging the suite.
 - Each loop returns on that report and logs the loop it is leaving, so a shutdown that stops a
   channel loop is readable in the log rather than inferred from its absence.
+- A poll loop handed a token no other code holds returns when that token is cancelled. A loop that
+  read the process-wide token instead would ignore the cancellation and the arm would time out.
 - Because the loops are now tracked, `drain()` waits for their exit and its remaining-task count
   includes them. That count still names no task; naming what remains at a drain timeout is a
   separate gap this amendment does not close.

--- a/docs/adr/ADR-119-daemon-component-supervision.md
+++ b/docs/adr/ADR-119-daemon-component-supervision.md
@@ -724,3 +724,40 @@ contract.
 - Schedule drain tests prove creator-bound gate evaluation and legacy generic fail-closed
   behavior; schedule-pack tests prove both creation verbs persist the creator.
 - Existing multi-backend and CAS regressions remain the routing and state-machine fences.
+
+## Amendment 5: Transport channel loops join the shutdown handoff (2026-09-13)
+
+### Context
+
+The base decision names the email ingest loops as work that is hand-spawned and shares no
+lifecycle contract. They are still spawned inline by the serve entrypoints rather than
+registered as components, and until now they were started with a bare task spawn and read no
+cancellation signal at all. Two consequences followed. `drain()` could not see them, because it
+counts only tasks registered through `track_background_task`, so a shutting-down daemon reported
+a background population that excluded every channel loop. And the loops kept issuing verbs while
+the store was closing underneath them, which surfaces as audit-obligation write failures in the
+log of a daemon that is on its way out.
+
+### Decision
+
+The four transport channel loops (email poll, email outbox, telegram poll, telegram outbox) are
+spawned through `track_background_task` and observe `daemon_shutdown_token()`.
+
+Cancellation is read between cycles and never inside one. A cycle issues verbs against the store,
+so dropping one mid-flight would abandon a cursor read or an ingest partway; stopping between
+cycles costs at most one re-poll on the next start. The two halves ship together on purpose:
+tracking an uncancellable infinite loop would spend the whole drain window on every shutdown.
+
+This does not make the loops components. They remain outside the registry, and the component
+migration the base decision describes is unchanged and still owed.
+
+### Verify by
+
+- `channel_cycle_wait` reports shutdown when its token is cancelled during the wait, and reports a
+  completed interval when the interval elapses first. The shutdown arm is bounded by a timeout, so
+  a wait that ignores the token fails the assertion instead of hanging the suite.
+- Each loop returns on that report and logs the loop it is leaving, so a shutdown that stops a
+  channel loop is readable in the log rather than inferred from its absence.
+- Because the loops are now tracked, `drain()` waits for their exit and its remaining-task count
+  includes them. That count still names no task; naming what remains at a drain timeout is a
+  separate gap this amendment does not close.


### PR DESCRIPTION
## What

The email and telegram channel loops are started with a bare `tokio::task::spawn` and read no
cancellation signal. Two things follow at every shutdown:

- The daemon's drain counts only tasks registered through `track_background_task`, so its background
  population excluded every channel loop. A drain that reports zero outstanding work could still have
  four loops running.
- The loops keep issuing verbs while the store closes underneath them, which surfaces as
  audit-obligation write failures in the log of a daemon already on its way out.

All four loops now spawn through `track_background_task` and observe the daemon shutdown token.

## Where the cancellation point is, and why it is there

The token is read *between* cycles, never inside one. A cycle issues verbs against the store, so
stopping mid-cycle would abandon a cursor read or an ingest partway; stopping between cycles costs at
most one re-poll. `channel_cycle_wait` is that point: it selects between the interval sleep and the
shutdown token and tells the caller which fired.

Tracking and cancelling ship together on purpose. Tracking an uncancellable infinite loop would spend
the entire drain window on every shutdown, which is worse than the bug being fixed.

The telegram poll loop has no sleep on its success path, because the Bot API long poll paces it. It
reads the token at the top of each iteration instead.

## Known limit, stated rather than discovered later

The telegram long poll blocks server-side for up to 25 seconds while the default drain budget is 10.
A telegram poll loop caught mid-request therefore still outlives the drain even with the token,
because this change does not race the in-flight HTTP request. Closing that gap is a separate change
and is worth doing: unlike a store cursor, an abandoned `getUpdates` is safe to retry, since the
offset is not committed until every envelope in the batch has been ingested.

## Tests

Two, both on `channel_cycle_wait`:

- a shutdown arm, bounded by `tokio::time::timeout` so a no-op change fails the test rather than
  hanging it;
- a normal-operation arm asserting the interval still completes while the daemon runs.

## Scope

The loops remain outside the component registry. That migration is unchanged and still owed;
`ADR-119` carries a dated amendment recording what moved here and what did not.
