### PR TITLE
Count dispatch signals and snapshot serializations

### DIFF
--- a/crates/khive-brain-core/src/brain_state.rs
+++ b/crates/khive-brain-core/src/brain_state.rs
@@ -28,6 +28,17 @@ pub struct BrainState {
     pub section_states: HashMap<String, SectionPosteriorState>,
     pub router_state: HashMap<String, RouterStateBlob>,
     pub adapter_set: HashMap<String, Vec<AdapterRecord>>,
+    /// Dispatch-signal counters for this process. Diagnostics only: they are
+    /// not part of the persisted snapshot, they start at zero on every load,
+    /// and nothing reads them to make a decision. They exist so the cost of
+    /// the signal path has a denominator: a duty cycle with no signal count
+    /// beside it cannot say whether the work was too much or merely frequent.
+    pub signals_applied: u64,
+    /// Profile-record snapshot serializations performed in this process. This
+    /// counts every one, not only the dispatch path's, because the question it
+    /// answers is how much serialization the process is doing; the signal
+    /// count beside it is what makes the ratio readable.
+    pub snapshot_serializations: u64,
 }
 
 impl BrainState {
@@ -46,6 +57,8 @@ impl BrainState {
             section_states: HashMap::new(),
             router_state: HashMap::new(),
             adapter_set: HashMap::new(),
+            signals_applied: 0,
+            snapshot_serializations: 0,
         }
     }
 
@@ -95,6 +108,8 @@ impl BrainState {
             section_states,
             router_state: snapshot.router_state,
             adapter_set: snapshot.adapter_set,
+            signals_applied: 0,
+            snapshot_serializations: 0,
         }
     }
 
@@ -468,6 +483,8 @@ mod tests {
             section_states: HashMap::new(),
             router_state: HashMap::new(),
             adapter_set: HashMap::new(),
+            signals_applied: 0,
+            snapshot_serializations: 0,
         };
         state_a.profiles.insert(p_early.id.clone(), p_early.clone());
         state_a.profiles.insert(p_later.id.clone(), p_later.clone());
@@ -480,6 +497,8 @@ mod tests {
             section_states: HashMap::new(),
             router_state: HashMap::new(),
             adapter_set: HashMap::new(),
+            signals_applied: 0,
+            snapshot_serializations: 0,
         };
         // Insert in the opposite order.
         state_b.profiles.insert(p_later.id.clone(), p_later.clone());

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -721,7 +721,24 @@ impl BrainPack {
     pub(crate) async fn handle_state(&self, _params: Value) -> Result<Value, RuntimeError> {
         let state = self.state.lock().unwrap();
         let snapshot = state.to_snapshot();
-        serde_json::to_value(&snapshot).map_err(|e| RuntimeError::InvalidInput(e.to_string()))
+        let signals_applied = state.signals_applied;
+        let snapshot_serializations = state.snapshot_serializations;
+        drop(state);
+        let mut value = serde_json::to_value(&snapshot)
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+        // Beside the state rather than inside it: the snapshot is the persisted
+        // shape, and these counters are process-local diagnostics that restart
+        // at zero on every load.
+        if let Some(map) = value.as_object_mut() {
+            map.insert(
+                "dispatch_counters".to_string(),
+                serde_json::json!({
+                    "signals_applied": signals_applied,
+                    "snapshot_serializations": snapshot_serializations,
+                }),
+            );
+        }
+        Ok(value)
     }
 
     // ── brain.config ──────────────────────────────────────────────────────

--- a/crates/khive-pack-brain/src/pack.rs
+++ b/crates/khive-pack-brain/src/pack.rs
@@ -80,6 +80,7 @@ pub(crate) async fn run_feedback_precommit_hook(profile_id: &str) {
 pub(crate) fn sync_balanced_recall_record(state: &mut BrainState) {
     let total_ev = state.balanced_recall.total_events;
     let snap_val = serde_json::to_value(state.balanced_recall.to_snapshot()).ok();
+    state.snapshot_serializations = state.snapshot_serializations.saturating_add(1);
     if let Some(record) = state.profiles.get_mut("balanced-recall-v1") {
         record.total_events = total_ev;
         record.state_snapshot = snap_val;
@@ -112,6 +113,7 @@ pub(crate) fn apply_dispatch_signal(state: &mut BrainState, signal: &BrainSignal
     match serving_profile {
         None | Some("balanced-recall-v1") => {
             state.balanced_recall.apply_signal(signal);
+            state.signals_applied = state.signals_applied.saturating_add(1);
             sync_balanced_recall_record(state);
         }
         Some(profile_id) => {
@@ -125,6 +127,8 @@ pub(crate) fn apply_dispatch_signal(state: &mut BrainState, signal: &BrainSignal
             profile_state.apply_signal(signal);
             let total_events = profile_state.total_events;
             let state_snapshot = serde_json::to_value(profile_state.to_snapshot()).ok();
+            state.signals_applied = state.signals_applied.saturating_add(1);
+            state.snapshot_serializations = state.snapshot_serializations.saturating_add(1);
             if let Some(record) = state.profiles.get_mut(profile_id) {
                 record.total_events = total_events;
                 record.state_snapshot = state_snapshot;

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -1341,6 +1341,11 @@ pub async fn ensure_loaded(
                         .collect(),
                     router_state: current_state.router_state.clone(),
                     adapter_set: current_state.adapter_set.clone(),
+                    // A namespace swap parks this namespace's live state and
+                    // restores it later in the same process, so its counters
+                    // travel with it rather than restarting at zero.
+                    signals_applied: current_state.signals_applied,
+                    snapshot_serializations: current_state.snapshot_serializations,
                 };
                 // Release the state guard before mutating the tracker (save-restore
                 // path) so the re-acquire below cannot deadlock.

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -11072,3 +11072,128 @@ mod feedback_actor_tests {
         );
     }
 }
+
+/// The dispatch-signal counters: the denominator a duty-cycle reading needs.
+///
+/// A profiler can say the process spends its time serializing snapshots. It
+/// cannot say whether that is one serialization per signal or a thousand, and
+/// the remedy differs. These arms pin what each counter counts, including the
+/// two paths that deliberately count nothing.
+mod dispatch_counters {
+    use khive_brain_core::{BalancedRecallState, BrainSignal, BrainState, ServeAttribution};
+    use serde_json::json;
+    use uuid::Uuid;
+
+    fn hit(profile: Option<&str>, attribution: ServeAttribution) -> BrainSignal {
+        BrainSignal::RecallHit {
+            target_id: Uuid::new_v4(),
+            latency_us: 1_000,
+            served_by_profile_id: profile.map(str::to_string),
+            serve_attribution: attribution,
+        }
+    }
+
+    #[test]
+    fn the_default_profile_path_counts_one_signal_and_one_serialization_each() {
+        let mut state = BrainState::new(8);
+        for _ in 0..5 {
+            crate::apply_dispatch_signal(&mut state, &hit(None, ServeAttribution::Unspecified));
+        }
+        assert_eq!(state.signals_applied, 5);
+        assert_eq!(
+            state.snapshot_serializations, 5,
+            "today every applied signal serializes; this equality is the before-measurement"
+        );
+    }
+
+    #[test]
+    fn a_named_resident_profile_counts_on_its_own_branch() {
+        let mut state = BrainState::new(8);
+        state
+            .profile_states
+            .insert("other-v1".to_string(), BalancedRecallState::new(8));
+        for _ in 0..3 {
+            crate::apply_dispatch_signal(
+                &mut state,
+                &hit(Some("other-v1"), ServeAttribution::Profile),
+            );
+        }
+        assert_eq!(state.signals_applied, 3);
+        assert_eq!(state.snapshot_serializations, 3);
+    }
+
+    #[test]
+    fn an_unattributed_signal_is_dropped_and_counts_nothing() {
+        let mut state = BrainState::new(8);
+        crate::apply_dispatch_signal(&mut state, &hit(None, ServeAttribution::Unattributed));
+        assert_eq!(
+            (state.signals_applied, state.snapshot_serializations),
+            (0, 0),
+            "a failed profile read proves no profile served, so nothing was applied to count"
+        );
+    }
+
+    #[test]
+    fn a_named_profile_that_is_not_resident_counts_nothing() {
+        let mut state = BrainState::new(8);
+        crate::apply_dispatch_signal(
+            &mut state,
+            &hit(Some("absent-v1"), ServeAttribution::Profile),
+        );
+        assert_eq!(
+            (state.signals_applied, state.snapshot_serializations),
+            (0, 0)
+        );
+        let mut control = BrainState::new(8);
+        control
+            .profile_states
+            .insert("absent-v1".to_string(), BalancedRecallState::new(8));
+        crate::apply_dispatch_signal(
+            &mut control,
+            &hit(Some("absent-v1"), ServeAttribution::Profile),
+        );
+        assert_eq!(
+            (control.signals_applied, control.snapshot_serializations),
+            (1, 1),
+            "same signal, profile resident: the arm above measured residency, not the signal"
+        );
+    }
+
+    #[test]
+    fn the_counters_stay_out_of_the_persisted_snapshot() {
+        let mut state = BrainState::new(8);
+        crate::apply_dispatch_signal(&mut state, &hit(None, ServeAttribution::Unspecified));
+        let persisted = serde_json::to_value(state.to_snapshot()).expect("snapshot serializes");
+        assert!(
+            persisted.get("signals_applied").is_none()
+                && persisted.get("snapshot_serializations").is_none(),
+            "process-local diagnostics must not enter the durable shape: {persisted}"
+        );
+        assert!(
+            persisted.get("balanced_recall").is_some(),
+            "control: the snapshot really was produced"
+        );
+    }
+
+    #[tokio::test]
+    async fn brain_state_reports_the_counters_beside_the_state() {
+        let rt = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");
+        let pack = crate::BrainPack::new(rt);
+        {
+            let mut state = pack.state.lock().unwrap();
+            for _ in 0..2 {
+                crate::apply_dispatch_signal(&mut state, &hit(None, ServeAttribution::Unspecified));
+            }
+        }
+        let value = pack
+            .handle_state(json!({}))
+            .await
+            .expect("brain.state must answer");
+        assert_eq!(value["dispatch_counters"]["signals_applied"], 2);
+        assert_eq!(value["dispatch_counters"]["snapshot_serializations"], 2);
+        assert!(
+            value.get("balanced_recall").is_some(),
+            "control: the state itself is still reported"
+        );
+    }
+}


### PR DESCRIPTION
Part 1 of #2657. Measurement only: this changes no behaviour on the signal path beyond two counter
increments, and it lands on its own because it is the before-measurement for the fix.

## Why a counter first

A serving daemon was measured at a 68 to 76 percent duty cycle of one core, sampled as a `ps`
CPU-time delta over windows of 60 and 280 seconds, and a five second `sample(1)` of the same process
attributed the non-parked work to the brain pack's balanced-recall record sync together with
`serde_json` value serialization. Sampler frame counts are occurrences rather than exclusive CPU, so
that is attribution and not a percentage split.

What could not be said is how many signals produced that cost. Nothing counted them, so the same duty
cycle was equally consistent with a cheap path called constantly and an expensive path called rarely,
and those two have opposite remedies.

## What this adds

`BrainState` carries two process-local counters, signals applied and profile-record snapshot
serializations, incremented where the work happens rather than where the call arrives. A signal
dropped before it is applied increments neither: an explicitly unattributed signal is dropped because
a failed profile read proves no profile served, and a named profile that is not resident in the
namespace fails closed rather than crediting the default.

`brain.state` reports them under a `dispatch_counters` key beside the state it already returns, so the
rate is readable without a profiler and without special privileges.

The counters stay out of the persisted snapshot. They describe this process, they start at zero on
every load, and nothing reads them to decide anything. The one case that carries them is a namespace
swap, which parks live state and restores it into the same process.

## Acceptance

Six arms, all new, in the brain pack's test module:

1. Five signals on the default-profile path leave both counters at five. The equality is the
   before-measurement: today every applied signal serializes.
2. Three signals to a resident named profile count on that branch too.
3. An explicitly unattributed signal moves neither counter.
4. A named profile that is not resident moves neither counter, with a control in the same test that
   makes the same profile resident and shows one and one. Without that control the arm would be
   measuring residency rather than the signal.
5. The counters do not appear in the serialized snapshot, with a control asserting the snapshot was
   really produced.
6. `brain.state` reports both counters and still reports the state.

Mutation control: replacing `saturating_add(1)` with `saturating_add(0)` on both applied-signal
increments reddens arms 1, 2, 4 and 6 and leaves 3 and 5 green, which is the expected split since
those two assert zeroes and the snapshot's shape. Restored byte-identical, verified by sha256.

## Gate

```
cargo fmt --all -- --check                                    rc 0
cargo check --workspace --all-targets --locked                rc 0
cargo clippy --workspace --all-targets --locked -D warnings   rc 0
cargo test -p khive-pack-brain    319 + 1 + 6 + 3 + 4 passed, 0 failed
cargo test -p khive-brain-core     52 passed, 0 failed
```

## Next

Part 2 makes the serialization lazy so the two counters stop being equal, and its acceptance reads
this counter: N signals must produce fewer than N serializations while the stored snapshot, when
read, stays byte-identical to what the eager path produced for the same signal sequence.
