### PR TITLE
feat(daemon): name tracked background tasks in the drain-timeout warning

### DIFF
--- a/crates/khive-mcp/src/attachment_cutover.rs
+++ b/crates/khive-mcp/src/attachment_cutover.rs
@@ -240,7 +240,7 @@ async fn coordinate_attachment_cutover_inner(
         return Ok(());
     }
 
-    let handle = khive_runtime::daemon::spawn_tracked_task(async move {
+    let handle = khive_runtime::spawn_named_tracked_task("attachment_cutover", async move {
         let sql = backend.sql();
         #[cfg(test)]
         test_sync::before_gc_owner(sql.as_ref()).await;

--- a/crates/khive-mcp/src/components.rs
+++ b/crates/khive-mcp/src/components.rs
@@ -453,12 +453,10 @@ fn start_component_registrations(
     }
     let count = regs.len();
     for reg in regs {
-        khive_runtime::track_background_task(supervise(
-            reg,
-            server.clone(),
-            parent.child_token(),
-            health.clone(),
-        ));
+        khive_runtime::track_named_background_task(
+            "component_supervision",
+            supervise(reg, server.clone(), parent.child_token(), health.clone()),
+        );
     }
     count
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -474,7 +474,7 @@ fn spawn_email_channel_loops(
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
                 if admission.inbound_poll {
-                    khive_runtime::track_background_task(async move {
+                    khive_runtime::track_named_background_task("email_channel_poll", async move {
                         if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await
                         {
                             tracing::error!(
@@ -497,14 +497,17 @@ fn spawn_email_channel_loops(
                 if admission.outbound_delivery {
                     match runtime_outbox {
                         Some(rt) => {
-                            khive_runtime::track_background_task(channel_outbox_loop(
-                                email_ch_clone,
-                                rt,
-                                ingest_ns_outbox,
-                                mailbox_clone,
-                                allowlist_clone,
-                                khive_runtime::daemon_shutdown_token(),
-                            ));
+                            khive_runtime::track_named_background_task(
+                                "email_channel_outbox",
+                                channel_outbox_loop(
+                                    email_ch_clone,
+                                    rt,
+                                    ingest_ns_outbox,
+                                    mailbox_clone,
+                                    allowlist_clone,
+                                    khive_runtime::daemon_shutdown_token(),
+                                ),
+                            );
                             tracing::info!("email channel outbox loop started");
                         }
                         None => {
@@ -1833,34 +1836,41 @@ fn spawn_telegram_channel_loops(
 
             let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
                 if admission.inbound_poll {
-                    khive_runtime::track_background_task(async move {
-                        if let Err(error) = ensure_channel_quarantine_storage(&verb_reg_poll).await
-                        {
-                            tracing::error!(
-                                error = %error,
-                                "telegram polling disabled: quarantine blob storage is unavailable"
-                            );
-                            return;
-                        }
-                        telegram_poll_loop(
-                            tg_ch_poll,
-                            verb_reg_poll,
-                            ingest_ns_poll,
-                            khive_runtime::daemon_shutdown_token(),
-                        )
-                        .await;
-                    });
+                    khive_runtime::track_named_background_task(
+                        "telegram_channel_poll",
+                        async move {
+                            if let Err(error) =
+                                ensure_channel_quarantine_storage(&verb_reg_poll).await
+                            {
+                                tracing::error!(
+                                    error = %error,
+                                    "telegram polling disabled: quarantine blob storage is unavailable"
+                                );
+                                return;
+                            }
+                            telegram_poll_loop(
+                                tg_ch_poll,
+                                verb_reg_poll,
+                                ingest_ns_poll,
+                                khive_runtime::daemon_shutdown_token(),
+                            )
+                            .await;
+                        },
+                    );
                     tracing::info!("telegram channel polling loop started");
                 }
                 if admission.outbound_delivery {
                     match outbox_runtime {
                         Some(rt) => {
-                            khive_runtime::track_background_task(telegram_outbox_loop(
-                                tg_ch_outbox,
-                                rt,
-                                ingest_ns_outbox,
-                                khive_runtime::daemon_shutdown_token(),
-                            ));
+                            khive_runtime::track_named_background_task(
+                                "telegram_channel_outbox",
+                                telegram_outbox_loop(
+                                    tg_ch_outbox,
+                                    rt,
+                                    ingest_ns_outbox,
+                                    khive_runtime::daemon_shutdown_token(),
+                                ),
+                            );
                             tracing::info!("telegram channel outbox loop started");
                         }
                         None => {

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -414,7 +414,8 @@ fn start_daemon_components_if_daemon(
         tracing::info!("read-only deployment: events daemon supervision skipped");
     } else if let Some(split) = server.events_split_config() {
         if let Some(socket) = split.socket_path.clone() {
-            khive_runtime::daemon::track_background_task(
+            khive_runtime::daemon::track_named_background_task(
+                "events_daemon_supervision",
                 khive_runtime::events_split::supervise_events_daemon(split.db_path.clone(), socket),
             );
         }

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -506,7 +506,7 @@ impl KgPack {
         let runtime = self.runtime.clone();
         let token = token.clone();
 
-        khive_runtime::track_background_task(async move {
+        khive_runtime::track_named_background_task("kg_search_event_append", async move {
             emit_search_executed_event(
                 &runtime,
                 &token,

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -2794,7 +2794,7 @@ pub(crate) fn start_rotation_watcher(rt: &KhiveRuntime, ann: &SharedAnn) {
 
     let ann = Arc::downgrade(ann);
     let shutdown = khive_runtime::daemon_shutdown_token();
-    khive_runtime::track_background_task(async move {
+    khive_runtime::track_named_background_task("knowledge_ann_rotation_watch", async move {
         let start = tokio::time::Instant::now() + ROTATION_WATCH_INTERVAL;
         let mut ticks = tokio::time::interval_at(start, ROTATION_WATCH_INTERVAL);
         ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -800,7 +800,7 @@ fn spawn_rebuild_task_inner(
         ann: ann.clone(),
         key: key.clone(),
     };
-    khive_runtime::track_background_task(async move {
+    khive_runtime::track_named_background_task("memory_ann_rebuild", async move {
         if chained {
             tokio::time::sleep(rebuild_chain_debounce()).await;
         }
@@ -911,7 +911,7 @@ pub(crate) fn start_rotation_watcher(rt: &KhiveRuntime, ann: &SharedAnn) {
 
     let ann = Arc::downgrade(ann);
     let shutdown = khive_runtime::daemon_shutdown_token();
-    khive_runtime::track_background_task(async move {
+    khive_runtime::track_named_background_task("memory_ann_rotation_watch", async move {
         let start = tokio::time::Instant::now() + ROTATION_WATCH_INTERVAL;
         let mut ticks = tokio::time::interval_at(start, ROTATION_WATCH_INTERVAL);
         ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1592,7 +1592,7 @@ async fn collect_model_ann_hits_inner(
             let token_detached = token.clone();
             let ann_detached = ann.clone();
             let model_detached = model_name.clone();
-            khive_runtime::track_background_task(async move {
+            khive_runtime::track_named_background_task("memory_ann_build", async move {
                 #[cfg(test)]
                 retrieval_failpoints::before_ann_build(&model_detached).await;
                 let result = ann::ensure_ann_for_model(

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -1160,7 +1160,7 @@ impl MemoryPack {
         let runtime = self.runtime.clone();
         let token = token.clone();
 
-        khive_runtime::track_background_task(async move {
+        khive_runtime::track_named_background_task("memory_recall_serve_ledger", async move {
             // The serve ledger lives in the brain pack; without it loaded
             // there is nothing to record, so skip the guaranteed-failed
             // dispatch (and its per-recall warn) entirely.

--- a/crates/khive-runtime/src/blob.rs
+++ b/crates/khive-runtime/src/blob.rs
@@ -232,7 +232,7 @@ impl BlobHydrator {
         let (sender, receiver) = tokio::sync::oneshot::channel::<RuntimeResult<VerifiedBlob>>();
         let store = Arc::clone(&self.store);
         let content_ref = content_ref.clone();
-        crate::track_background_task(async move {
+        crate::track_named_background_task("blob_hydration", async move {
             // The tracked supervisor itself owns backend work and the lease.
             // Dropping a request only drops `receiver`; the supervisor stays
             // visible to daemon drain until the backend future actually ends.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -989,12 +989,68 @@ fn background_tasks() -> &'static Arc<std::sync::atomic::AtomicUsize> {
 /// is cancelled — a plain post-`await` `fetch_sub` only covers the return
 /// path and leaks the count forever on a panic, since unwinding skips every
 /// statement after the panic point.
+// ── outstanding background-task names ────────────────────────────────────────
+//
+// Names of the tasks the background counter is currently holding, so a drain
+// timeout can say which ones held it open instead of printing a bare count.
+// Registered and released at exactly the points the counter is incremented and
+// decremented, and in the order that keeps the counter authoritative: the name
+// goes in after the increment and comes out before the decrement, so a reported
+// name always belongs to a task the counter already holds. The reverse ordering
+// would let the warning name a task that had already finished, which is the one
+// reading that would send someone looking in the wrong place.
+static BACKGROUND_TASK_NAMES: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<&'static str, usize>>,
+> = std::sync::OnceLock::new();
+
+fn background_task_names_registry(
+) -> &'static std::sync::Mutex<std::collections::HashMap<&'static str, usize>> {
+    BACKGROUND_TASK_NAMES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Name recorded for tasks spawned through the unnamed entry points, which
+/// stay on the public API of a published crate.
+pub const UNNAMED_BACKGROUND_TASK: &str = "unnamed";
+
+fn register_background_task_name(name: &'static str) {
+    let mut names = background_task_names_registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *names.entry(name).or_insert(0) += 1;
+}
+
+fn release_background_task_name(name: &'static str) {
+    let mut names = background_task_names_registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(count) = names.get_mut(name) {
+        *count -= 1;
+        if *count == 0 {
+            names.remove(name);
+        }
+    }
+}
+
+/// Names of the in-flight tracked background tasks, sorted and deduplicated.
+/// A diagnostic beside [`background_task_count`], never a substitute for it:
+/// the count is what drain waits on.
+pub fn background_task_names() -> Vec<String> {
+    let names = background_task_names_registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut out: Vec<String> = names.keys().map(|name| (*name).to_string()).collect();
+    out.sort();
+    out
+}
+
 struct BackgroundTaskGuard {
     counter: Arc<std::sync::atomic::AtomicUsize>,
+    name: &'static str,
 }
 
 impl Drop for BackgroundTaskGuard {
     fn drop(&mut self) {
+        release_background_task_name(self.name);
         self.counter
             .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
     }
@@ -1010,9 +1066,25 @@ where
     F: std::future::Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
+    spawn_named_tracked_task(UNNAMED_BACKGROUND_TASK, fut)
+}
+
+/// [`spawn_tracked_task`] with a name that a drain timeout can print.
+///
+/// The name is a short static string describing the task, never a formatted or
+/// caller-supplied value: it is read by an operator staring at a shutdown that
+/// would not finish, so it is a label for a call site, not a record of one
+/// occurrence.
+pub fn spawn_named_tracked_task<F, T>(name: &'static str, fut: F) -> tokio::task::JoinHandle<T>
+where
+    F: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
     background_tasks().fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    register_background_task_name(name);
     let guard = BackgroundTaskGuard {
         counter: background_tasks().clone(),
+        name,
     };
     tokio::spawn(async move {
         let _guard = guard;
@@ -1028,7 +1100,16 @@ pub fn track_background_task<F>(fut: F)
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
-    drop(spawn_tracked_task(fut));
+    track_named_background_task(UNNAMED_BACKGROUND_TASK, fut);
+}
+
+/// [`track_background_task`] with a name that a drain timeout can print. See
+/// [`spawn_named_tracked_task`] for what belongs in the name.
+pub fn track_named_background_task<F>(name: &'static str, fut: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    drop(spawn_named_tracked_task(name, fut));
 }
 
 /// Current count of in-flight tasks started via [`track_background_task`].
@@ -2048,13 +2129,16 @@ async fn run_daemon_with_boot_guard_inner<D: DaemonDispatch>(
         let cfg = CheckpointConfig::from_env();
         let checkpoint_task_count = checkpoint_tasks.len();
         for task in checkpoint_tasks {
-            track_background_task(run_checkpoint_task(
-                task.pool,
-                cfg.clone(),
-                task.lifecycle_owner,
-                checkpoint_shutdown_rx.clone(),
-                task.is_main,
-            ));
+            track_named_background_task(
+                "wal_checkpoint",
+                run_checkpoint_task(
+                    task.pool,
+                    cfg.clone(),
+                    task.lifecycle_owner,
+                    checkpoint_shutdown_rx.clone(),
+                    task.is_main,
+                ),
+            );
         }
         tracing::info!(checkpoint_task_count, "WAL checkpoint task(s) started");
     }
@@ -2484,6 +2568,7 @@ async fn drain_with_timeout(
             tracing::warn!(
                 remaining_connections = active.load(Ordering::SeqCst),
                 remaining_background_tasks = background_task_count(),
+                outstanding_background_tasks = %background_task_names().join(", "),
                 "drain timeout reached; forcing shutdown"
             );
             return false;
@@ -5196,5 +5281,138 @@ mod tests {
             "root is not special-cased: the rule is equality with the daemon's \
              euid, not a privilege comparison"
         );
+    }
+
+    /// Captures one tracing event's fields as `name=value ` text, so a test can
+    /// assert on what an operator reading the log actually sees rather than on
+    /// the value the log line was formatted from.
+    struct CapturedFields(Arc<std::sync::Mutex<Vec<String>>>);
+
+    impl tracing::Subscriber for CapturedFields {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            struct Visitor(String);
+            impl tracing::field::Visit for Visitor {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    self.0.push_str(&format!("{}={:?} ", field.name(), value));
+                }
+            }
+            let mut visitor = Visitor(String::new());
+            event.record(&mut visitor);
+            self.0.lock().unwrap().push(visitor.0);
+        }
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    // Shares the process-wide background-task statics with the counter tests
+    // above; see the `#[serial(background_tasks)]` note there.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn drain_timeout_warning_names_the_outstanding_tasks() {
+        let lines = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CapturedFields(lines.clone());
+        let _dispatch = tracing::dispatcher::set_default(&tracing::Dispatch::new(subscriber));
+
+        let active = std::sync::atomic::AtomicUsize::new(0);
+        let (stop_tx, stop_rx) = tokio::sync::broadcast::channel::<()>(1);
+        for name in ["test_task_alpha", "test_task_beta"] {
+            let mut rx = stop_rx.resubscribe();
+            track_named_background_task(name, async move {
+                let _ = rx.recv().await;
+            });
+        }
+        drop(stop_rx);
+
+        let drained = drain_with_timeout(&active, std::time::Duration::from_millis(150)).await;
+        assert!(
+            !drained,
+            "two unfinished tasks must make the drain time out"
+        );
+
+        let warned = lines
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|line| line.contains("drain timeout reached"))
+            .cloned()
+            .expect("the drain timeout must emit its warning through the test subscriber");
+        assert!(
+            warned.contains("test_task_alpha") && warned.contains("test_task_beta"),
+            "the drain-timeout warning must name every outstanding task; got {warned}"
+        );
+
+        let _ = stop_tx.send(());
+        for _ in 0..100 {
+            if background_task_names().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    // Shares the process-wide background-task statics; see the
+    // `#[serial(background_tasks)]` note above.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn a_named_task_drops_its_name_when_it_finishes() {
+        let before = background_task_count();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        track_named_background_task("test_task_finishes", async move {
+            let _ = rx.await;
+        });
+        assert!(
+            background_task_names().contains(&"test_task_finishes".to_string()),
+            "a live named task must be listed while the counter holds it"
+        );
+        tx.send(()).expect("still awaiting");
+        for _ in 0..100 {
+            if background_task_count() == before {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(background_task_count(), before);
+        assert!(
+            !background_task_names().contains(&"test_task_finishes".to_string()),
+            "a finished task's name must be released, not left to accumulate"
+        );
+    }
+
+    // Shares the process-wide background-task statics; see the
+    // `#[serial(background_tasks)]` note above.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn the_unnamed_entry_point_still_registers_and_releases() {
+        let before = background_task_count();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        track_background_task(async move {
+            let _ = rx.await;
+        });
+        assert_eq!(background_task_count(), before + 1);
+        assert!(
+            background_task_names().contains(&UNNAMED_BACKGROUND_TASK.to_string()),
+            "the unchanged public entry point must still register, under the placeholder name"
+        );
+        tx.send(()).expect("still awaiting");
+        for _ in 0..100 {
+            if background_task_count() == before {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(background_task_count(), before);
     }
 }

--- a/crates/khive-runtime/src/events_split.rs
+++ b/crates/khive-runtime/src/events_split.rs
@@ -1015,7 +1015,7 @@ pub async fn run_events_daemon(db_path: &Path, socket_path: &Path) -> anyhow::Re
         let backend = Arc::clone(&backend);
         let stores = Arc::clone(&stores);
         let frame_budget = Arc::clone(&frame_budget);
-        crate::daemon::spawn_tracked_task(async move {
+        crate::daemon::spawn_named_tracked_task("events_connection", async move {
             serve_events_conn(stream, backend, stores, frame_budget).await;
             drop(permit);
         });
@@ -1395,14 +1395,17 @@ impl EventsSplitClient {
             preflight_store,
         });
 
-        crate::daemon::spawn_tracked_task(run_forwarder(
-            socket_path,
-            append_rx,
-            counters,
-            outage_logged,
-            delivery_timeout,
-            crate::daemon::daemon_shutdown_token(),
-        ));
+        crate::daemon::spawn_named_tracked_task(
+            "events_forwarder",
+            run_forwarder(
+                socket_path,
+                append_rx,
+                counters,
+                outage_logged,
+                delivery_timeout,
+                crate::daemon::daemon_shutdown_token(),
+            ),
+        );
         Ok(client)
     }
 

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -93,8 +93,10 @@ pub use curation::{
 #[cfg(unix)]
 pub use daemon::{acquire_recovery_lock, pid_path, run_daemon, socket_path, DaemonDispatch};
 pub use daemon::{
-    active_phase_names, background_task_count, daemon_shutdown_token, register_active_phase,
-    track_background_task, DaemonRequestFrame, DaemonResponseFrame, PhaseGuard, PROTOCOL_VERSION,
+    active_phase_names, background_task_count, background_task_names, daemon_shutdown_token,
+    register_active_phase, spawn_named_tracked_task, track_background_task,
+    track_named_background_task, DaemonRequestFrame, DaemonResponseFrame, PhaseGuard,
+    PROTOCOL_VERSION, UNNAMED_BACKGROUND_TASK,
 };
 pub use embedder_registry::{EmbedderProvider, EmbedderRegistry, LatticeEmbedderProvider};
 pub use engine_config::{


### PR DESCRIPTION
## What

Tracked background tasks carry a short static name, and the drain-timeout warning prints the outstanding names beside the counts it already printed.

## Why

A daemon that could not finish draining logged `remaining_connections` and `remaining_background_tasks` and nothing else. A consumer measuring shutdowns sees `background_tasks = 1` repeatedly with no path from that line to the task holding the window open, so every explanation offered for it is a guess. The tracking helper took no name and kept only a counter, and the production call sites are spread across five crates: the daemon's checkpoint task, its blob hydration supervisor and both events-split paths, the MCP crate's serve start, component supervision, attachment cutover and its four channel loops, the KG pack's off-response event append, and the knowledge and memory packs' ANN and recall paths. Seventeen of them is too many to guess between.

`register_active_phase` already existed and produces `active_phase_names()`, but it has one production caller, so it is not a substitute.

## How

The name is registered where the counter is incremented and released where it is decremented, both inside the guard that already runs on every exit path, so the two move together through normal return, panic and cancellation alike.

The counter stays authoritative. A name is registered after the increment and released before the decrement, so a printed name always belongs to a task the counter still holds; the ordering can only under-report a name, never invent one. The count is what drain waits on; the names are a diagnostic beside it.

Names are short static strings describing a call site, never formatted or caller-supplied values, because the reader is an operator looking at a shutdown that would not finish.

The existing unnamed entry points keep their signatures and delegate with a placeholder name, since they are public API of a published crate.

## Deliberately not in this change

The drain timeout, what is tracked, and cancellation are all unchanged. This makes an existing failure legible; it does not try to stop it happening.

## Verification

Host gate, one lane, workspace scope:

- `cargo fmt --all -- --check`, `cargo check --workspace --all-targets --locked`, `cargo clippy --workspace --all-targets --locked -- -D warnings`: all clean.
- `cargo test -p khive-runtime --locked --no-fail-fast`: 12 test binaries, 1660 + 156 tests, 0 failed, 0 filtered out.

New arms:

- A drain that times out with two named unfinished tasks emits a warning naming both. The arm reads the emitted event through a capturing subscriber, so it asserts what an operator sees rather than the value the line was formatted from.
- A named task's name is released when it finishes, checked alongside the counter returning to its baseline.
- The unchanged unnamed entry point still registers, under the placeholder name, and still releases.

Mutation control: no-oping the name release reddens the release arm alone (1 failed, 69 passed in that module) and leaves the other two green; reverting restores 70 passed. Stated before running and reconciled after.

Census: seventeen production call sites moved to the named helpers. A repository-wide search for the unnamed helpers afterwards returns five matches, all in the daemon's own test module, which is the coverage for the unchanged entry points.

