### PR TITLE
The kg pack README said fences add no expiry check

### DIFF
--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -139,11 +139,12 @@ chain (`|`) preserves caller order; a request array gives dense numbers in write
 admission order, which need not be array order.
 
 `stream.append`, singleton note `create`/`update`, and `stream.batch` append
-members accept a `fence` object `{key, kind, expected_version}` or a non-empty
-ordered list of at most 100 distinct `(kind, key)` objects. Each entry requires
-`expected_version`: an integer at least 1 asserts the live holder's exact version
-in the write namespace; explicit null asserts that no live note holds that
-`(kind, key)`. Missing and soft-deleted notes satisfy an absence assertion.
+members accept a `fence` object `{key, kind, expected_version, live_until?}` or
+a non-empty ordered list of at most 100 distinct `(kind, key)` objects. Each
+entry requires `expected_version`: an integer at least 1 asserts the live
+holder's exact version in the write namespace; explicit null asserts that no
+live note holds that `(kind, key)`. Missing and soft-deleted notes satisfy an
+absence assertion.
 `version` is accepted as an input alias instead of `expected_version`; supplying
 both names, omitting both, or supplying unknown fields is invalid. Serialization
 always emits `expected_version`, including an explicit null for absence.
@@ -151,7 +152,12 @@ always emits `expected_version`, including an explicit null for absence.
 Fences are checked in order in the same writer transaction as the write. A
 mismatch returns `fence_conflict`; an absence conflict carries string-valued
 `expected_version="absent"` and the live `current_version`. List refusals also
-carry a zero-based string `index`. Oversized lists are rejected with
+carry a zero-based string `index`. A `live_until` deadline that has passed is a
+separate refusal, `expired`, carrying the deadline read and the writer clock; a
+path resolving to nothing or to a value that is not an RFC 3339 timestamp
+refuses `live_until_unreadable` naming the value's type and never the value.
+The version is compared first, so a stale version reports `fence_conflict` even
+when the deadline has also passed. Oversized lists are rejected with
 `invalid_input` naming the cap and count sent before entry interpretation or
 writer admission. Empty lists, duplicate `(kind, key)` entries and outer
 `fence:null` are invalid on these surfaces.
@@ -165,8 +171,12 @@ member writes in their transaction; an atomic member refusal also carries its
 string `member` position.
 
 `stream.batch(observed=...)` is unchanged: each observation still requires its
-`version` field, with no `expected_version` alias. Its optional `id` and
-`live_until` contracts do not apply to fence objects; fences add no expiry check.
+`version` field, with no `expected_version` alias. Its optional `id` contract
+does not apply to fence objects. Its `live_until` contract does: a fence entry
+takes the same dotted document path into the fenced head, resolved inside the
+writing transaction against one clock reading shared by every entry in that
+write, and requires a positive `expected_version` because an absence assertion
+has no document to read a deadline out of.
 
 ```text
 request(ops='stream.append(stream="run", record={"step":1}, expected_seq=1)', presentation="verbose")


### PR DESCRIPTION
## What

Three sentences in the kg pack README described the fence as a version comparison with no time predicate. That stopped being true when the fence gained `live_until`, and one of the sentences said so explicitly: "fences add no expiry check".

## The corrections

- The fence shape line now reads `{key, kind, expected_version, live_until?}`.
- The refusal paragraph names the two deadline refusals beside `fence_conflict`, and states that the version is compared first, so a stale version reports `fence_conflict` even when the deadline has also passed.
- The paragraph contrasting fences with `stream.batch(observed=...)` now separates the two contracts correctly: `id` is still observation-only, `live_until` is not.

No behaviour changes; this is the document catching up with the code. The handler help and the ADR were already correct, which is what makes a wrong README the most dangerous of the three: it is the one a reader reaches for first and the one nothing re-derives.

## Verification

The change is one file. `git diff --name-only main..` returns `crates/khive-pack-kg/README.md` and nothing else, so no source file is touched and no gate arm can change classification on it. The sentences themselves were checked against the merged fence code and the handler help rather than against each other.
